### PR TITLE
Add Set-VisualEffects with colored per-effect output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ See [VERSIONING.md](VERSIONING.md) for how we version and release.
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-09
+
 ### Added
 
 - `Set-VisualEffects` (System module): applies the Performance Options "Visual Effects" settings
@@ -22,6 +24,12 @@ See [VERSIONING.md](VERSIONING.md) for how we version and release.
   yellow `[skipped]` = already at the configured value.
 - `Write-LogStep -Style` (Logging module): render a step row in another level's color (e.g. a
   green/red outcome row) while keeping the plain Step layout, visibility, and STEP file-log tag.
+
+### Changed
+
+- Versioning policy (`VERSIONING.md`): below 1.0, `0.x.0` releases are reserved for milestone-ladder
+  gates, and backward-compatible additions that land between milestones ship as `0.1.x` patch
+  releases. The strict SemVer split (new function/config option = MINOR) resumes at 1.0.0.
 
 ## [0.1.0] - 2026-07-08
 
@@ -44,5 +52,6 @@ The first public release of WinuX.
   `WinuX.exe` from every version tag and attaches it - with a SHA-256 checksum - to the
   GitHub release.
 
-[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/IvanPavlak/WinuX/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/IvanPavlak/WinuX/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ See [VERSIONING.md](VERSIONING.md) for how we version and release.
 
 ## [Unreleased]
 
+### Added
+
+- `Set-VisualEffects` (System module): applies the Performance Options "Visual Effects" settings
+  programmatically from the new `VisualEffects` configuration section - one human-readable boolean
+  per dialog checkbox, written via the registry and `SystemParametersInfo`. Config-gated: the base
+  configuration ships the section fully commented so a vanilla bootstrap changes nothing; forks opt
+  in via `Configuration.local.psd1`. Runs during Bootstrap right after `Set-TaskbarAutoHide`.
+  Every managed effect is reported on its own colored row: green = enabled, red = disabled,
+  yellow `[skipped]` = already at the configured value.
+- `Write-LogStep -Style` (Logging module): render a step row in another level's color (e.g. a
+  green/red outcome row) while keeping the plain Step layout, visibility, and STEP file-log tag.
+
 ## [0.1.0] - 2026-07-08
 
 The first public release of WinuX.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -14,8 +14,23 @@ of exported functions.**
 
 ### Pre-1.0 (the 0.x series)
 
-Per SemVer §4, anything MAY change while we are below 1.0. Breaking changes bump **MINOR**
-(not MAJOR) and MUST appear under a `### Breaking` heading with migration notes.
+Per SemVer §4, anything MAY change while we are below 1.0. In the 0.x series the version number
+tracks the **milestone ladder below**, which overrides the general PATCH/MINOR split in the
+table above:
+
+- **MINOR (`0.x.0`)** is reserved for reaching a numbered milestone on the ladder (e.g. `0.2.0`
+  is the fully config-driven bootstrap). A milestone release naturally also carries whatever
+  additions and fixes accumulated on the way to it.
+- **PATCH (`0.1.x`, `0.2.x`, ...)** carries everything that ships *between* milestones - new
+  functions, new config options, bug fixes, doc/theming/dependency changes - as long as it is
+  backward compatible. This deliberately relaxes the table's PATCH definition (where a new
+  function/config option is a MINOR); the strict split resumes at `1.0.0`.
+- **Breaking changes** still bump the **MINOR** (not MAJOR) and MUST appear under a `### Breaking`
+  heading with migration notes.
+
+So a backward-compatible addition that does not itself reach the next milestone - e.g. adding
+`Set-VisualEffects` and its `VisualEffects` config section - ships as a **PATCH** (`0.1.1`),
+leaving `0.2.0` reserved for the milestone it names.
 
 **1.0.0** is reached when all four pillars are simultaneously true and proven on clean
 machines:

--- a/Windows/PowerShell/Configuration.psd1
+++ b/Windows/PowerShell/Configuration.psd1
@@ -41,6 +41,7 @@
 # → KeyboardLayouts                     : Set-KeyboardLayouts
 # → NerdFonts, DefaultNerdFont          : Configure-NerdFont
 # → ExplorerOptions                     : Set-ExplorerOptions
+# → VisualEffects                       : Set-VisualEffects
 # → AutoEnvironmentVariables            : Set-EnvironmentVariables
 # → DotnetProjectsSearchPath            : Determine-DotnetDependencies
 # → PostgreSqlPasswords                 : Configure-PostgreSqlPasswords
@@ -850,6 +851,37 @@
 			Description = "Do not show frequently used folders in Quick access"
 		}
 	)
+
+	# ==========================================================================
+	# Visual Effects
+	# ==========================================================================
+	# Performance Options visual effects (System Properties → Performance Options
+	# → Visual Effects tab), applied by Set-VisualEffects during Bootstrap. Every
+	# key mirrors one dialog checkbox one-to-one: $true = effect on (appearance),
+	# $false = effect off (performance). Keys left commented out are not touched;
+	# with everything commented (the shipped default) Bootstrap changes NOTHING -
+	# a fork opts in via Configuration.local.psd1. When at least one effect is
+	# managed, the dialog's radio button is set to "Custom" (VisualFXSetting = 3).
+	# ==========================================================================
+	VisualEffects                 = @{
+		# AnimateControlsAndElementsInsideWindows   = $false
+		# AnimateWindowsWhenMinimisingAndMaximising = $false
+		# AnimationsInTheTaskbar                    = $false
+		# EnablePeek                                = $false
+		# FadeOrSlideMenusIntoView                  = $false
+		# FadeOrSlideToolTipsIntoView               = $false
+		# FadeOutMenuItemsAfterClicking             = $false
+		# SaveTaskbarThumbnailPreviews              = $true
+		# ShowShadowsUnderMousePointer              = $false
+		# ShowShadowsUnderWindows                   = $false
+		# ShowThumbnailsInsteadOfIcons              = $true
+		# ShowTranslucentSelectionRectangle         = $true
+		# ShowWindowContentsWhileDragging           = $true
+		# SlideOpenComboBoxes                       = $false
+		# SmoothEdgesOfScreenFonts                  = $true
+		# SmoothScrollListBoxes                     = $false
+		# UseDropShadowsForIconLabelsOnTheDesktop   = $false
+	}
 
 	# ==========================================================================
 	# Environment Variables

--- a/Windows/PowerShell/Modules/Bootstrap/Functions/Bootstrap.ps1
+++ b/Windows/PowerShell/Modules/Bootstrap/Functions/Bootstrap.ps1
@@ -214,6 +214,10 @@ function Bootstrap {
 		# geometry is work-area based and correct either way - this is UX parity only.
 		Set-TaskbarAutoHide -Auto
 
+		# Config-driven (VisualEffects); no-op unless the fork opts in. Applies the
+		# Performance Options visual-effects profile (registry + SystemParametersInfo).
+		Set-VisualEffects
+
 		if ($wslSetupEnabled) {
 			Initialize-WSLEnvironment
 		}

--- a/Windows/PowerShell/Modules/Logging/Functions/Write-Log.ps1
+++ b/Windows/PowerShell/Modules/Logging/Functions/Write-Log.ps1
@@ -38,8 +38,9 @@ function Write-Log {
 		Title | Step | Success | Warning | Error | Debug. Defaults to Step.
 
 	.PARAMETER Style
-		Only meaningful when Level=Debug: render the verbose-gated message in another level's color
-		(e.g. -Style Success keeps a green diagnostic). Defaults to the Debug color (DarkCyan).
+		Only meaningful when Level=Debug or Level=Step: render the message in another level's color
+		while keeping the level's own layout, gating, and file-log tag (e.g. -Style Success keeps a
+		green diagnostic, or colors a Step row by outcome). Defaults to the level's own color.
 
 	.PARAMETER NoNewLine
 		Suppress the trailing newline (maps to Write-Host -NoNewline) for composing a line across
@@ -96,7 +97,8 @@ function Write-Log {
 	$state = $global:LoggingState
 
 	# --- Resolve palette (config-driven, documented defaults) ---
-	$renderStyle = if ($Level -eq "Debug" -and $Style) { $Style } else { $Level }
+	# Debug and Step accept a -Style color override (layout/gating stay the level's own)
+	$renderStyle = if (($Level -eq "Debug" -or $Level -eq "Step") -and $Style) { $Style } else { $Level }
 	$color = $state.Colors[$renderStyle]
 	if (-not $color) { $color = "White" }
 

--- a/Windows/PowerShell/Modules/Logging/Functions/Write-LogStep.ps1
+++ b/Windows/PowerShell/Modules/Logging/Functions/Write-LogStep.ps1
@@ -12,6 +12,11 @@ function Write-LogStep {
 	.PARAMETER Message
 		The statement text. Include any intended leading-space indentation; omit the leading "`n".
 
+	.PARAMETER Style
+		Render the step in another level's color while keeping the plain Step layout, visibility,
+		and STEP file-log tag (e.g. -Style Success for a green outcome row, -Style Error for a red
+		one). Defaults to the Step color (White).
+
 	.PARAMETER NoNewLine
 		Suppress the trailing newline (for composing a line across multiple calls).
 
@@ -23,12 +28,19 @@ function Write-LogStep {
 
 	.EXAMPLE
 		Write-LogStep "Opening training file..."
+
+	.EXAMPLE
+		Write-LogStep " SmoothEdgesOfScreenFonts => [enabled]" -Style Success
 	#>
 	[CmdletBinding()]
 	param(
 		[Parameter(Mandatory = $true, Position = 0)]
 		[AllowEmptyString()]
 		[string]$Message,
+
+		[Parameter(Mandatory = $false)]
+		[ValidateSet("Title", "Step", "Success", "Warning", "Error", "Debug")]
+		[string]$Style = "Step",
 
 		[Parameter(Mandatory = $false)]
 		[switch]$NoNewLine,
@@ -39,5 +51,5 @@ function Write-LogStep {
 		[Parameter(Mandatory = $false)]
 		[switch]$BlankLineAfter
 	)
-	Write-Log -Level Step -Message $Message -NoNewLine:$NoNewLine -NoLeadingNewline:$NoLeadingNewline -BlankLineAfter:$BlankLineAfter
+	Write-Log -Level Step -Message $Message -Style $Style -NoNewLine:$NoNewLine -NoLeadingNewline:$NoLeadingNewline -BlankLineAfter:$BlankLineAfter
 }

--- a/Windows/PowerShell/Modules/System/Functions/Set-VisualEffects.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Set-VisualEffects.ps1
@@ -1,0 +1,251 @@
+function Set-VisualEffects {
+	<#
+	.SYNOPSIS
+		Applies the Performance Options "Visual Effects" settings from configuration.
+
+	.DESCRIPTION
+		Reads per-effect booleans from `VisualEffects` in Configuration.psd1 /
+		Configuration.local.psd1 and applies them - the programmatic equivalent of the
+		"Custom" profile in System Properties > Performance Options > Visual Effects.
+		Every key mirrors one dialog checkbox one-to-one: $true enables the effect
+		(appearance), $false disables it (performance). Keys left out of the
+		configuration are not touched, and when the section is absent or empty the
+		function changes NOTHING - the machine keeps its current visual effects. This
+		keeps the upstream default vanilla; a fork opts in via its local configuration.
+
+		Explorer- and DWM-backed effects are written to the registry; the remaining
+		effects go through SystemParametersInfo - the same mechanism the dialog itself
+		uses - which persists them to the user profile (UserPreferencesMask et al.) and
+		broadcasts WM_SETTINGCHANGE so they apply live. The dialog's radio button is
+		set to "Custom" (VisualFXSetting = 3) whenever at least one effect is managed.
+		Restart-Explorer runs only when a registry-backed effect actually changed.
+
+		Idempotent - compares every configured effect against the current state and
+		returns early when nothing needs to change. When changes are applied, every
+		managed effect is reported on its own line: green when enabled, red when
+		disabled, yellow [skipped] when already at the configured value. Unknown
+		keys are skipped with a warning.
+
+	.EXAMPLE
+		Set-VisualEffects
+		Applies all effects configured in the VisualEffects section.
+	#>
+	Write-LogTitle "Setting Visual Effects"
+
+	$desiredEffects = $Configuration.VisualEffects
+	if (-not ($desiredEffects -is [hashtable]) -or $desiredEffects.Count -eq 0) {
+		Write-LogWarning "VisualEffects is not configured - leaving visual effects as-is!"
+		return
+	}
+
+	# One entry per checkbox in the Visual Effects dialog (alphabetical, like the dialog).
+	# Registry entries cover the Explorer/DWM settings that have no SPI code; everything else
+	# goes through SystemParametersInfo so it applies live and persists without a logoff.
+	# ShowThumbnailsInsteadOfIcons maps to IconsOnly, so its On/Off values are inverted.
+	$effectDefinitions = @(
+		@{ Key = "AnimateControlsAndElementsInsideWindows"; Kind = "SpiParameter"; GetCode = 0x1042; SetCode = 0x1043 }
+		@{ Key = "AnimateWindowsWhenMinimisingAndMaximising"; Kind = "SpiMinMaxAnimation" }
+		@{ Key = "AnimationsInTheTaskbar"; Kind = "Registry"; Path = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced"; Name = "TaskbarAnimations"; OnValue = 1; OffValue = 0 }
+		@{ Key = "EnablePeek"; Kind = "Registry"; Path = "HKCU:\Software\Microsoft\Windows\DWM"; Name = "EnableAeroPeek"; OnValue = 1; OffValue = 0 }
+		@{ Key = "FadeOrSlideMenusIntoView"; Kind = "SpiParameter"; GetCode = 0x1002; SetCode = 0x1003 }
+		@{ Key = "FadeOrSlideToolTipsIntoView"; Kind = "SpiParameter"; GetCode = 0x1016; SetCode = 0x1017 }
+		@{ Key = "FadeOutMenuItemsAfterClicking"; Kind = "SpiParameter"; GetCode = 0x1014; SetCode = 0x1015 }
+		@{ Key = "SaveTaskbarThumbnailPreviews"; Kind = "Registry"; Path = "HKCU:\Software\Microsoft\Windows\DWM"; Name = "AlwaysHibernateThumbnails"; OnValue = 1; OffValue = 0 }
+		@{ Key = "ShowShadowsUnderMousePointer"; Kind = "SpiParameter"; GetCode = 0x101A; SetCode = 0x101B }
+		@{ Key = "ShowShadowsUnderWindows"; Kind = "SpiParameter"; GetCode = 0x1024; SetCode = 0x1025 }
+		@{ Key = "ShowThumbnailsInsteadOfIcons"; Kind = "Registry"; Path = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced"; Name = "IconsOnly"; OnValue = 0; OffValue = 1 }
+		@{ Key = "ShowTranslucentSelectionRectangle"; Kind = "Registry"; Path = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced"; Name = "ListviewAlphaSelect"; OnValue = 1; OffValue = 0 }
+		@{ Key = "ShowWindowContentsWhileDragging"; Kind = "SpiUiParameter"; GetCode = 0x0026; SetCode = 0x0025 }
+		@{ Key = "SlideOpenComboBoxes"; Kind = "SpiParameter"; GetCode = 0x1004; SetCode = 0x1005 }
+		@{ Key = "SmoothEdgesOfScreenFonts"; Kind = "SpiFontSmoothing"; GetCode = 0x004A; SetCode = 0x004B }
+		@{ Key = "SmoothScrollListBoxes"; Kind = "SpiParameter"; GetCode = 0x1006; SetCode = 0x1007 }
+		@{ Key = "UseDropShadowsForIconLabelsOnTheDesktop"; Kind = "Registry"; Path = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced"; Name = "ListviewShadow"; OnValue = 1; OffValue = 0 }
+	)
+
+	# --- Typo protection: warn about configured keys that match no known effect ---
+	$knownKeys = $effectDefinitions.Key
+	foreach ($configuredKey in $desiredEffects.Keys) {
+		if ($configuredKey -notin $knownKeys) {
+			Write-LogWarning "Unknown VisualEffects key [$configuredKey] - skipping!"
+		}
+	}
+
+	$applicableDefinitions = @($effectDefinitions | Where-Object { $desiredEffects.ContainsKey($_.Key) })
+	if ($applicableDefinitions.Count -eq 0) {
+		Write-LogWarning "VisualEffects contains no known effect keys - leaving visual effects as-is!"
+		return
+	}
+
+	# SystemParametersInfo bridge - only compiled when an SPI-backed effect is configured
+	$needsNativeMethods = @($applicableDefinitions | Where-Object { $_.Kind -ne "Registry" }).Count -gt 0
+	if ($needsNativeMethods -and -not ([System.Management.Automation.PSTypeName]'VisualEffectsModule.NativeMethods').Type) {
+		Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+
+namespace VisualEffectsModule {
+	public static class NativeMethods {
+		[StructLayout(LayoutKind.Sequential)]
+		public struct ANIMATIONINFO {
+			public uint cbSize;
+			public int iMinAnimate;
+		}
+
+		[DllImport("user32.dll", SetLastError = true)]
+		private static extern bool SystemParametersInfo(uint uiAction, uint uiParam, ref int pvParam, uint fWinIni);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		private static extern bool SystemParametersInfo(uint uiAction, uint uiParam, IntPtr pvParam, uint fWinIni);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		private static extern bool SystemParametersInfo(uint uiAction, uint uiParam, ref ANIMATIONINFO pvParam, uint fWinIni);
+
+		// SPIF_UPDATEINIFILE | SPIF_SENDCHANGE - persist to the user profile and broadcast the change
+		private const uint SPIF_PERSIST = 0x01 | 0x02;
+
+		// Effects reported through pvParam (SPI_GET* family)
+		public static int GetParameter(uint getAction) {
+			int value = 0;
+			SystemParametersInfo(getAction, 0, ref value, 0);
+			return value;
+		}
+
+		// Effects carried in pvParam (SPI_SET* family, e.g. menu animation, drop shadow)
+		public static void SetParameter(uint setAction, int value) {
+			SystemParametersInfo(setAction, 0, (IntPtr)value, SPIF_PERSIST);
+		}
+
+		// Effects carried in uiParam (SPI_SETDRAGFULLWINDOWS, SPI_SETFONTSMOOTHING)
+		public static void SetUiParameter(uint setAction, int value) {
+			SystemParametersInfo(setAction, (uint)value, IntPtr.Zero, SPIF_PERSIST);
+		}
+
+		// Min/max window animation uses the ANIMATIONINFO struct (SPI_GET/SETANIMATION)
+		public static bool GetMinMaxAnimation() {
+			ANIMATIONINFO info = new ANIMATIONINFO();
+			info.cbSize = (uint)Marshal.SizeOf(typeof(ANIMATIONINFO));
+			SystemParametersInfo(0x0048, info.cbSize, ref info, 0);
+			return info.iMinAnimate != 0;
+		}
+
+		public static void SetMinMaxAnimation(bool enabled) {
+			ANIMATIONINFO info = new ANIMATIONINFO();
+			info.cbSize = (uint)Marshal.SizeOf(typeof(ANIMATIONINFO));
+			info.iMinAnimate = enabled ? 1 : 0;
+			SystemParametersInfo(0x0049, info.cbSize, ref info, SPIF_PERSIST);
+		}
+	}
+}
+"@
+	}
+
+	# --- Compare every configured effect against the current state ---
+	$effectStates = @()
+	foreach ($definition in $applicableDefinitions) {
+		$desired = [bool]$desiredEffects[$definition.Key]
+
+		$current = switch ($definition.Kind) {
+			"Registry" {
+				try {
+					$currentRaw = Get-ItemPropertyValue -Path $definition.Path -Name $definition.Name -ErrorAction Stop
+					$currentRaw -eq $definition.OnValue
+				}
+				catch {
+					# Value or key missing - state unknown, force an explicit write
+					$null
+				}
+			}
+			"SpiParameter" { [VisualEffectsModule.NativeMethods]::GetParameter($definition.GetCode) -ne 0 }
+			"SpiUiParameter" { [VisualEffectsModule.NativeMethods]::GetParameter($definition.GetCode) -ne 0 }
+			"SpiFontSmoothing" { [VisualEffectsModule.NativeMethods]::GetParameter($definition.GetCode) -ne 0 }
+			"SpiMinMaxAnimation" { [VisualEffectsModule.NativeMethods]::GetMinMaxAnimation() }
+		}
+
+		$effectStates += @{ Definition = $definition; Desired = $desired; NeedsChange = ($current -ne $desired) }
+	}
+
+	# The dialog's radio button: 0=LetWindowsChoose, 1=BestAppearance, 2=BestPerformance, 3=Custom
+	$visualFxPath = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects"
+	try {
+		$currentVisualFxSetting = Get-ItemPropertyValue -Path $visualFxPath -Name "VisualFXSetting" -ErrorAction Stop
+	}
+	catch {
+		$currentVisualFxSetting = $null
+	}
+
+	$pendingChanges = @($effectStates | Where-Object { $_.NeedsChange })
+	if ($pendingChanges.Count -eq 0 -and $currentVisualFxSetting -eq 3) {
+		Write-LogWarning "Visual effects already configured!"
+		return
+	}
+
+	# --- Apply every effect: green = enabled, red = disabled, yellow = already correct ---
+	$registryChanges = 0
+	foreach ($effectState in $effectStates) {
+		$definition = $effectState.Definition
+		$desired = $effectState.Desired
+
+		if (-not $effectState.NeedsChange) {
+			Write-LogStep " $($definition.Key) => [skipped]" -Style Warning
+			continue
+		}
+
+		$stateLabel = if ($desired) { "enabled" } else { "disabled" }
+		$rowStyle = if ($desired) { "Success" } else { "Error" }
+
+		try {
+			switch ($definition.Kind) {
+				"Registry" {
+					if (-not (Test-Path $definition.Path)) {
+						New-Item -Path $definition.Path -Force | Out-Null
+					}
+					$targetValue = if ($desired) { $definition.OnValue } else { $definition.OffValue }
+					Set-ItemProperty -Path $definition.Path -Name $definition.Name -Value $targetValue -Force
+					$registryChanges++
+				}
+				"SpiParameter" {
+					[VisualEffectsModule.NativeMethods]::SetParameter($definition.SetCode, [int]$desired)
+				}
+				"SpiUiParameter" {
+					[VisualEffectsModule.NativeMethods]::SetUiParameter($definition.SetCode, [int]$desired)
+				}
+				"SpiFontSmoothing" {
+					[VisualEffectsModule.NativeMethods]::SetUiParameter($definition.SetCode, [int]$desired)
+					if ($desired) {
+						# SPI_SETFONTSMOOTHINGTYPE => FE_FONTSMOOTHINGCLEARTYPE; without it,
+						# enabling font smoothing falls back to legacy greyscale anti-aliasing
+						[VisualEffectsModule.NativeMethods]::SetParameter(0x200B, 2)
+					}
+				}
+				"SpiMinMaxAnimation" {
+					[VisualEffectsModule.NativeMethods]::SetMinMaxAnimation($desired)
+				}
+			}
+			Write-LogStep " $($definition.Key) => [$stateLabel]" -Style $rowStyle
+		}
+		catch {
+			Write-LogError "Failed to set effect [$($definition.Key)]: $($_.Exception.Message)"
+		}
+	}
+
+	# Managing individual effects is exactly what the dialog's "Custom" profile means
+	if ($currentVisualFxSetting -ne 3) {
+		try {
+			if (-not (Test-Path $visualFxPath)) {
+				New-Item -Path $visualFxPath -Force | Out-Null
+			}
+			Set-ItemProperty -Path $visualFxPath -Name "VisualFXSetting" -Value 3 -Force
+		}
+		catch {
+			Write-LogError "Failed to set VisualFXSetting: $($_.Exception.Message)"
+		}
+	}
+
+	# SPI-backed changes broadcast WM_SETTINGCHANGE themselves; only the Explorer/DWM
+	# registry values need Explorer to reload them
+	if ($registryChanges -gt 0) {
+		Restart-Explorer
+	}
+
+	Write-LogSuccess "Visual effects configured!"
+}

--- a/Windows/PowerShell/Modules/System/System.psd1
+++ b/Windows/PowerShell/Modules/System/System.psd1
@@ -49,6 +49,7 @@
 		'Set-SpecialFolders',
 		'Set-SystemTheme',
 		'Set-TaskbarAutoHide',
+		'Set-VisualEffects',
 		'Set-Wallpaper',
 		'Show-PinnedAppsWarning',
 		'SymbolicLinkMaker',

--- a/Windows/PowerShell/Modules/Tests/Modules/Logging/Write-Log.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Logging/Write-Log.Tests.ps1
@@ -83,6 +83,13 @@ Describe "Write-Log engine" {
 			& $Wrapper "msg"
 			Should -Invoke -ModuleName Logging Write-Host -ParameterFilter { $ForegroundColor -eq $Color }
 		}
+
+		It "renders a Step row in the -Style override color while keeping the plain Step layout and STEP file tag" {
+			Write-LogStep " row => [disabled]" -Style Error
+			# Red color, but the plain Step layout (no "=>" prefix added by the engine)
+			Should -Invoke -ModuleName Logging Write-Host -ParameterFilter { $ForegroundColor -eq 'Red' -and $Object -eq "`n row => [disabled]" }
+			(Get-Content (Get-LogPath) -Raw) | Should -Match '\[STEP\].*row => \[disabled\]'
+		}
 	}
 
 	Context "Verbose gating" {

--- a/Windows/PowerShell/Modules/Tests/Modules/System/Set-VisualEffects.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/System/Set-VisualEffects.Tests.ps1
@@ -1,0 +1,185 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$FunctionsPath = Join-Path $ModuleRoot "System\Functions"
+
+	. "$FunctionsPath\Set-VisualEffects.ps1"
+}
+
+Describe "Set-VisualEffects" {
+	BeforeEach {
+		$script:Configuration = [PSCustomObject]@{
+			VisualEffects = $null
+		}
+		Mock Write-Host { }
+		Mock Write-LogTitle { }
+		Mock Write-LogStep { }
+		Mock Write-LogSuccess { }
+		Mock Write-LogWarning { }
+		Mock Write-LogError { }
+		Mock Restart-Explorer { }
+	}
+
+	It "returns without side effects when VisualEffects is missing from configuration" {
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		Should -Invoke Write-LogTitle -Times 1
+		Should -Invoke Write-LogWarning -Times 1
+		Should -Invoke Restart-Explorer -Times 0
+	}
+
+	It "returns without side effects when VisualEffects is empty" {
+		$script:Configuration = [PSCustomObject]@{ VisualEffects = @{} }
+
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		Should -Invoke Write-LogWarning -Times 1
+		Should -Invoke Restart-Explorer -Times 0
+	}
+
+	It "warns and applies nothing when only unknown keys are configured" {
+		$script:Configuration = [PSCustomObject]@{ VisualEffects = @{ NotARealEffect = $true } }
+
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		# One warning for the unknown key, one for having nothing applicable left
+		Should -Invoke Write-LogWarning -Times 2
+		Should -Invoke Restart-Explorer -Times 0
+	}
+
+	It "skips applying when every configured effect already matches" {
+		$script:Configuration = [PSCustomObject]@{ VisualEffects = @{ EnablePeek = $false } }
+		Mock Get-ItemPropertyValue {
+			if ($Name -eq "VisualFXSetting") { 3 } else { 0 }
+		}
+		Mock Set-ItemProperty { }
+
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		Should -Invoke Set-ItemProperty -Times 0
+		Should -Invoke Restart-Explorer -Times 0
+		Should -Invoke Write-LogWarning -Times 1
+	}
+
+	It "applies a mismatched registry effect and restarts Explorer once" {
+		$script:Configuration = [PSCustomObject]@{ VisualEffects = @{ EnablePeek = $false } }
+		Mock Get-ItemPropertyValue {
+			if ($Name -eq "VisualFXSetting") { 3 } else { 1 }
+		}
+		Mock Test-Path { $true }
+		Mock Set-ItemProperty { }
+
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Name -eq "EnableAeroPeek" -and $Value -eq 0 }
+		Should -Invoke Restart-Explorer -Times 1
+		Should -Invoke Write-LogSuccess -Times 1
+		# Disabled effects render as red rows
+		Should -Invoke Write-LogStep -Times 1 -ParameterFilter { $Style -eq "Error" -and $Message -like "*EnablePeek*disabled*" }
+	}
+
+	It "reports already-matching effects as yellow skipped rows while applying the rest" {
+		$script:Configuration = [PSCustomObject]@{
+			VisualEffects = @{
+				EnablePeek                        = $false
+				ShowTranslucentSelectionRectangle = $true
+			}
+		}
+		Mock Get-ItemPropertyValue {
+			if ($Name -eq "VisualFXSetting") { 3 }
+			elseif ($Name -eq "EnableAeroPeek") { 0 }
+			else { 0 }
+		}
+		Mock Test-Path { $true }
+		Mock Set-ItemProperty { }
+
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		# EnablePeek already off => yellow skipped row, no write
+		Should -Invoke Write-LogStep -Times 1 -ParameterFilter { $Style -eq "Warning" -and $Message -like "*EnablePeek*skipped*" }
+		# ShowTranslucentSelectionRectangle turned on => green row + registry write
+		Should -Invoke Write-LogStep -Times 1 -ParameterFilter { $Style -eq "Success" -and $Message -like "*ShowTranslucentSelectionRectangle*enabled*" }
+		Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Name -eq "ListviewAlphaSelect" -and $Value -eq 1 }
+	}
+
+	It "writes the inverted registry value for ShowThumbnailsInsteadOfIcons" {
+		$script:Configuration = [PSCustomObject]@{ VisualEffects = @{ ShowThumbnailsInsteadOfIcons = $true } }
+		Mock Get-ItemPropertyValue {
+			if ($Name -eq "VisualFXSetting") { 3 } else { 1 }
+		}
+		Mock Test-Path { $true }
+		Mock Set-ItemProperty { }
+
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		# Effect ON maps to IconsOnly = 0 (thumbnails instead of icons)
+		Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Name -eq "IconsOnly" -and $Value -eq 0 }
+	}
+
+	It "sets the Custom profile radio button when VisualFXSetting differs" {
+		$script:Configuration = [PSCustomObject]@{ VisualEffects = @{ EnablePeek = $false } }
+		Mock Get-ItemPropertyValue {
+			if ($Name -eq "VisualFXSetting") { 1 } else { 0 }
+		}
+		Mock Test-Path { $true }
+		Mock Set-ItemProperty { }
+
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		# The effect itself already matches - only the radio button is written
+		Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Name -eq "VisualFXSetting" -and $Value -eq 3 }
+		Should -Invoke Restart-Explorer -Times 0
+	}
+
+	It "treats a missing registry value as a mismatch and applies it" {
+		$script:Configuration = [PSCustomObject]@{ VisualEffects = @{ AnimationsInTheTaskbar = $false } }
+		Mock Get-ItemPropertyValue {
+			if ($Name -eq "VisualFXSetting") { 3 } else { throw "Property TaskbarAnimations does not exist" }
+		}
+		Mock Test-Path { $true }
+		Mock Set-ItemProperty { }
+
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Name -eq "TaskbarAnimations" -and $Value -eq 0 }
+		Should -Invoke Restart-Explorer -Times 1
+	}
+
+	It "creates the registry key path when it does not exist" {
+		$script:Configuration = [PSCustomObject]@{ VisualEffects = @{ SaveTaskbarThumbnailPreviews = $true } }
+		Mock Get-ItemPropertyValue {
+			if ($Name -eq "VisualFXSetting") { 3 } else { throw "Key does not exist" }
+		}
+		Mock Test-Path { $false }
+		Mock New-Item { }
+		Mock Set-ItemProperty { }
+
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		Should -Invoke New-Item -Times 1
+		Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Name -eq "AlwaysHibernateThumbnails" -and $Value -eq 1 }
+	}
+
+	It "continues applying remaining effects when one write fails" {
+		$script:Configuration = [PSCustomObject]@{
+			VisualEffects = @{
+				EnablePeek                        = $false
+				ShowTranslucentSelectionRectangle = $true
+			}
+		}
+		Mock Get-ItemPropertyValue {
+			if ($Name -eq "VisualFXSetting") { 3 } else { throw "Property does not exist" }
+		}
+		Mock Test-Path { $true }
+		Mock Set-ItemProperty {
+			if ($Name -eq "EnableAeroPeek") { throw "Access denied" }
+		}
+
+		{ Set-VisualEffects } | Should -Not -Throw
+
+		Should -Invoke Write-LogError -Times 1
+		Should -Invoke Set-ItemProperty -Times 1 -ParameterFilter { $Name -eq "ListviewAlphaSelect" -and $Value -eq 1 }
+		Should -Invoke Write-LogSuccess -Times 1
+	}
+}

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -641,6 +641,38 @@ correct with a visible taskbar too. A fork opts in via `Configuration.local.psd1
 
 **Consumer function:** `Set-TaskbarAutoHide`
 
+### Visual Effects
+
+**Key:** `VisualEffects` → Hashtable of per-effect booleans; the programmatic equivalent of the
+"Custom" profile in System Properties > Performance Options > Visual Effects. Every key mirrors
+one dialog checkbox one-to-one: `$true` = effect on (appearance), `$false` = effect off
+(performance). Keys left out of the configuration are not touched; when the section is absent or
+empty (the shipped default - it is fully commented), Bootstrap changes nothing. A fork opts in
+via `Configuration.local.psd1`. Explorer/DWM-backed effects are written to the registry, the
+rest through `SystemParametersInfo`; when at least one effect is managed the dialog's radio
+button is set to "Custom" (`VisualFXSetting = 3`).
+
+**Valid keys** (the dialog checkboxes in PascalCase): `AnimateControlsAndElementsInsideWindows`,
+`AnimateWindowsWhenMinimisingAndMaximising`, `AnimationsInTheTaskbar`, `EnablePeek`,
+`FadeOrSlideMenusIntoView`, `FadeOrSlideToolTipsIntoView`, `FadeOutMenuItemsAfterClicking`,
+`SaveTaskbarThumbnailPreviews`, `ShowShadowsUnderMousePointer`, `ShowShadowsUnderWindows`,
+`ShowThumbnailsInsteadOfIcons`, `ShowTranslucentSelectionRectangle`,
+`ShowWindowContentsWhileDragging`, `SlideOpenComboBoxes`, `SmoothEdgesOfScreenFonts`,
+`SmoothScrollListBoxes`, `UseDropShadowsForIconLabelsOnTheDesktop`
+
+**Example:**
+
+```powershell
+VisualEffects = @{
+    SmoothEdgesOfScreenFonts        = $true
+    ShowWindowContentsWhileDragging = $true
+    AnimationsInTheTaskbar          = $false
+    EnablePeek                      = $false
+}
+```
+
+**Consumer function:** `Set-VisualEffects`
+
 ---
 
 ## More Sections (quick reference)

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -45,6 +45,7 @@ The configuration uses a hierarchical structure designed to eliminate duplicatio
 | `KeyboardLayouts`          | Keyboard layout codes            | `Set-KeyboardLayouts`           |
 | `NerdFonts`                | Font configurations              | `Configure-NerdFont`            |
 | `ExplorerOptions`          | Windows Explorer settings        | `Set-ExplorerOptions`           |
+| `VisualEffects`            | Visual effects (Performance tab) | `Set-VisualEffects`             |
 | `AutoEnvironmentVariables` | Environment variables            | `Set-EnvironmentVariables`      |
 | `PostgreSqlPasswords`      | Database credentials             | `Configure-PostgreSqlPasswords` |
 | `NuGetConfig`              | NuGet source/destination         | `Configure-NuGetConfig`         |

--- a/docs/docs_overview.md
+++ b/docs/docs_overview.md
@@ -129,7 +129,7 @@ Phase 4 (Packages):              Install-WinGetPackageManager → Install-WinGet
 Phase 5 (Dev Tools):             PersonalSteps (fork-defined; base runs none) → Install-DotnetEF
 Phase 6 (Environment):           Set-EnvironmentVariables -Auto → Create-CondaEnvironments
                                  → Configure-NuGetConfig
-Phase 7 (Taskbar):               Configure-Taskbar -FromBootstrap → Set-TaskbarAutoHide -Auto
+Phase 7 (Taskbar):               Configure-Taskbar -FromBootstrap → Set-TaskbarAutoHide -Auto → Set-VisualEffects
 Phase 8 (WSL & Symlinks):        Initialize-WSLEnvironment → SymbolicLinkMaker → Configure-WSLSSH (WSL steps config-gated)
 Phase 9 (Finalize):              Lock taskbar → Restart-Explorer → Restart-Machine
 ```

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -60,7 +60,8 @@ After `Install-Bootstrap` completes, the main `Bootstrap` function runs with `-W
 │  PHASE 7: TASKBAR & VISUAL CONFIGURATION                                    │
 │  ├─→ Configure-Taskbar -FromBootstrap                                       │
 │  │   └─ Pins configured apps in order                                       │
-│  └─→ Set-TaskbarAutoHide -Auto (config-gated: TaskbarAutoHide)              │
+│  ├─→ Set-TaskbarAutoHide -Auto (config-gated: TaskbarAutoHide)              │
+│  └─→ Set-VisualEffects (config-gated: VisualEffects)                        │
 │                                                                             │
 │  PHASE 8: WSL & SYMBOLIC LINKS                                              │
 │  ├─→ Initialize-WSLEnvironment                                              │

--- a/docs/modules/logging.md
+++ b/docs/modules/logging.md
@@ -73,7 +73,7 @@ console verbosity, so the on-disk record is always complete.
 
 ## [Write-Log](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Logging/Functions/Write-Log.ps1)
 
-- **Description:** Core logging engine that every `Write-Log*` wrapper calls. Renders a styled, leveled message to the console (house style per level) and mirrors it to the structured session log; errors are additionally appended verbosely to the error log. Prefer the wrappers in normal code; call `Write-Log` directly only when the level must be chosen dynamically. Pass the message text only - the engine adds the leading newline and level decoration.
+- **Description:** Core logging engine that every `Write-Log*` wrapper calls. Renders a styled, leveled message to the console (house style per level) and mirrors it to the structured session log; errors are additionally appended verbosely to the error log. `-Style` overrides the render color for the `Debug` and `Step` levels while keeping the level's own layout, visibility gating, and file-log tag. Prefer the wrappers in normal code; call `Write-Log` directly only when the level must be chosen dynamically. Pass the message text only - the engine adds the leading newline and level decoration.
 - **Parameters:** `-Message` `[-Level]` `[-Style]` `[-NoNewLine]` `[-NoLeadingNewline]` `[-Exception]` `[-BlankLineAfter]`
 - **Usage:** `Write-Log -Level Success -Message "Workspace opened!"`
 
@@ -97,9 +97,9 @@ console verbosity, so the on-disk record is always complete.
 
 ## [Write-LogStep](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Logging/Functions/Write-LogStep.ps1)
 
-- **Description:** Writes a plain step/progress statement (White), replacing the `Write-Host -ForegroundColor White` idiom. Leading-space indentation in the message is preserved so nested sub-steps keep their alignment.
-- **Parameters:** `-Message` `[-NoNewLine]` `[-NoLeadingNewline]` `[-BlankLineAfter]`
-- **Usage:** `Write-LogStep "Opening training file..."`
+- **Description:** Writes a plain step/progress statement (White), replacing the `Write-Host -ForegroundColor White` idiom. Leading-space indentation in the message is preserved so nested sub-steps keep their alignment. `-Style` renders the step in another level's color while keeping the plain Step layout, visibility, and STEP file-log tag - used for per-item outcome rows (e.g. green/red/yellow effect rows in `Set-VisualEffects`).
+- **Parameters:** `-Message` `[-Style]` `[-NoNewLine]` `[-NoLeadingNewline]` `[-BlankLineAfter]`
+- **Usage:** `Write-LogStep "Opening training file..."`, `Write-LogStep " ItemName => [enabled]" -Style Success`
 
 ## [Write-LogSuccess](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Logging/Functions/Write-LogSuccess.ps1)
 

--- a/docs/modules/system.md
+++ b/docs/modules/system.md
@@ -868,6 +868,20 @@ Set-TaskbarAutoHide -Enabled $true
 Set-TaskbarAutoHide -Enabled $false
 ```
 
+## [Set-VisualEffects](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Set-VisualEffects.ps1)
+
+- **Description:** Applies the Performance Options "Visual Effects" settings (System Properties > Performance Options > Visual Effects tab) from the `VisualEffects` section in the configuration. Every key mirrors one dialog checkbox one-to-one (`$true` = effect on / appearance, `$false` = effect off / performance); keys left out of the configuration are not touched, and when the section is absent or empty the function changes nothing - the vanilla default. Explorer/DWM-backed effects are written to the registry; the remaining effects go through `SystemParametersInfo` (the dialog's own mechanism), which persists them to the user profile and applies them live. Sets the dialog's radio button to "Custom" (`VisualFXSetting = 3`) whenever at least one effect is managed, and runs `Restart-Explorer` only when a registry-backed effect actually changed. Idempotent - returns early when every configured effect already matches; when changes are applied, every managed effect is reported on its own colored row (green = enabled, red = disabled, yellow `[skipped]` = already at the configured value). Unknown keys are skipped with a warning. Takes no parameters - all settings come from the configuration.
+- **Usage:** `Set-VisualEffects`
+
+Called during Bootstrap (after `Set-TaskbarAutoHide`), making visual effects an opt-in provisioning step: the base configuration ships the `VisualEffects` section fully commented (no effects touched) and a fork defines its preferences in `Configuration.local.psd1`. Valid keys: `AnimateControlsAndElementsInsideWindows`, `AnimateWindowsWhenMinimisingAndMaximising`, `AnimationsInTheTaskbar`, `EnablePeek`, `FadeOrSlideMenusIntoView`, `FadeOrSlideToolTipsIntoView`, `FadeOutMenuItemsAfterClicking`, `SaveTaskbarThumbnailPreviews`, `ShowShadowsUnderMousePointer`, `ShowShadowsUnderWindows`, `ShowThumbnailsInsteadOfIcons`, `ShowTranslucentSelectionRectangle`, `ShowWindowContentsWhileDragging`, `SlideOpenComboBoxes`, `SmoothEdgesOfScreenFonts`, `SmoothScrollListBoxes`, `UseDropShadowsForIconLabelsOnTheDesktop`.
+
+```powershell
+# Apply all effects configured in the VisualEffects section
+Set-VisualEffects
+```
+
+**See also:** [Set-ExplorerOptions](system.md#set-exploreroptions), [Set-TaskbarAutoHide](system.md#set-taskbarautohide)
+
 ## [Set-Wallpaper](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Set-Wallpaper.ps1)
 
 - **Description:** Sets the desktop wallpaper based on `MachineType` and theme. With `-Auto` it reads paths from `WallpaperDarkSettings`/`WallpaperLightSettings` in `Configuration.psd1` (selecting the entry for the current machine type, falling back to `Default`); without `-Auto` it presents an interactive picker of available wallpapers and styles. Supports multi-monitor configurations with per-monitor wallpaper and style assignment via the `IDesktopWallpaper` COM interface, automatically filtering out disconnected/phantom monitors so only active displays are configured. When the `VirtualDesktop` module is available it applies the wallpaper across all virtual desktops; otherwise only the current desktop. Wallpaper style (Fill, Fit, Stretch, Tile, Center, Span) is read from `WallpaperStyles`. Requires administrator privileges, uses COM retry logic for transient failures, and is idempotent - skipping when wallpaper, style, and tile values are already correct.


### PR DESCRIPTION
## Description

Add `Set-VisualEffects` (System module): applies the Performance Options "Visual Effects"
profile from a new, human-readable `VisualEffects` config section (one boolean per dialog
checkbox), via the registry and SystemParametersInfo. Config-gated and no-op by default - the
base `Configuration.psd1` ships the section fully commented, so a vanilla bootstrap changes
nothing; a fork opts in via `Configuration.local.psd1`. Runs during Bootstrap right after
`Set-TaskbarAutoHide`.

Also extends the Logging engine with `Write-LogStep -Style` (a small, backward-compatible
change: `-Style` already existed for Debug; this widens it to Step while keeping the plain Step
layout, visibility, and STEP file-log tag), so each effect prints on its own colored row:
green (enabled) / red (disabled) / yellow (skipped).

This PR also cuts the release: it amends the versioning policy (`VERSIONING.md`) so
backward-compatible additions ship as `0.1.x` patch releases below 1.0, and promotes the
changelog to `## [0.1.1]`. After merge, the only remaining step is pushing the `v0.1.1` tag.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [ ] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

## Quality bar

- [x] The change is **minimal and focused** (one logical change; reuses existing helpers, no duplication / DRY).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` using placeholder paths (`{Dev}`, `{User}`, `{MachineType}`, `{RepoRoot}`, `{AppData}`).

## Tests

```powershell
Run-Tests -TestName "Set-VisualEffects"   # green
Run-Tests -TestName "Write-Log"           # green
```

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/`.
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text.
- [ ] N/A - no testable behavior changed (docs/chore only).

## Documentation & manifests

- [x] I updated `docs/modules/<Module>.md` for any added/renamed/removed/changed function. (system.md, logging.md)
- [x] I updated the module `.psd1` `FunctionsToExport`. (System.psd1)
- [x] I updated `docs/docs_overview.md` (and `docs/_sidebar.md` if a page was added/removed). (also configuration-reference.md, overview.md, first-run.md)
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds.
- [ ] N/A - no exported function changed.

## Tested on

- Windows version: Windows 11 25H2 (build 26200)
- PowerShell version: 7.5.4
- Machine type(s): Work via a private fork

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] This PR contains no secrets or personal data (tokens, real paths/hostnames/emails).