### PR TITLE
Run -Alongside workspaces commands in a new shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `Open-Workspace -Alongside` (Workflow module) now always runs in a completely new shell: the invocation relaunches itself in a fresh Windows Terminal window and hands the calling shell its prompt back immediately. The new window is created under an explicit window ID that is passed to the relaunched shell via `WT_WINDOW_ID`, terminal-opening actions inside it are forced to `-InSameShell` so the workspace's terminal tabs join that exact window (never the most-recently-used one), the window layout places the new window on the workspace's virtual desktops like any other workspace window, and a configured `Terminate-WindowsTerminalTabs -OnlyCurrent` closes the now-redundant bootstrap tab as its final step.
 - `Open-Terminal -InSameShell` (Application module) targets the exact caller window via `$env:WT_WINDOW_ID` when the calling shell knows its own window ID, falling back to window ID 0 as before. Windows Terminal resolves `-w 0` to the *most recently used* window, so with multiple terminal windows open the fallback can land tabs in a different window than the caller's - setting `WT_WINDOW_ID` removes that ambiguity.
 
+### Fixed
+
+- `Open-Workspace -Alongside` (Workflow module) is far less prone to failing partway through with virtual-desktop "RPC server may be unavailable" errors (or a silently ignored `Switch-Desktop`). The Windows `VirtualDesktop` COM/RPC session that creating, switching, and removing desktops relies on tends to go stale in a long-running shell, and `-Alongside` is the heaviest user of those calls (it creates desktops to the right of existing ones, moves the new windows onto them, and prunes empties). Because the whole flow now runs in a brand-new shell (see Changed), those calls execute against a fresh RPC session from the start, which circumvents the stale-session failures in practice - it does not fix a session wedged outside the WinuX process, hence "far less prone" rather than "never".
+
 ## [0.1.2] - 2026-07-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-07-10
+
+### Added
+
+- `Open-Project -InSameShell` (Workflow module): when explicitly passed, overrides the configured `InSameShell` value of the `Open-ProjectTerminals-Or-RunProject` action so the project's terminal tabs open in the caller's Windows Terminal window. Used by `Open-Workspace -Alongside` to gather all tabs in the relaunched shell window.
+
+### Changed
+
+- `Open-Workspace -Alongside` (Workflow module) now always runs in a completely new shell: the invocation relaunches itself in a fresh Windows Terminal window and hands the calling shell its prompt back immediately. The new window is created under an explicit window ID that is passed to the relaunched shell via `WT_WINDOW_ID`, terminal-opening actions inside it are forced to `-InSameShell` so the workspace's terminal tabs join that exact window (never the most-recently-used one), the window layout places the new window on the workspace's virtual desktops like any other workspace window, and a configured `Terminate-WindowsTerminalTabs -OnlyCurrent` closes the now-redundant bootstrap tab as its final step.
+- `Open-Terminal -InSameShell` (Application module) targets the exact caller window via `$env:WT_WINDOW_ID` when the calling shell knows its own window ID, falling back to window ID 0 as before. Windows Terminal resolves `-w 0` to the *most recently used* window, so with multiple terminal windows open the fallback can land tabs in a different window than the caller's - setting `WT_WINDOW_ID` removes that ambiguity.
+
 ## [0.1.2] - 2026-07-09
 
 ### Changed

--- a/Windows/PowerShell/Modules/Application/Functions/Open-Terminal.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Open-Terminal.ps1
@@ -18,8 +18,12 @@ function Open-Terminal {
 		Opens Windows Terminal with administrator privileges.
 
 	.PARAMETER InSameShell
-		Opens all tabs in the current Windows Terminal window (window ID 0) instead of creating a new window.
+		Opens all tabs in the current Windows Terminal window instead of creating a new window.
 		Default: $false (creates a new window)
+		The current window is targeted via $env:WT_WINDOW_ID when the calling shell knows its
+		own window ID (set by Open-Workspace's -Alongside bootstrap). Without it, window ID 0
+		is used - note that "wt -w 0" targets the MOST RECENTLY USED window, which with
+		multiple Windows Terminal windows open is not necessarily the caller's window.
 
 	.PARAMETER WindowId
 		Specifies an explicit Windows Terminal window ID to open tabs in.
@@ -67,7 +71,19 @@ function Open-Terminal {
 		$PwshPath = Join-Path -Path $PSHOME -ChildPath "pwsh.exe"
 
 		if ($Command.Count -gt 0) {
-			$resolvedWindowId = if ($PSBoundParameters.ContainsKey('WindowId')) { $WindowId } elseif ($InSameShell) { 0 } else { [guid]::NewGuid().ToString() }
+			# InSameShell prefers the exact window ID when the calling shell knows it
+			# (WT_WINDOW_ID, set by Open-Workspace's -Alongside bootstrap): "wt -w 0"
+			# targets the MOST RECENTLY USED window, so with multiple Windows Terminal
+			# windows open it can land tabs in a different window than the caller's.
+			$resolvedWindowId = if ($PSBoundParameters.ContainsKey('WindowId')) {
+				$WindowId
+			}
+			elseif ($InSameShell) {
+				if ($env:WT_WINDOW_ID) { $env:WT_WINDOW_ID } else { 0 }
+			}
+			else {
+				[guid]::NewGuid().ToString()
+			}
 			$StartWT = $false
 
 			for ($i = 0; $i -lt $Command.Count; $i++) {

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Open-Terminal.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Open-Terminal.Tests.ps1
@@ -11,6 +11,18 @@ Describe "Open-Terminal" {
 	BeforeEach {
 		Mock Start-Process { }
 		Mock Start-Sleep { }
+
+		$script:previousWtWindowId = $env:WT_WINDOW_ID
+		Remove-Item Env:WT_WINDOW_ID -ErrorAction SilentlyContinue
+	}
+
+	AfterEach {
+		if ($null -ne $script:previousWtWindowId) {
+			$env:WT_WINDOW_ID = $script:previousWtWindowId
+		}
+		else {
+			Remove-Item Env:WT_WINDOW_ID -ErrorAction SilentlyContinue
+		}
 	}
 
 	Context "Parameter validation" {
@@ -91,11 +103,31 @@ Describe "Open-Terminal" {
 	}
 
 	Context "When InSameShell is specified without WindowId" {
-		It "Should use window ID 0" {
+		It "Should use window ID 0 when WT_WINDOW_ID is not set" {
 			Open-Terminal -Command "echo test" -InSameShell
 
 			Should -Invoke Start-Process -Times 1 -ParameterFilter {
 				$ArgumentList -contains "0"
+			}
+		}
+
+		It "Should prefer WT_WINDOW_ID over window ID 0 when the calling shell knows its window" {
+			$env:WT_WINDOW_ID = "caller-window-guid"
+
+			Open-Terminal -Command "echo test" -InSameShell
+
+			Should -Invoke Start-Process -Times 1 -ParameterFilter {
+				$ArgumentList -contains "caller-window-guid"
+			}
+		}
+
+		It "Should use an explicit WindowId over WT_WINDOW_ID" {
+			$env:WT_WINDOW_ID = "caller-window-guid"
+
+			Open-Terminal -Command "echo test" -WindowId "explicit-id" -InSameShell
+
+			Should -Invoke Start-Process -Times 1 -ParameterFilter {
+				$ArgumentList -contains "explicit-id"
 			}
 		}
 	}

--- a/Windows/PowerShell/Modules/Tests/Modules/Workflow/Open-Project.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Workflow/Open-Project.Tests.ps1
@@ -42,4 +42,22 @@ Describe "Open-Project" {
 		Should -Invoke Open-Browser -Times 1 -ParameterFilter { $Groups -eq "Docs" }
 		$result | Should -Contain "Demo"
 	}
+
+	It "forwards explicitly bound InSameShell to Open-ProjectTerminals" {
+		Open-Project -Project "Demo" -InSameShell
+
+		Should -Invoke Open-ProjectTerminals -Times 1 -ParameterFilter { $Project -eq "Demo" -and $InSameShell -eq $true }
+	}
+
+	It "forwards an explicit InSameShell false to Run-Project when RunApp is specified" {
+		Open-Project -Project "Demo" -RunApp -InSameShell:$false
+
+		Should -Invoke Run-Project -Times 1 -ParameterFilter { $Project -eq "Demo" -and $InSameShell -eq $false }
+	}
+
+	It "does not pass InSameShell to Open-ProjectTerminals when not provided" {
+		Open-Project -Project "Demo"
+
+		Should -Invoke Open-ProjectTerminals -Times 1 -ParameterFilter { $null -eq $InSameShell }
+	}
 }

--- a/Windows/PowerShell/Modules/Tests/Modules/Workflow/Open-ProjectTerminals.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Workflow/Open-ProjectTerminals.Tests.ps1
@@ -37,6 +37,22 @@ Describe "Open-ProjectTerminals" {
 			)
 			DefaultWSLDistribution = "Ubuntu"
 		}
+
+		# Shells descended from an Open-Workspace -Alongside bootstrap carry a real
+		# WT_WINDOW_ID, which the caller-window resolution prefers over "0" - clear it
+		# so the window-id assertions below are deterministic regardless of where the
+		# test run was started from.
+		$script:previousWtWindowId = $env:WT_WINDOW_ID
+		Remove-Item Env:WT_WINDOW_ID -ErrorAction SilentlyContinue
+	}
+
+	AfterEach {
+		if ($null -ne $script:previousWtWindowId) {
+			$env:WT_WINDOW_ID = $script:previousWtWindowId
+		}
+		else {
+			Remove-Item Env:WT_WINDOW_ID -ErrorAction SilentlyContinue
+		}
 	}
 
 	Context "Parameter validation" {
@@ -86,6 +102,16 @@ Describe "Open-ProjectTerminals" {
 
 			Should -Invoke Open-Terminal -Times 2 -ParameterFilter {
 				$WindowId -eq "0"
+			}
+		}
+
+		It "Should prefer WT_WINDOW_ID over window 0 when the calling shell knows its window" {
+			$env:WT_WINDOW_ID = "caller-window-guid"
+
+			Open-ProjectTerminals -Project "TestProject" -InSameShell
+
+			Should -Invoke Open-Terminal -Times 2 -ParameterFilter {
+				$WindowId -eq "caller-window-guid"
 			}
 		}
 

--- a/Windows/PowerShell/Modules/Tests/Modules/Workflow/Open-Workspace.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Workflow/Open-Workspace.Tests.ps1
@@ -29,7 +29,7 @@ BeforeAll {
 		$Params
 	}
 
-	function Get-WindowHandle { @() }
+	function Get-WindowHandle { param($ProcessName) @() }
 	function Get-NextAvailableDesktopIndex { 0 }
 	function Test-BrowserGroupAlreadyOpen { $false }
 	function Open-Browser { param($Groups, $Browser) }
@@ -108,7 +108,7 @@ Describe "Open-Workspace" {
 		Mock Test-BrowserGroupAlreadyOpen { $false }
 		Mock Open-Terminal {
 			param($Command, [switch]$Administrator, [switch]$InSameShell, $WindowId, $TabTitles)
-			$script:openTerminalCalls += [PSCustomObject]@{ Command = $Command }
+			$script:openTerminalCalls += [PSCustomObject]@{ Command = $Command; WindowId = $WindowId }
 		}
 		Mock Test-ActionOne { param($Alpha) $script:invokedActions += [PSCustomObject]@{ Name = 'Test-ActionOne'; Alpha = $Alpha } }
 		Mock Test-ActionTwo { param($Beta) $script:invokedActions += [PSCustomObject]@{ Name = 'Test-ActionTwo'; Beta = $Beta } }
@@ -191,6 +191,20 @@ Describe "Open-Workspace" {
 		$command | Should -BeLike "*`$env:OPEN_WORKSPACE_START_UTC = '*'*"
 		$command | Should -BeLike "*`$env:OPEN_WORKSPACE_ALONGSIDE_SHELL = '1';*"
 		$command | Should -BeLike "*Open-Workspace -Workspace 'TestWorkspace' -Alongside"
+	}
+
+	It "creates the relaunch window under an explicit ID and hands it to the child via WT_WINDOW_ID" {
+		$script:Configuration.WorkspaceActions['TestWorkspace'] = @(
+			@{ Action = 'Test-ActionOne'; Parameters = @{ Alpha = 1 } }
+		)
+
+		Open-Workspace -Workspace 'TestWorkspace' -Alongside
+
+		$script:openTerminalCalls.Count | Should -Be 1
+		$windowId = $script:openTerminalCalls[0].WindowId
+		$windowId | Should -Not -BeNullOrEmpty
+		{ [guid]::Parse($windowId) } | Should -Not -Throw
+		$script:openTerminalCalls[0].Command | Should -BeLike "*`$env:WT_WINDOW_ID = '$windowId';*"
 	}
 
 	It "forwards Project and ExtraArgs in the relaunch command" {
@@ -375,6 +389,51 @@ Describe "Open-Workspace" {
 		$script:setLayoutCalls[0].DesktopOffset | Should -Be 3
 		$script:setLayoutCalls[0].Alongside | Should -BeTrue
 		$script:setLayoutCalls[0].PreCapturedExistingWindows.Count | Should -Be 1
+	}
+
+	It "excludes its own hosting terminal window from pre-captured windows in the alongside shell" {
+		$env:OPEN_WORKSPACE_ALONGSIDE_SHELL = '1'
+
+		# The title-probe query (-ProcessName WindowsTerminal) sees the probe marker in
+		# this shell's own window title; the plain capture query returns both windows.
+		Mock Get-WindowHandle {
+			param($ProcessName)
+			if ($ProcessName -eq 'WindowsTerminal') {
+				@([PSCustomObject]@{ Handle = [IntPtr]777; Title = $Host.UI.RawUI.WindowTitle; ProcessId = 42 })
+			}
+			else {
+				@(
+					[PSCustomObject]@{ Handle = [IntPtr]555; Title = 'OtherWorkspaceWindow'; ProcessId = 1 },
+					[PSCustomObject]@{ Handle = [IntPtr]777; Title = 'BootstrapWindow'; ProcessId = 42 }
+				)
+			}
+		}
+
+		$script:Configuration.WorkspaceActions['TestWorkspace'] = @(
+			@{ Action = 'Set-WorkspaceWindowLayout'; Parameters = @{ WorkspaceName = 'TestWorkspace' } }
+		)
+
+		Open-Workspace -Workspace 'TestWorkspace' -Alongside
+
+		$script:setLayoutCalls.Count | Should -Be 1
+		$script:setLayoutCalls[0].PreCapturedExistingWindows.Contains([IntPtr]555) | Should -BeTrue
+		$script:setLayoutCalls[0].PreCapturedExistingWindows.Contains([IntPtr]777) | Should -BeFalse
+	}
+
+	It "keeps all pre-captured windows when opening without Alongside" {
+		Mock Get-WindowHandle {
+			param($ProcessName)
+			@([PSCustomObject]@{ Handle = [IntPtr]777; Title = 'SomeWindow'; ProcessId = 42 })
+		}
+
+		$script:Configuration.WorkspaceActions['TestWorkspace'] = @(
+			@{ Action = 'Set-WorkspaceWindowLayout'; Parameters = @{ WorkspaceName = 'TestWorkspace' } }
+		)
+
+		Open-Workspace -Workspace 'TestWorkspace'
+
+		$script:setLayoutCalls.Count | Should -Be 1
+		$script:setLayoutCalls[0].PreCapturedExistingWindows.Contains([IntPtr]777) | Should -BeTrue
 	}
 
 	It "adds swagger group to Open-Browser when project swagger is not already open" {

--- a/Windows/PowerShell/Modules/Tests/Modules/Workflow/Open-Workspace.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Workflow/Open-Workspace.Tests.ps1
@@ -33,6 +33,7 @@ BeforeAll {
 	function Get-NextAvailableDesktopIndex { 0 }
 	function Test-BrowserGroupAlreadyOpen { $false }
 	function Open-Browser { param($Groups, $Browser) }
+	function Open-Terminal { param($Command, [switch]$Administrator, [switch]$InSameShell, $WindowId, $TabTitles) }
 	function Set-WorkspaceWindowLayout { param($WorkspaceName, $PreCapturedExistingWindows, $DesktopOffset, [switch]$Alongside) }
 
 	function Open-Project {
@@ -50,6 +51,11 @@ BeforeAll {
 		$script:invokedActions += [PSCustomObject]@{ Name = 'Test-ActionTwo'; Beta = $Beta }
 	}
 
+	function Test-ShellAwareAction {
+		param($Alpha, [switch]$InSameShell)
+		$script:invokedActions += [PSCustomObject]@{ Name = 'Test-ShellAwareAction'; Alpha = $Alpha; InSameShell = [bool]$InSameShell }
+	}
+
 	function Test-ThrowingAction {
 		param()
 		throw 'intentional action failure'
@@ -62,11 +68,27 @@ Describe "Open-Workspace" {
 		$script:terminateCalls = @()
 		$script:browserCalls = @()
 		$script:setLayoutCalls = @()
+		$script:openTerminalCalls = @()
 
 		Mock Write-Host { }
 		Mock Resolve-Selection { param($InputObject) $InputObject }
 		Mock Get-WindowHandle { @() }
-		Mock Get-FilteredParams { param($CommandName, $Params) $Params }
+		# Mirror the real Get-FilteredParams contract: only parameters the target command
+		# declares survive. Open-Workspace force-injects InSameShell in the relaunched
+		# alongside shell and relies on this filtering to drop it from actions that do
+		# not support it (e.g. Terminate-WindowsTerminalTabs).
+		Mock Get-FilteredParams {
+			param($CommandName, $Params)
+			$cmdInfo = Get-Command $CommandName -ErrorAction SilentlyContinue
+			if (-not $cmdInfo) { return $Params }
+			$filtered = @{}
+			foreach ($key in $Params.Keys) {
+				if ($cmdInfo.Parameters.Keys -contains $key) {
+					$filtered[$key] = $Params[$key]
+				}
+			}
+			return $filtered
+		}
 		Mock Get-NextAvailableDesktopIndex { 3 }
 		Mock Open-Project { param($Project) $Project }
 		Mock Open-Browser {
@@ -84,8 +106,13 @@ Describe "Open-Workspace" {
 		}
 		Mock Terminate-WindowsTerminalTabs { param([switch]$OnlyCurrent) $script:terminateCalls += [PSCustomObject]@{ OnlyCurrent = [bool]$OnlyCurrent } }
 		Mock Test-BrowserGroupAlreadyOpen { $false }
+		Mock Open-Terminal {
+			param($Command, [switch]$Administrator, [switch]$InSameShell, $WindowId, $TabTitles)
+			$script:openTerminalCalls += [PSCustomObject]@{ Command = $Command }
+		}
 		Mock Test-ActionOne { param($Alpha) $script:invokedActions += [PSCustomObject]@{ Name = 'Test-ActionOne'; Alpha = $Alpha } }
 		Mock Test-ActionTwo { param($Beta) $script:invokedActions += [PSCustomObject]@{ Name = 'Test-ActionTwo'; Beta = $Beta } }
+		Mock Test-ShellAwareAction { param($Alpha, [switch]$InSameShell) $script:invokedActions += [PSCustomObject]@{ Name = 'Test-ShellAwareAction'; Alpha = $Alpha; InSameShell = [bool]$InSameShell } }
 		Mock Test-ThrowingAction { throw 'intentional action failure' }
 
 		$script:Configuration = @{
@@ -98,6 +125,9 @@ Describe "Open-Workspace" {
 
 		$script:previousWtProjectTab = $env:WT_PROJECT_TAB
 		Remove-Item Env:WT_PROJECT_TAB -ErrorAction SilentlyContinue
+
+		$script:previousAlongsideShellMarker = $env:OPEN_WORKSPACE_ALONGSIDE_SHELL
+		Remove-Item Env:OPEN_WORKSPACE_ALONGSIDE_SHELL -ErrorAction SilentlyContinue
 	}
 
 	AfterEach {
@@ -106,6 +136,13 @@ Describe "Open-Workspace" {
 		}
 		else {
 			Remove-Item Env:WT_PROJECT_TAB -ErrorAction SilentlyContinue
+		}
+
+		if ($null -ne $script:previousAlongsideShellMarker) {
+			$env:OPEN_WORKSPACE_ALONGSIDE_SHELL = $script:previousAlongsideShellMarker
+		}
+		else {
+			Remove-Item Env:OPEN_WORKSPACE_ALONGSIDE_SHELL -ErrorAction SilentlyContinue
 		}
 	}
 
@@ -139,15 +176,75 @@ Describe "Open-Workspace" {
 		$script:invokedActions[1].Beta | Should -Be 2
 	}
 
-	It "skips Terminate-WindowsTerminalTabs -OnlyCurrent when Alongside is used" {
+	It "relaunches -Alongside into a new shell window without running any actions" {
+		$script:Configuration.WorkspaceActions['TestWorkspace'] = @(
+			@{ Action = 'Test-ActionOne'; Parameters = @{ Alpha = 1 } }
+		)
+
+		Open-Workspace -Workspace 'TestWorkspace' -Alongside
+
+		$script:invokedActions.Count | Should -Be 0
+		Should -Invoke Get-NextAvailableDesktopIndex -Times 0 -Exactly
+		$script:openTerminalCalls.Count | Should -Be 1
+		$command = $script:openTerminalCalls[0].Command
+		$command | Should -BeLike "*`$env:WT_PROJECT_TAB = `$null;*"
+		$command | Should -BeLike "*`$env:OPEN_WORKSPACE_START_UTC = '*'*"
+		$command | Should -BeLike "*`$env:OPEN_WORKSPACE_ALONGSIDE_SHELL = '1';*"
+		$command | Should -BeLike "*Open-Workspace -Workspace 'TestWorkspace' -Alongside"
+	}
+
+	It "forwards Project and ExtraArgs in the relaunch command" {
+		$script:Configuration.WorkspaceActions['TestWorkspace'] = @(
+			@{ Action = 'Test-ActionOne'; Parameters = @{ Alpha = 1 } }
+		)
+
+		Open-Workspace -Workspace 'TestWorkspace' -Project 'ProjectA' -Alongside -Override -CustomParam 'some value'
+
+		$script:openTerminalCalls.Count | Should -Be 1
+		$script:openTerminalCalls[0].Command |
+			Should -BeLike "*Open-Workspace -Workspace 'TestWorkspace' -Project 'ProjectA' -Alongside -Override -CustomParam 'some value'"
+	}
+
+	It "runs Terminate-WindowsTerminalTabs -OnlyCurrent inside the relaunched alongside shell" {
+		$env:OPEN_WORKSPACE_ALONGSIDE_SHELL = '1'
 		$script:Configuration.WorkspaceActions['TestWorkspace'] = @(
 			@{ Action = 'Terminate-WindowsTerminalTabs'; Parameters = @{ OnlyCurrent = $true } }
 		)
 
 		Open-Workspace -Workspace 'TestWorkspace' -Alongside
 
-		$script:terminateCalls.Count | Should -Be 0
+		$script:openTerminalCalls.Count | Should -Be 0
+		$script:terminateCalls.Count | Should -Be 1
+		$script:terminateCalls[0].OnlyCurrent | Should -BeTrue
 		Should -Invoke Get-NextAvailableDesktopIndex -Times 1 -Exactly
+	}
+
+	It "forces InSameShell on actions inside the relaunched alongside shell and consumes the marker" {
+		$env:OPEN_WORKSPACE_ALONGSIDE_SHELL = '1'
+		$script:Configuration.WorkspaceActions['TestWorkspace'] = @(
+			@{ Action = 'Test-ShellAwareAction'; Parameters = @{ Alpha = 5 } }
+		)
+
+		Open-Workspace -Workspace 'TestWorkspace' -Alongside
+
+		$script:openTerminalCalls.Count | Should -Be 0
+		$script:invokedActions.Count | Should -Be 1
+		$script:invokedActions[0].Name | Should -Be 'Test-ShellAwareAction'
+		$script:invokedActions[0].Alpha | Should -Be 5
+		$script:invokedActions[0].InSameShell | Should -BeTrue
+		$env:OPEN_WORKSPACE_ALONGSIDE_SHELL | Should -BeNullOrEmpty
+	}
+
+	It "does not force InSameShell when opening without Alongside" {
+		$script:Configuration.WorkspaceActions['TestWorkspace'] = @(
+			@{ Action = 'Test-ShellAwareAction'; Parameters = @{ Alpha = 6 } }
+		)
+
+		Open-Workspace -Workspace 'TestWorkspace'
+
+		$script:openTerminalCalls.Count | Should -Be 0
+		$script:invokedActions.Count | Should -Be 1
+		$script:invokedActions[0].InSameShell | Should -BeFalse
 	}
 
 	It "skips Terminate-WindowsTerminalTabs -OnlyCurrent when caller tab belongs to same workspace project" {
@@ -233,6 +330,7 @@ Describe "Open-Workspace" {
 	}
 
 	It "recomputes desktop offset per selected workspace when opening alongside" {
+		$env:OPEN_WORKSPACE_ALONGSIDE_SHELL = '1'
 		$script:Configuration.Workspaces = @('WorkspaceA', 'WorkspaceB')
 		$script:Configuration.WorkspaceActions['WorkspaceA'] = @(
 			@{ Action = 'Set-WorkspaceWindowLayout'; Parameters = @{ WorkspaceName = 'WorkspaceA' } }
@@ -261,6 +359,7 @@ Describe "Open-Workspace" {
 	}
 
 	It "forwards desktop offset and pre-captured windows to Set-WorkspaceWindowLayout when opening alongside" {
+		$env:OPEN_WORKSPACE_ALONGSIDE_SHELL = '1'
 		Mock Get-WindowHandle {
 			@([PSCustomObject]@{ Handle = [IntPtr]55; Title = 'Existing'; ProcessId = 1 })
 		}

--- a/Windows/PowerShell/Modules/Workflow/Functions/Open-Project.ps1
+++ b/Windows/PowerShell/Modules/Workflow/Functions/Open-Project.ps1
@@ -28,6 +28,12 @@ function Open-Project {
 		Switch to start the project's runnable app instead of opening terminals.
 		Applies to the `Open-ProjectTerminals-Or-RunProject` action only.
 
+	.PARAMETER InSameShell
+		Forces the project's terminal tabs to open in the current Windows Terminal
+		window. When explicitly provided it overrides the configured value of the
+		`Open-ProjectTerminals-Or-RunProject` action. Open-Workspace's -Alongside
+		relaunch relies on this to gather all tabs in the relaunched shell window.
+
 	.EXAMPLE
 		Open-Project
 		Shows the project selection menu.
@@ -49,7 +55,10 @@ function Open-Project {
 		[switch]$RunApp,
 
 		[Parameter()]
-		[string]$VSCodeWorkspace
+		[string]$VSCodeWorkspace,
+
+		[Parameter()]
+		[switch]$InSameShell
 	)
 
 	$resolveParams = @{
@@ -108,6 +117,12 @@ function Open-Project {
 				}
 			}
 			elseif ($action -eq "Open-ProjectTerminals-Or-RunProject") {
+				# An explicitly bound InSameShell overrides the configured value so callers
+				# (e.g. Open-Workspace's -Alongside relaunch) can force the terminal tabs
+				# into their own window.
+				if ($PSBoundParameters.ContainsKey('InSameShell')) {
+					$actionParams["InSameShell"] = $InSameShell
+				}
 				if ($RunAppBool) {
 					& "Run-Project" @actionParams
 				}

--- a/Windows/PowerShell/Modules/Workflow/Functions/Open-Workspace.ps1
+++ b/Windows/PowerShell/Modules/Workflow/Functions/Open-Workspace.ps1
@@ -96,11 +96,15 @@ function Open-Workspace {
 	try {
 		# -Alongside always runs in a completely new shell: replay this exact invocation
 		# in a fresh Windows Terminal window and hand the calling shell its prompt back.
-		# The bootstrap command marks the new shell via $alongsideShellEnvVar (so it
-		# executes the flow instead of relaunching again), carries the timer start across
-		# so the reported duration includes the relaunch, and clears WT_PROJECT_TAB
-		# because the new window's WT process can inherit it from a project-tab caller
-		# and the bootstrap tab must not pass for a project tab. Inside the new shell,
+		# The new window is created under a GUID chosen HERE and handed to the child as
+		# WT_WINDOW_ID, so every InSameShell tab the child opens targets this exact
+		# window - "wt -w 0" resolves to the most recently used window, which with the
+		# caller's window still open is not necessarily the new one. The bootstrap
+		# command also marks the new shell via $alongsideShellEnvVar (so it executes
+		# the flow instead of relaunching again), carries the timer start across so the
+		# reported duration includes the relaunch, and clears WT_PROJECT_TAB because
+		# the new window's WT process can inherit it from a project-tab caller and the
+		# bootstrap tab must not pass for a project tab. Inside the new shell,
 		# terminal-opening actions are forced to -InSameShell (see the action loop) so
 		# their tabs join the new window, and a configured
 		# Terminate-WindowsTerminalTabs -OnlyCurrent closes the redundant bootstrap tab
@@ -133,8 +137,10 @@ function Open-Workspace {
 				}
 			}
 
+			$alongsideWindowId = [guid]::NewGuid().ToString()
 			$effectiveStartUtc = $currentInvocationStartUtc - $carryOverElapsed
 			$bootstrapCommand = "`$env:WT_PROJECT_TAB = `$null; " +
+			"`$env:WT_WINDOW_ID = '$alongsideWindowId'; " +
 			"`$env:$workspaceTimerEnvVar = '$($effectiveStartUtc.ToString('o'))'; " +
 			"`$env:$alongsideShellEnvVar = '1'; " +
 			($invocationTokens -join ' ')
@@ -142,7 +148,8 @@ function Open-Workspace {
 			$workspaceLabel = if ($Workspace) { " $($Workspace -join ', ')" } else { "" }
 			Write-LogTitle "Relaunching [Open-Workspace$workspaceLabel -Alongside] in a new shell window"
 			Write-LogDebug " [Open-Workspace] Alongside relaunch command => [$($invocationTokens -join ' ')]" -Style Success
-			Open-Terminal -Command $bootstrapCommand
+			Write-LogDebug " [Open-Workspace] Alongside shell window ID => [$alongsideWindowId]" -Style Success
+			Open-Terminal -Command $bootstrapCommand -WindowId $alongsideWindowId
 			return
 		}
 
@@ -153,6 +160,39 @@ function Open-Workspace {
 		# unchanged.
 		if (Test-AdminPrivileges -CheckOnly) {
 			Write-LogWarning "Running from an elevated shell - spawned windows (and PowerToys, if started by this flow) will be elevated. FancyZones cannot snap elevated windows unless PowerToys itself runs elevated. Prefer running workspaces from a non-admin shell."
+		}
+
+		# The relaunched shell's own hosting window IS the new workspace's terminal
+		# window (project tabs join it via InSameShell), but it was spawned by the
+		# parent invocation moments before this run - so the per-workspace "existing
+		# windows" capture below would classify it as pre-existing, and the alongside
+		# layout (which skips existing windows to protect other workspaces) would
+		# never place it on the workspace desktops. Identify it up front by flashing
+		# a unique marker into this shell's window title and finding which Windows
+		# Terminal window reflects it, so each capture can exclude it.
+		$ownTerminalWindowHandle = $null
+		if ($Alongside -and $isAlongsideShell) {
+			$originalHostTitle = $Host.UI.RawUI.WindowTitle
+			try {
+				$titleProbe = "AlongsideShell_" + [guid]::NewGuid().ToString()
+				$Host.UI.RawUI.WindowTitle = $titleProbe
+				Start-Sleep -Milliseconds 50
+
+				$ownTerminalWindow = Get-WindowHandle -ProcessName "WindowsTerminal" -ErrorAction SilentlyContinue |
+					Where-Object { $_.Title -like "*$titleProbe*" } |
+					Select-Object -First 1
+
+				if ($ownTerminalWindow) {
+					$ownTerminalWindowHandle = $ownTerminalWindow.Handle
+					Write-LogDebug " [Open-Workspace] Alongside shell hosting window => [$ownTerminalWindowHandle]" -Style Success
+				}
+				else {
+					Write-LogDebug " [Open-Workspace] Could not identify the alongside shell's own window (title probe not reflected) - the new terminal window will not be laid out" -Style Warning
+				}
+			}
+			finally {
+				try { $Host.UI.RawUI.WindowTitle = $originalHostTitle } catch {}
+			}
 		}
 
 		$resolveParams = @{
@@ -268,6 +308,12 @@ function Open-Workspace {
 				foreach ($win in $existingWindowsBeforeOpen) {
 					$existingHandlesBeforeOpen.Add($win.Handle) | Out-Null
 				}
+			}
+
+			# The relaunched shell's own window hosts this workspace's terminal tabs -
+			# treat it as NEW so the alongside layout places it on the workspace desktops.
+			if ($ownTerminalWindowHandle) {
+				$existingHandlesBeforeOpen.Remove($ownTerminalWindowHandle) | Out-Null
 			}
 
 			$selectedProjects = @()

--- a/Windows/PowerShell/Modules/Workflow/Functions/Open-Workspace.ps1
+++ b/Windows/PowerShell/Modules/Workflow/Functions/Open-Workspace.ps1
@@ -172,8 +172,9 @@ function Open-Workspace {
 		# Terminal window reflects it, so each capture can exclude it.
 		$ownTerminalWindowHandle = $null
 		if ($Alongside -and $isAlongsideShell) {
-			$originalHostTitle = $Host.UI.RawUI.WindowTitle
+			$originalHostTitle = $null
 			try {
+				$originalHostTitle = $Host.UI.RawUI.WindowTitle
 				$titleProbe = "AlongsideShell_" + [guid]::NewGuid().ToString()
 				$Host.UI.RawUI.WindowTitle = $titleProbe
 				Start-Sleep -Milliseconds 50
@@ -190,8 +191,13 @@ function Open-Workspace {
 					Write-LogDebug " [Open-Workspace] Could not identify the alongside shell's own window (title probe not reflected) - the new terminal window will not be laid out" -Style Warning
 				}
 			}
+			catch {
+				Write-LogDebug " [Open-Workspace] Window title probe failed => $($_.Exception.Message)" -Style Warning
+			}
 			finally {
-				try { $Host.UI.RawUI.WindowTitle = $originalHostTitle } catch {}
+				if ($null -ne $originalHostTitle) {
+					try { $Host.UI.RawUI.WindowTitle = $originalHostTitle } catch {}
+				}
 			}
 		}
 

--- a/Windows/PowerShell/Modules/Workflow/Functions/Open-Workspace.ps1
+++ b/Windows/PowerShell/Modules/Workflow/Functions/Open-Workspace.ps1
@@ -20,13 +20,20 @@ function Open-Workspace {
 		For example, if you have WinuX workspace open and want to work on Server simultaneously,
 		use: Open-Workspace Server -Alongside
 
+		The whole open flow always runs in a completely new shell window: the invocation is
+		relaunched in a fresh Windows Terminal window and the calling shell gets its prompt
+		back immediately. Inside that new window, terminal-opening actions are forced to
+		-InSameShell so the workspace's terminal tabs join the new window instead of
+		spawning further windows.
+
 	.EXAMPLE
 		Open-Workspace WinuX
 		# Opens WinuX workspace on the first virtual desktop(s)
 
 	.EXAMPLE
 		Open-Workspace Server -Alongside
-		# Opens Server workspace on virtual desktops to the right of existing ones
+		# Relaunches in a new shell window and opens Server workspace on virtual desktops
+		# to the right of existing ones; Server's terminal tabs open in that new window
 
 	#>
 	[CmdletBinding()]
@@ -43,6 +50,17 @@ function Open-Workspace {
 		[Parameter(ValueFromRemainingArguments = $true)]
 		[object[]]$ExtraArgs
 	)
+
+	# -Alongside relaunches this whole invocation inside a brand-new shell window (see
+	# the relaunch block below). The relaunched instance is marked with this env var;
+	# the marker is consumed immediately so only THIS invocation treats itself as the
+	# relaunched one - a later -Alongside run typed into that same shell window
+	# relaunches into its own new window again.
+	$alongsideShellEnvVar = 'OPEN_WORKSPACE_ALONGSIDE_SHELL'
+	$isAlongsideShell = -not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($alongsideShellEnvVar, 'Process'))
+	if ($isAlongsideShell) {
+		[Environment]::SetEnvironmentVariable($alongsideShellEnvVar, $null, 'Process')
+	}
 
 	$workspaceTimerEnvVar = 'OPEN_WORKSPACE_START_UTC'
 	$currentInvocationStartUtc = [DateTimeOffset]::UtcNow
@@ -76,6 +94,58 @@ function Open-Workspace {
 
 	$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 	try {
+		# -Alongside always runs in a completely new shell: replay this exact invocation
+		# in a fresh Windows Terminal window and hand the calling shell its prompt back.
+		# The bootstrap command marks the new shell via $alongsideShellEnvVar (so it
+		# executes the flow instead of relaunching again), carries the timer start across
+		# so the reported duration includes the relaunch, and clears WT_PROJECT_TAB
+		# because the new window's WT process can inherit it from a project-tab caller
+		# and the bootstrap tab must not pass for a project tab. Inside the new shell,
+		# terminal-opening actions are forced to -InSameShell (see the action loop) so
+		# their tabs join the new window, and a configured
+		# Terminate-WindowsTerminalTabs -OnlyCurrent closes the redundant bootstrap tab
+		# as its final step.
+		if ($Alongside -and -not $isAlongsideShell) {
+			$quote = { param($value) "'" + ([string]$value -replace "'", "''") + "'" }
+
+			$invocationTokens = @('Open-Workspace')
+			if ($Workspace) {
+				$invocationTokens += '-Workspace'
+				$invocationTokens += (@($Workspace) | ForEach-Object { & $quote $_ }) -join ', '
+			}
+			if ($Project) {
+				$invocationTokens += '-Project'
+				$invocationTokens += (@($Project) | ForEach-Object { & $quote $_ }) -join ', '
+			}
+			$invocationTokens += '-Alongside'
+			foreach ($extraArg in $ExtraArgs) {
+				if ($extraArg -is [string] -and $extraArg.StartsWith('-')) {
+					$invocationTokens += $extraArg
+				}
+				elseif ($extraArg -is [bool]) {
+					$invocationTokens += '$' + $extraArg.ToString().ToLower()
+				}
+				elseif ($extraArg -is [array]) {
+					$invocationTokens += (@($extraArg) | ForEach-Object { & $quote $_ }) -join ', '
+				}
+				else {
+					$invocationTokens += & $quote $extraArg
+				}
+			}
+
+			$effectiveStartUtc = $currentInvocationStartUtc - $carryOverElapsed
+			$bootstrapCommand = "`$env:WT_PROJECT_TAB = `$null; " +
+			"`$env:$workspaceTimerEnvVar = '$($effectiveStartUtc.ToString('o'))'; " +
+			"`$env:$alongsideShellEnvVar = '1'; " +
+			($invocationTokens -join ' ')
+
+			$workspaceLabel = if ($Workspace) { " $($Workspace -join ', ')" } else { "" }
+			Write-LogTitle "Relaunching [Open-Workspace$workspaceLabel -Alongside] in a new shell window"
+			Write-LogDebug " [Open-Workspace] Alongside relaunch command => [$($invocationTokens -join ' ')]" -Style Success
+			Open-Terminal -Command $bootstrapCommand
+			return
+		}
+
 		# Every process this flow spawns (apps, terminals, and PowerToys if Start-FancyZones
 		# has to launch it) inherits this shell's token. From an elevated shell that means
 		# elevated app windows - which a non-elevated FancyZones cannot snap - and/or an
@@ -247,6 +317,14 @@ function Open-Workspace {
 					}
 				}
 
+				# Inside the relaunched alongside shell every terminal-opening action must
+				# land its tabs in THIS new window instead of spawning yet another one:
+				# force InSameShell on. Get-FilteredParams strips the parameter from
+				# actions that do not support it.
+				if ($Alongside -and $isAlongsideShell) {
+					$actionParams["InSameShell"] = $true
+				}
+
 				if ($action -eq "Open-Project") {
 					if (-not $actionParams.ContainsKey("Project") -and $Project) {
 						$actionParams["Project"] = $Project
@@ -318,15 +396,13 @@ function Open-Workspace {
 					$actionParams["DesktopOffset"] = $desktopOffset
 				}
 
-				# Skip Terminate-WindowsTerminalTabs -OnlyCurrent when:
-				# 1. -Alongside is active (the calling tab belongs to an existing workspace)
-				# 2. The calling tab is a project terminal tab for THIS workspace (idempotent re-run)
-				#    But NOT when it's from a DIFFERENT workspace's project tab
+				# Skip Terminate-WindowsTerminalTabs -OnlyCurrent when the calling tab is a
+				# project terminal tab for THIS workspace (idempotent re-run), but NOT when
+				# it's from a DIFFERENT workspace's project tab. In alongside mode this code
+				# only ever runs inside the relaunched shell (the parent invocation returns
+				# right after spawning it), where the calling tab is the disposable bootstrap
+				# tab - closing it is exactly what we want, so alongside is not skipped here.
 				if ($action -eq "Terminate-WindowsTerminalTabs" -and $actionParams.ContainsKey("OnlyCurrent") -and $actionParams["OnlyCurrent"]) {
-					if ($Alongside) {
-						Write-LogDebug " [Open-Workspace] Skipping Terminate-WindowsTerminalTabs -OnlyCurrent (opening alongside)" -Style Warning
-						continue
-					}
 					if ($env:WT_PROJECT_TAB) {
 						$isCallerTabForThisWorkspace = $workspaceProjectTabNames | Where-Object { $env:WT_PROJECT_TAB -match [regex]::Escape($_) }
 						if ($isCallerTabForThisWorkspace) {

--- a/docs/modules/application.md
+++ b/docs/modules/application.md
@@ -396,7 +396,7 @@ Opens a fresh Windows Terminal window by default. When `-Command` is supplied, e
 | ---------------- | ------------------------------------------------------------------------------------------------------ |
 | `-Command`       | Array of commands to execute, each in its own tab (base64-encoded internally).                         |
 | `-Administrator` | Opens Windows Terminal with elevated privileges.                                                       |
-| `-InSameShell`   | Opens tabs in the current Windows Terminal window (ID 0) instead of a new window. Default: new window. |
+| `-InSameShell`   | Opens tabs in the current Windows Terminal window instead of a new window (targets `$env:WT_WINDOW_ID` when the calling shell knows its window, e.g. inside `Open-Workspace -Alongside`; otherwise ID 0 = the most recently used window). Default: new window. |
 | `-WindowId`      | Explicit Windows Terminal window ID to open tabs in; overrides `-InSameShell`.                         |
 | `-TabTitles`     | Array of custom tab titles; should match the number of commands.                                       |
 

--- a/docs/modules/workflow.md
+++ b/docs/modules/workflow.md
@@ -194,17 +194,18 @@ Open-DnD -Campaign "AnotherCampaign" -FoundryVTT
 ## [Open-Project](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Workflow/Functions/Open-Project.ps1)
 
 - **Description:** Opens a development project with all its configured tools, applications and terminal tabs. Reads the project's action list from `ProjectActions` in `Configuration.psd1` and executes each action in order; with `-RunApp` it starts the project's server instead of opening terminal tabs. Omit the project name to pick from an interactive menu.
-- **Parameters:** -Project, -RunApp, -VSCodeWorkspace
+- **Parameters:** -Project, -RunApp, -VSCodeWorkspace, -InSameShell
 - **Usage:** `Open-Project`, `Open-Project MyProject`, `Open-Project MyProject -RunApp`
 - **Projects:** MyProject, OtherProject (the entries of the `Projects` array in `Configuration.psd1`)
 
-Each action in `ProjectActions` is a named PowerShell function (e.g. `Open-VSCode`, `Open-VisualStudio`, `Open-Browser`) whose parameters are resolved at runtime. The `{ProjectName}` placeholder in any action parameter is replaced with the actual project name at execution time. When no project name is supplied, an interactive menu lists every project in the `Projects` array; multiple projects may be selected and each is opened in sequence. The special action `Open-ProjectTerminals-Or-RunProject` is context-sensitive: with `-RunApp` it starts the server via `Run-Project`, otherwise it opens terminal tabs via `Open-ProjectTerminals`. When `-VSCodeWorkspace <name>` is set, the project's `Open-VSCode` action opens the given `.code-workspace` (via `Open-VSCodeWorkspace`) in place of the project folder. The function returns the list of project names that were opened.
+Each action in `ProjectActions` is a named PowerShell function (e.g. `Open-VSCode`, `Open-VisualStudio`, `Open-Browser`) whose parameters are resolved at runtime. The `{ProjectName}` placeholder in any action parameter is replaced with the actual project name at execution time. When no project name is supplied, an interactive menu lists every project in the `Projects` array; multiple projects may be selected and each is opened in sequence. The special action `Open-ProjectTerminals-Or-RunProject` is context-sensitive: with `-RunApp` it starts the server via `Run-Project`, otherwise it opens terminal tabs via `Open-ProjectTerminals`. When `-VSCodeWorkspace <name>` is set, the project's `Open-VSCode` action opens the given `.code-workspace` (via `Open-VSCodeWorkspace`) in place of the project folder. An explicitly passed `-InSameShell` overrides the configured value of the `Open-ProjectTerminals-Or-RunProject` action - `Open-Workspace`'s `-Alongside` relaunch uses this to gather the project's terminal tabs in the relaunched shell window. The function returns the list of project names that were opened.
 
 | Parameter          | Description                                                                                                                                |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
 | `-Project`         | One or more project names from the `Projects` configuration array. Omit to show the interactive selection menu.                            |
 | `-RunApp`          | Starts the project's runnable app instead of opening terminals (applies to the `Open-ProjectTerminals-Or-RunProject` action only).         |
 | `-VSCodeWorkspace` | When set, the project's `Open-VSCode` action opens the given `.code-workspace` (via `Open-VSCodeWorkspace`) instead of the project folder. |
+| `-InSameShell`     | When explicitly passed, overrides the configured `InSameShell` of the `Open-ProjectTerminals-Or-RunProject` action so terminal tabs open in the caller's window. |
 
 ```powershell
 # Interactive project selection menu
@@ -299,7 +300,7 @@ Open-ProjectTerminals -Project "MyProject" -Force
 
 ## [Open-Workspace](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Workflow/Functions/Open-Workspace.ps1)
 
-- **Description:** The main entry point for starting work. Opens a predefined workspace by executing a configured sequence of actions (projects, browser tab groups, applications, and window layouts) across virtual desktops. Use `-Alongside` to spawn the workspace on new virtual desktops to the right of existing ones, letting multiple workspaces run simultaneously without interfering. In alongside mode the computed desktop offset is injected into the workspace's actions so they land on the new desktops - both `Set-WorkspaceWindowLayout` and the final `Focus-VirtualDesktop` action receive `-DesktopOffset`, so the configured landing (e.g. `DesktopNumber = 1`) focuses the new workspace's own first desktop instead of the original desktop 1. Automatically reconciles the calling terminal tab via `Terminate-WindowsTerminalTabs -OnlyCurrent` (skipped when running alongside or re-running from a same-workspace project tab). Diagnostic output for the workspace and its actions is shown when run under `Set-LogLevel Verbose`.
+- **Description:** The main entry point for starting work. Opens a predefined workspace by executing a configured sequence of actions (projects, browser tab groups, applications, and window layouts) across virtual desktops. Use `-Alongside` to spawn the workspace on new virtual desktops to the right of existing ones, letting multiple workspaces run simultaneously without interfering. An `-Alongside` invocation always runs in a completely new shell: it relaunches itself in a fresh Windows Terminal window (the calling shell gets its prompt back immediately) and, inside that window, forces `-InSameShell` on terminal-opening actions so the workspace's terminal tabs join the new window instead of spawning further windows. In alongside mode the computed desktop offset is injected into the workspace's actions so they land on the new desktops - both `Set-WorkspaceWindowLayout` and the final `Focus-VirtualDesktop` action receive `-DesktopOffset`, so the configured landing (e.g. `DesktopNumber = 1`) focuses the new workspace's own first desktop instead of the original desktop 1. Automatically reconciles the calling terminal tab via `Terminate-WindowsTerminalTabs -OnlyCurrent` (skipped when re-running from a same-workspace project tab; in alongside mode it runs inside the relaunched window and closes that window's now-redundant bootstrap tab). Diagnostic output for the workspace and its actions is shown when run under `Set-LogLevel Verbose`.
 - **Parameters:** -Workspace, -Project, -Alongside, -VSCodeWorkspace
 - **Usage:** `Open-Workspace`, `Open-Workspace MyWorkspace`, `Open-Workspace MyWorkspace MyProject`, `Open-Workspace MyWorkspace -Alongside`, `w dotfiles -VSCodeWorkspace Consolidation`, `w MyWorkspace`
 - **Alias:** w
@@ -312,7 +313,7 @@ Everything the flow spawns inherits the invoking shell's token, so running from 
 | ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-Workspace`       | One or more workspace names to open. Omit to show the selection menu.                                                                                                                                                                                                               |
 | `-Project`         | Optional project name(s) forwarded to the `Open-Project` action within the workspace.                                                                                                                                                                                               |
-| `-Alongside`       | Opens the workspace on new virtual desktop(s) added to the right of existing ones, so multiple workspaces coexist.                                                                                                                                                                  |
+| `-Alongside`       | Opens the workspace on new virtual desktop(s) added to the right of existing ones, so multiple workspaces coexist. Always relaunches in a new Windows Terminal window; the workspace's terminal tabs open in that window (`-InSameShell` is forced on terminal-opening actions).     |
 | `-VSCodeWorkspace` | Opens `<name>.code-workspace` (from `VSCode\Workspaces`) in place of the project folder. Pass a bare `-VSCodeWorkspace` for a selection menu; omit it to use the `DefaultVSCodeWorkspaces` config entry (if any) or normal folder behaviour. |
 
 ```powershell
@@ -326,6 +327,7 @@ Open-Workspace MyWorkspace
 Open-Workspace MyWorkspace MyProject
 
 # Open another workspace on new desktops alongside the current one
+# (relaunches in a new shell window; its terminal tabs open in that window)
 Open-Workspace OtherProject -Alongside
 
 # Open a workspace but load a .code-workspace file instead of the project folder


### PR DESCRIPTION
## Description

`Open-Workspace -Alongside` now always runs in a completely new shell. The invocation relaunches itself in a fresh Windows Terminal window and hands the calling shell its prompt back immediately; the whole open flow (apps, browsers, terminals, layout) executes inside that window's bootstrap shell.

## Related issue

No separate tracking issue, but beyond the terminal-placement fix this also **sidesteps the virtual-desktop RPC failures** that intermittently break `-Alongside`. The `VirtualDesktop` COM/RPC session the Window module uses to create, switch, and remove virtual desktops goes stale in a long-running shell: `Switch-Desktop` starts silently no-op'ing and `Ensure-VirtualDesktops` / `Remove-VirtualDesktops` begin throwing "RPC server may be unavailable". That is exactly the path `-Alongside` exercises hardest - it is the heaviest virtual-desktop consumer, creating desktops to the right of existing ones, moving the new windows onto them, and pruning empties afterward. Until now the only recovery was in-session patching (`Reset-VirtualDesktopState` reloads the VirtualDesktop module to force a fresh COM/RPC session, and the layout step can re-run a failed window in a fresh shell), and that is best-effort rather than reliable.

Because the entire `-Alongside` flow now runs in a brand-new shell process, its virtual-desktop calls execute against a clean RPC session from the start - which is the most reliable form of that "fresh shell" recovery, done up front instead of as a mid-run rescue. It does not *fix* the underlying Windows RPC staleness (a session wedged outside our process can still fail, hence "mostly"), but in practice it circumvents the issue almost entirely for the workspace-open path.

Key mechanics:

- **Deterministic window targeting.** The parent creates the new window under an explicit GUID and passes it to the relaunched shell via `WT_WINDOW_ID`. Every terminal-opening action inside the relaunched shell is forced to `-InSameShell`, and both `Open-ProjectTerminals` and `Open-Terminal` now resolve the caller window from `WT_WINDOW_ID` before falling back to window ID 0. This matters because [`wt -w 0` targets the *most recently used* window](https://learn.microsoft.com/en-us/windows/terminal/command-line-arguments), not the invoker's window - with the original workspace window still open, tabs would otherwise land there.
- **Layout placement.** The relaunched shell's own hosting window is identified via a unique title probe and excluded from the pre-captured "existing windows" set, so the alongside layout (which skips pre-existing windows to protect other workspaces) places it on the new workspace's virtual desktops like any other workspace window.
- **`Open-Project -InSameShell`.** New pass-through parameter: when explicitly bound it overrides the configured value of the `Open-ProjectTerminals-Or-RunProject` action, which is how the relaunch forces project tabs into its window.
- **Bootstrap cleanup.** A configured `Terminate-WindowsTerminalTabs -OnlyCurrent` now runs inside the relaunched shell and closes the redundant bootstrap tab as its final step (the old "skip when alongside" guard protected the caller's tab, which the parent no longer risks since it returns before running any actions).
- The bootstrap command also carries the elapsed-time marker across the relaunch and clears an inherited `WT_PROJECT_TAB`, and the relaunch marker env var is consumed at entry so a later `-Alongside` typed into that same window relaunches again.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [ ] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

Note: `-Alongside` keeps its command surface but changes where the flow executes (new window instead of the calling shell). Documented in `CHANGELOG.md` under Changed.

## Quality bar

- [x] The change is **minimal and focused** (one logical change; reuses existing helpers, no duplication / DRY).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` using placeholder paths (N/A - no new setting introduced).

## Tests

```powershell
Run-Tests -TestName "Open-Workspace"     # 24 passed
Run-Tests -TestName "Open-Project"       # includes 3 new InSameShell forwarding tests
Run-Tests -TestName "Open-ProjectTerminals"
Run-Tests -TestName "Open-Terminal"      # includes WT_WINDOW_ID resolution tests
Run-Tests                                 # full suite: 1066 passed, 0 failed
```

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/` (relaunch command shape and window-ID handoff, forced `InSameShell`, marker consumption, own-window exclusion from pre-captured windows, `WT_WINDOW_ID` resolution precedence, and env hygiene so window-id assertions stay deterministic in shells descended from an alongside bootstrap).
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text.
- [ ] N/A - no testable behavior changed (docs/chore only).

## Documentation & manifests

- [x] I updated `docs/modules/<Module>.md` for any added/renamed/removed/changed function (`workflow.md`: Open-Workspace `-Alongside` behavior + Open-Project `-InSameShell`; `application.md`: Open-Terminal `-InSameShell` resolution).
- [ ] I updated the module `.psd1` `FunctionsToExport` (N/A - no function added, renamed, or removed).
- [ ] I updated `docs/docs_overview.md` (N/A - no page added or removed).
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds (no exported function set changed).

## Tested on

- Windows version: Windows 11 Pro (build 26200)
- PowerShell version: 7.6.3
- Machine type(s): PC

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] This PR contains no secrets or personal data (tokens, real paths/hostnames/emails).