### PR TITLE
Gate PersonalSteps per machine type and validate all machine scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.5] - 2026-07-15
+
+### Added
+
+- `Test-MachineTypeScope` (Bootstrap module): the single gate behind every machine-scoped data source - the `Machine` column of the WinGet/Scoop/Chocolatey CSVs and `BootstrapConfig.PersonalSteps`. Splits a scope like `PC/Laptop` on `/`, matches case-insensitively, treats `All` as the wildcard, and validates every token against `ValidMachineTypes`: an unknown token (e.g. the typo `Labtop`) is reported via `Write-LogError` together with its data source and the list of valid values, and contributes nothing to the match - a misspelled scope can no longer silently install or skip anything.
+- `Invoke-PersonalSteps` (Bootstrap module): runs the fork-defined `BootstrapConfig.PersonalSteps`, extracted out of `Bootstrap` into its own exported function. Entries are now machine-gated: a plain function name runs on every machine type (exactly as before), while `@{ Function = "Install-MyTool"; Machine = "PC/Laptop" }` runs only where its `Machine` scope matches - mirroring the app CSVs' `Machine` column.
+
+### Changed
+
+- `Install-WingetApps`, `Install-ScoopApps`, and `Install-ChocolateyApps` (Application module) route their `Machine`-column filtering through `Test-MachineTypeScope`, so CSV rows gain the same unknown-token validation instead of three copies of a silent inline filter.
+
+### Fixed
+
+- `Test-AdminPrivileges` (Helper module): the elevate-and-rerun offer replayed the immediate caller's source line, which at call depth two or more is an engine line such as `& $stepName` - the fresh elevated shell has no such variable, so the rerun died with "The expression after '&' in a pipeline element produced an object that was not valid". It now replays the outermost call-stack frame that recorded a line - the command the user actually typed - with unchanged behavior for every existing depth-one caller.
+
 ## [0.1.4] - 2026-07-11
 
 ### Added
@@ -71,7 +86,8 @@ The first public release of WinuX.
 - Governance and licensing: MIT license, contributor guide, code of conduct, security policy, and third-party notices.
 - CI: the full Pester suite on every pull request, and a release workflow that builds `WinuX.exe` from every version tag and attaches it - with a SHA-256 checksum - to the GitHub release.
 
-[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.5...HEAD
+[0.1.5]: https://github.com/IvanPavlak/WinuX/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/IvanPavlak/WinuX/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/IvanPavlak/WinuX/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/IvanPavlak/WinuX/compare/v0.1.1...v0.1.2

--- a/Windows/PowerShell/Configuration.psd1
+++ b/Windows/PowerShell/Configuration.psd1
@@ -79,7 +79,7 @@
 # → BootstrapConfig              : Bootstrap, Install-Bootstrap
 #
 # Machine Type Detection:
-# → ValidMachineTypes            : DetermineMachineType
+# → ValidMachineTypes            : DetermineMachineType, Test-MachineTypeScope
 # → HostnameToMachineType        : DetermineMachineType
 # → DefaultMachineType           : DetermineMachineType
 # → LaptopChassisTypes           : Test-PowerPlan (WMI chassis type detection)
@@ -629,10 +629,15 @@
 		}
 
 		# Fork-defined optional bootstrap steps, run right after Upgrade-All (consumed by
-		# Bootstrap). Each entry is the name of a function the fork's modules export; entries
-		# that do not resolve are skipped with a warning. The base ships an empty list, so a
-		# vanilla WinuX bootstrap runs no personal steps. Forks set their own list in
-		# Configuration.local.psd1, e.g. PersonalSteps = @("Install-MyBackupTool").
+		# Bootstrap). Each entry is either the name of a function the fork's modules export
+		# (runs on every machine type), or a hashtable @{ Function = "Name"; Machine = "PC/Laptop" }
+		# gated per machine type exactly like the app CSVs' Machine column ("All" covers every
+		# machine; tokens are validated by Test-MachineTypeScope, so typos are reported instead
+		# of silently never matching). Entries that do not resolve are skipped with a warning.
+		# The base ships an empty list, so a vanilla WinuX bootstrap runs no personal steps.
+		# Forks set their own list in Configuration.local.psd1, e.g.
+		# PersonalSteps = @("Install-MyBackupTool") or
+		# PersonalSteps = @(@{ Function = "Install-MyBackupTool"; Machine = "PC" }).
 		PersonalSteps         = @()
 
 		# External script URLs

--- a/Windows/PowerShell/Configuration.psd1
+++ b/Windows/PowerShell/Configuration.psd1
@@ -629,8 +629,9 @@
 		}
 
 		# Fork-defined optional bootstrap steps, run right after Upgrade-All (consumed by
-		# Bootstrap). Each entry is either the name of a function the fork's modules export
-		# (runs on every machine type), or a hashtable @{ Function = "Name"; Machine = "PC/Laptop" }
+		# Bootstrap -> Invoke-PersonalSteps). Each entry is either the name of a function the
+		# fork's modules export (runs on every machine type), or a hashtable
+		# @{ Function = "Name"; Machine = "PC/Laptop" }
 		# gated per machine type exactly like the app CSVs' Machine column ("All" covers every
 		# machine; tokens are validated by Test-MachineTypeScope, so typos are reported instead
 		# of silently never matching). Entries that do not resolve are skipped with a warning.

--- a/Windows/PowerShell/Modules/Application/Functions/Install-ChocolateyApps.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Install-ChocolateyApps.ps1
@@ -25,9 +25,7 @@ function Install-ChocolateyApps {
 	$chocoApps = Import-Csv $csvPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_.App) -and -not $_.App.TrimStart().StartsWith('#') }
 
 	foreach ($app in $chocoApps) {
-		$validMachines = ("$($app.Machine)").Trim() -split "/" | ForEach-Object { $_.Trim() }
-
-		if ($MachineType -notin $validMachines -and "All" -notin $validMachines) { continue }
+		if (-not (Test-MachineTypeScope -Scope "$($app.Machine)" -MachineType $MachineType -Context "ChocolateyApps.csv [$($app.App)]")) { continue }
 
 		$appName = $app.App
 		Write-LogTitle "$appName"

--- a/Windows/PowerShell/Modules/Application/Functions/Install-ScoopApps.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Install-ScoopApps.ps1
@@ -34,9 +34,7 @@ function Install-ScoopApps {
 	}
 
 	foreach ($app in $scoopApps) {
-		$validMachines = ("$($app.Machine)").Trim() -split "/" | ForEach-Object { $_.Trim() }
-
-		if ($MachineType -notin $validMachines -and "All" -notin $validMachines) { continue }
+		if (-not (Test-MachineTypeScope -Scope "$($app.Machine)" -MachineType $MachineType -Context "ScoopApps.csv [$($app.App)]")) { continue }
 
 		$global = if ($app.Global -eq "true") { "--global" } else { "" }
 		$version = if ($app.Version -and $app.Version -ne "latest") { "@$($app.Version)" } else { "" }

--- a/Windows/PowerShell/Modules/Application/Functions/Install-WingetApps.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Install-WingetApps.ps1
@@ -43,9 +43,7 @@ function Install-WinGetApps {
 	$failedApps = @()
 
 	foreach ($app in $wingetApps) {
-		$validMachines = ("$($app.Machine)").Trim() -split "/" | ForEach-Object { $_.Trim() }
-
-		if ($MachineType -notin $validMachines -and "All" -notin $validMachines) { continue }
+		if (-not (Test-MachineTypeScope -Scope "$($app.Machine)" -MachineType $MachineType -Context "WinGetApps.csv [$($app.App)]")) { continue }
 
 		$scope = switch ($app.Scope) {
 			"d" { "" }

--- a/Windows/PowerShell/Modules/Bootstrap/Bootstrap.psd1
+++ b/Windows/PowerShell/Modules/Bootstrap/Bootstrap.psd1
@@ -10,6 +10,7 @@
 		'Expand-Hashtable',
 		'Initialize-Configuration',
 		'Install-WinGetPackageManager',
+		'Invoke-PersonalSteps',
 		'Load-PathConfiguration',
 		'Merge-Hashtable',
 		'Test-MachineTypeScope'

--- a/Windows/PowerShell/Modules/Bootstrap/Bootstrap.psd1
+++ b/Windows/PowerShell/Modules/Bootstrap/Bootstrap.psd1
@@ -11,6 +11,7 @@
 		'Initialize-Configuration',
 		'Install-WinGetPackageManager',
 		'Load-PathConfiguration',
-		'Merge-Hashtable'
+		'Merge-Hashtable',
+		'Test-MachineTypeScope'
 	)
 }

--- a/Windows/PowerShell/Modules/Bootstrap/Functions/Bootstrap.ps1
+++ b/Windows/PowerShell/Modules/Bootstrap/Functions/Bootstrap.ps1
@@ -16,7 +16,7 @@ function Bootstrap {
 		5. Nerd Font, PowerShell modules, special folder redirections
 		6. WSL configuration (config-gated per machine type via BootstrapConfig.WSLSetup)
 		7. WinGet, Scoop, and Chocolatey - install package managers then apps from CSVs
-		8. Upgrade all packages, fork-defined personal steps (BootstrapConfig.PersonalSteps), .NET EF CLI
+		8. Upgrade all packages, fork-defined personal steps (BootstrapConfig.PersonalSteps, optionally machine-gated), .NET EF CLI
 		9. Environment variables, Conda environments, NuGet config, taskbar pins
 		10. WSL environment initialization, symbolic links, WSL SSH setup (WSL steps use the same gate)
 		11. Lock taskbar layout, restart Explorer, restart machine
@@ -190,12 +190,30 @@ function Bootstrap {
 		# Fork-defined optional install steps (BootstrapConfig.PersonalSteps) - the base config
 		# ships an empty list, so a vanilla WinuX bootstrap runs nothing here. Forks name their
 		# personal tools in Configuration.local.psd1; each entry must be an exported function.
+		# An entry is either a plain function name (runs on every machine type) or a hashtable
+		# @{ Function = "Name"; Machine = "PC/Laptop" } gated per machine type exactly like the
+		# app CSVs' Machine column (tokens validated by Test-MachineTypeScope).
 		foreach ($personalStep in @($global:Configuration.BootstrapConfig.PersonalSteps)) {
-			if ($personalStep -and (Get-Command $personalStep -ErrorAction SilentlyContinue)) {
-				& $personalStep
+			if (-not $personalStep) { continue }
+
+			$stepName = if ($personalStep -is [System.Collections.IDictionary]) { "$($personalStep['Function'])" } else { "$personalStep" }
+			$stepScope = if ($personalStep -is [System.Collections.IDictionary] -and $null -ne $personalStep['Machine']) { "$($personalStep['Machine'])" } else { "All" }
+
+			if (-not $stepName) {
+				Write-LogWarning "Personal step entry has no Function name - skipping"
+				continue
 			}
-			elseif ($personalStep) {
-				Write-LogWarning "Personal step [$personalStep] not found - skipping"
+
+			if (-not (Test-MachineTypeScope -Scope $stepScope -Context "PersonalSteps [$stepName]")) {
+				Write-LogDebug "Personal step [$stepName] skipped (machine scope => [$stepScope])"
+				continue
+			}
+
+			if (Get-Command $stepName -ErrorAction SilentlyContinue) {
+				& $stepName
+			}
+			else {
+				Write-LogWarning "Personal step [$stepName] not found - skipping"
 			}
 		}
 

--- a/Windows/PowerShell/Modules/Bootstrap/Functions/Bootstrap.ps1
+++ b/Windows/PowerShell/Modules/Bootstrap/Functions/Bootstrap.ps1
@@ -188,34 +188,9 @@ function Bootstrap {
 		Upgrade-All
 
 		# Fork-defined optional install steps (BootstrapConfig.PersonalSteps) - the base config
-		# ships an empty list, so a vanilla WinuX bootstrap runs nothing here. Forks name their
-		# personal tools in Configuration.local.psd1; each entry must be an exported function.
-		# An entry is either a plain function name (runs on every machine type) or a hashtable
-		# @{ Function = "Name"; Machine = "PC/Laptop" } gated per machine type exactly like the
-		# app CSVs' Machine column (tokens validated by Test-MachineTypeScope).
-		foreach ($personalStep in @($global:Configuration.BootstrapConfig.PersonalSteps)) {
-			if (-not $personalStep) { continue }
-
-			$stepName = if ($personalStep -is [System.Collections.IDictionary]) { "$($personalStep['Function'])" } else { "$personalStep" }
-			$stepScope = if ($personalStep -is [System.Collections.IDictionary] -and $null -ne $personalStep['Machine']) { "$($personalStep['Machine'])" } else { "All" }
-
-			if (-not $stepName) {
-				Write-LogWarning "Personal step entry has no Function name - skipping"
-				continue
-			}
-
-			if (-not (Test-MachineTypeScope -Scope $stepScope -Context "PersonalSteps [$stepName]")) {
-				Write-LogDebug "Personal step [$stepName] skipped (machine scope => [$stepScope])"
-				continue
-			}
-
-			if (Get-Command $stepName -ErrorAction SilentlyContinue) {
-				& $stepName
-			}
-			else {
-				Write-LogWarning "Personal step [$stepName] not found - skipping"
-			}
-		}
+		# ships an empty list, so a vanilla WinuX bootstrap runs nothing here. Entries are plain
+		# function names or machine-gated hashtables; see Invoke-PersonalSteps.
+		Invoke-PersonalSteps
 
 		Install-DotnetEf
 

--- a/Windows/PowerShell/Modules/Bootstrap/Functions/Invoke-PersonalSteps.ps1
+++ b/Windows/PowerShell/Modules/Bootstrap/Functions/Invoke-PersonalSteps.ps1
@@ -1,0 +1,71 @@
+function Invoke-PersonalSteps {
+	<#
+	.SYNOPSIS
+		Runs the fork-defined personal install steps from BootstrapConfig.PersonalSteps, machine-gated.
+
+	.DESCRIPTION
+		Executes the optional, fork-defined bootstrap steps listed in BootstrapConfig.PersonalSteps
+		(set in Configuration.local.psd1). When nothing applies - the list is empty (the base
+		configuration ships it empty) or every entry is gated to other machine types - it reports
+		so with a warning naming the current machine type. Called automatically by Bootstrap right
+		after Upgrade-All.
+
+		Each entry is either a plain function name (runs on every machine type) or a hashtable
+		@{ Function = "Name"; Machine = "PC/Laptop" } gated per machine type exactly like the app
+		CSVs' Machine column - scope tokens are validated by Test-MachineTypeScope, so unknown
+		machine types are reported instead of silently never matching.
+
+		Entries without a Function name and entries that do not resolve to an exported command are
+		skipped with a warning. Entries whose machine scope does not cover the current machine type
+		are skipped silently (a debug line records the skip).
+
+		Requires administrator privileges - personal steps install software. The check runs up
+		front via Test-AdminPrivileges, so a non-elevated invocation fails fast (offering the
+		elevated rerun) instead of aborting mid-run inside a step.
+
+	.EXAMPLE
+		Invoke-PersonalSteps
+		Runs every configured personal step applicable to the current machine type.
+	#>
+	[CmdletBinding()]
+	param()
+
+	Test-AdminPrivileges
+
+	Write-LogTitle "Invoking Personal Steps"
+
+	$personalSteps = @($global:Configuration.BootstrapConfig.PersonalSteps | Where-Object { $_ })
+
+	# Set once any entry's machine scope covers this machine (resolvable or not). When nothing
+	# applies - empty list, or every entry gated to other machine types - say so, instead of
+	# ending silently under the title (out-of-scope skips only log at debug level).
+	$anyStepInScope = $false
+
+	foreach ($personalStep in $personalSteps) {
+		$stepName = if ($personalStep -is [System.Collections.IDictionary]) { "$($personalStep['Function'])" } else { "$personalStep" }
+		$stepScope = if ($personalStep -is [System.Collections.IDictionary] -and $null -ne $personalStep['Machine']) { "$($personalStep['Machine'])" } else { "All" }
+
+		if (-not $stepName) {
+			Write-LogWarning "Personal step entry has no Function name - skipping"
+			continue
+		}
+
+		if (-not (Test-MachineTypeScope -Scope $stepScope -Context "PersonalSteps [$stepName]")) {
+			Write-LogDebug "Personal step [$stepName] skipped (machine scope => [$stepScope])"
+			continue
+		}
+
+		$anyStepInScope = $true
+
+		if (Get-Command $stepName -ErrorAction SilentlyContinue) {
+			& $stepName
+		}
+		else {
+			Write-LogWarning "Personal step [$stepName] not found - skipping"
+		}
+	}
+
+	if (-not $anyStepInScope) {
+		Write-LogWarning "No personal steps configured for this [$global:MachineType] machine!"
+	}
+}

--- a/Windows/PowerShell/Modules/Bootstrap/Functions/Test-MachineTypeScope.ps1
+++ b/Windows/PowerShell/Modules/Bootstrap/Functions/Test-MachineTypeScope.ps1
@@ -1,0 +1,75 @@
+function Test-MachineTypeScope {
+	<#
+	.SYNOPSIS
+		Tests whether a machine-scope string ("All", "PC/Laptop", ...) applies to a machine type, validating every token.
+
+	.DESCRIPTION
+		The single gate behind every machine-scoped data source: the Machine column of the
+		WinGet/Scoop/Chocolatey CSVs and the BootstrapConfig.PersonalSteps entries. Splits the
+		scope string on "/", trims each token, and returns $true when the scope names "All" or
+		the given machine type (matching is case-insensitive, so "laptop" covers "Laptop").
+
+		Every token is checked against ValidMachineTypes from the configuration plus the "All"
+		wildcard. Unknown tokens (e.g. the typo "Labtop") are reported through Write-LogError
+		together with the valid values, and contribute nothing to the match - so a misspelled
+		scope can never silently install or skip anything. A blank scope is reported the same
+		way and never matches. When the configuration defines no ValidMachineTypes (synthetic
+		test configurations), token validation is skipped and only matching is performed.
+
+	.PARAMETER Scope
+		The machine-scope string: one or more machine types separated by "/" (e.g. "PC/Laptop"),
+		or "All" to cover every machine type.
+
+	.PARAMETER MachineType
+		Machine type to test the scope against. Defaults to $global:MachineType (resolved by
+		Load-PathConfiguration / DetermineMachineType). When empty, only "All" scopes match.
+
+	.PARAMETER Context
+		Optional label naming the data source (e.g. "WinGetApps.csv [Git.Git]"), included in
+		error messages so an invalid token can be located and fixed immediately.
+
+	.EXAMPLE
+		Test-MachineTypeScope -Scope "PC/Laptop" -MachineType "Laptop"
+		Returns $true - the scope covers Laptop.
+
+	.EXAMPLE
+		Test-MachineTypeScope -Scope "Labtop" -MachineType "Laptop" -Context "WinGetApps.csv [MyApp]"
+		Returns $false and reports the unknown token [Labtop] with the list of valid values.
+	#>
+	[CmdletBinding()]
+	[OutputType([bool])]
+	param(
+		[Parameter(Mandatory = $false)]
+		[AllowEmptyString()]
+		[string]$Scope,
+
+		[Parameter(Mandatory = $false)]
+		[string]$MachineType = $global:MachineType,
+
+		[Parameter(Mandatory = $false)]
+		[string]$Context
+	)
+
+	$contextSuffix = if ($Context) { " in [$Context]" } else { "" }
+	$validTypes = @($global:Configuration.ValidMachineTypes | Where-Object { $_ })
+
+	$tokens = @(("$Scope").Trim() -split "/" | ForEach-Object { $_.Trim() } | Where-Object { $_ })
+	if ($tokens.Count -eq 0) {
+		Write-LogError "Empty machine scope$contextSuffix - expected 'All' or machine types separated by '/'"
+		return $false
+	}
+
+	# Validate every token against the configured machine types (plus the "All" wildcard) so a
+	# typo like "Labtop" is reported instead of silently never matching. Configurations without
+	# ValidMachineTypes (synthetic test configs) skip validation and keep pure matching behavior.
+	$recognizedTokens = @(foreach ($token in $tokens) {
+			if ($token -eq "All" -or $validTypes.Count -eq 0 -or $token -in $validTypes) {
+				$token
+			}
+			else {
+				Write-LogError "Unknown machine type [$token]$contextSuffix - valid values: $(@(@("All") + $validTypes) -join ', ')"
+			}
+		})
+
+	return ("All" -in $recognizedTokens -or ($MachineType -and $MachineType -in $recognizedTokens))
+}

--- a/Windows/PowerShell/Modules/Helper/Functions/Test-AdminPrivileges.ps1
+++ b/Windows/PowerShell/Modules/Helper/Functions/Test-AdminPrivileges.ps1
@@ -29,7 +29,18 @@ function Test-AdminPrivileges {
 
 	if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
 		$currentDirectory = (Get-Location).Path
-		$triggeringCommand = (Get-PSCallStack)[1].InvocationInfo.Line
+		# Replay the command the user actually typed. Each frame's InvocationInfo.Line is the
+		# source line that invoked that frame, so the OUTERMOST frame that recorded a line holds
+		# the original typed command (the interactive prompt's own frame records none). Inner
+		# frames carry engine source lines (e.g. "& $stepName" dispatching a personal step) that
+		# are meaningless in a fresh elevated shell, where those variables do not exist and the
+		# rerun dies with "The expression after '&' ... was not valid".
+		$callStack = Get-PSCallStack
+		$triggeringCommand = ""
+		for ($frameIndex = $callStack.Count - 1; $frameIndex -ge 1; $frameIndex--) {
+			$triggeringCommand = "$($callStack[$frameIndex].InvocationInfo.Line)".Trim()
+			if ($triggeringCommand) { break }
+		}
 
 		Write-LogError "This must be run with Administrator privileges!"
 

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Install-ChocolateyApps.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Install-ChocolateyApps.Tests.ps1
@@ -6,6 +6,9 @@ BeforeAll {
 
 	$AppFunctionsPath = Join-Path (Get-RepositoryPath).Modules "Application\Functions"
 	. "$AppFunctionsPath\Install-ChocolateyApps.ps1"
+	# Dot-source the machine-scope gate so the Machine-column filtering resolves even in
+	# sessions whose imported Bootstrap module predates the Test-MachineTypeScope export.
+	. (Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions\Test-MachineTypeScope.ps1")
 }
 
 AfterAll {

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Install-ScoopApps.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Install-ScoopApps.Tests.ps1
@@ -6,6 +6,9 @@ BeforeAll {
 
 	$AppFunctionsPath = Join-Path (Get-RepositoryPath).Modules "Application\Functions"
 	. "$AppFunctionsPath\Install-ScoopApps.ps1"
+	# Dot-source the machine-scope gate so the Machine-column filtering resolves even in
+	# sessions whose imported Bootstrap module predates the Test-MachineTypeScope export.
+	. (Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions\Test-MachineTypeScope.ps1")
 
 	# scoop is absent on clean CI runners; a throwing stub makes 'scoop export' fail
 	# deterministically without Mock scoop (which would require scoop to pre-exist).

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Install-WingetApps.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Install-WingetApps.Tests.ps1
@@ -6,6 +6,9 @@ BeforeAll {
 
 	$AppFunctionsPath = Join-Path (Get-RepositoryPath).Modules "Application\Functions"
 	. "$AppFunctionsPath\Install-WingetApps.ps1"
+	# Dot-source the machine-scope gate so the Machine-column filtering resolves even in
+	# sessions whose imported Bootstrap module predates the Test-MachineTypeScope export.
+	. (Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions\Test-MachineTypeScope.ps1")
 }
 
 AfterAll {
@@ -36,5 +39,20 @@ XP9KHM4BK9FZ7Q,PC,Latest,d,n,s
 		Install-WinGetApps
 
 		Should -Invoke Invoke-Expression -Times 1 -Exactly -ParameterFilter { $Command -like '*winget install*Git.Git*' }
+	}
+
+	It "reports unknown machine tokens via Write-LogError and skips the row" {
+		$global:Configuration.ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test')
+		Mock Write-LogError { }
+		$csv = @'
+App,Machine,Version,Scope,Interactive,Source
+Git.Git,Labtop,Latest,d,n,w
+'@
+		Set-Content -Path (Join-Path $TestDrive 'winget.csv') -Value $csv
+
+		Install-WinGetApps
+
+		Should -Invoke Write-LogError -ParameterFilter { $Message -like '*Labtop*' }
+		Should -Invoke Invoke-Expression -Times 0 -ParameterFilter { $Command -like '*winget install*' }
 	}
 }

--- a/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Bootstrap.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Bootstrap.Tests.ps1
@@ -6,6 +6,9 @@ BeforeAll {
 
 	$BootstrapFunctionsPath = Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions"
 	. "$BootstrapFunctionsPath\Bootstrap.ps1"
+	# Dot-source the machine-scope gate so PersonalSteps gating resolves even in sessions whose
+	# imported Bootstrap module predates the Test-MachineTypeScope export.
+	. "$BootstrapFunctionsPath\Test-MachineTypeScope.ps1"
 }
 
 AfterAll {
@@ -30,6 +33,7 @@ Describe "Bootstrap" {
 		Mock Write-LogSuccess { }
 		Mock Write-LogWarning { }
 		Mock Write-LogError { }
+		Mock Write-LogDebug { }
 		Mock Test-AdminPrivileges { }
 		Mock Start-Logging { $global:startTime = Get-Date }
 		Mock Stop-Logging { }
@@ -138,5 +142,44 @@ Describe "Bootstrap" {
 		Bootstrap
 
 		Should -Invoke Write-LogWarning -Times 0 -ParameterFilter { $Message -like "*Personal step*" }
+	}
+
+	It "runs hashtable PersonalSteps whose Machine scope covers the machine type and skips the rest" {
+		$global:MachineType = 'Test'
+		$global:Configuration.ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test')
+		# Rename-Machine / Start-Win11Debloat are real exported commands that plain Bootstrap
+		# (no -WithInitialSetup) never calls, so they cleanly probe which entries actually ran.
+		$global:Configuration.BootstrapConfig = @{
+			PersonalSteps = @(
+				@{ Function = 'Rename-Machine'; Machine = 'Test' },
+				@{ Function = 'Start-Win11Debloat'; Machine = 'PC/Laptop' }
+			)
+		}
+
+		Bootstrap
+
+		Should -Invoke Rename-Machine -Times 1 -Exactly
+		Should -Invoke Start-Win11Debloat -Times 0
+		Should -Invoke Write-LogWarning -Times 0 -ParameterFilter { $Message -like "*Personal step*" }
+	}
+
+	It "reports invalid machine tokens in a personal step scope and does not run the step" {
+		$global:MachineType = 'Test'
+		$global:Configuration.ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test')
+		$global:Configuration.BootstrapConfig = @{ PersonalSteps = @(@{ Function = 'Rename-Machine'; Machine = 'Tset' }) }
+
+		Bootstrap
+
+		Should -Invoke Rename-Machine -Times 0
+		Should -Invoke Write-LogError -Times 1 -Exactly -ParameterFilter { $Message -like "*Tset*" }
+	}
+
+	It "warns on a personal step entry without a Function name" {
+		$global:MachineType = 'Test'
+		$global:Configuration.BootstrapConfig = @{ PersonalSteps = @(@{ Machine = 'All' }) }
+
+		Bootstrap
+
+		Should -Invoke Write-LogWarning -Times 1 -Exactly -ParameterFilter { $Message -like "*no Function name*" }
 	}
 }

--- a/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Bootstrap.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Bootstrap.Tests.ps1
@@ -6,9 +6,9 @@ BeforeAll {
 
 	$BootstrapFunctionsPath = Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions"
 	. "$BootstrapFunctionsPath\Bootstrap.ps1"
-	# Dot-source the machine-scope gate so PersonalSteps gating resolves even in sessions whose
-	# imported Bootstrap module predates the Test-MachineTypeScope export.
-	. "$BootstrapFunctionsPath\Test-MachineTypeScope.ps1"
+	# Dot-source the personal-steps runner so it exists to Mock even in sessions whose imported
+	# Bootstrap module predates the Invoke-PersonalSteps export.
+	. "$BootstrapFunctionsPath\Invoke-PersonalSteps.ps1"
 }
 
 AfterAll {
@@ -33,7 +33,7 @@ Describe "Bootstrap" {
 		Mock Write-LogSuccess { }
 		Mock Write-LogWarning { }
 		Mock Write-LogError { }
-		Mock Write-LogDebug { }
+		Mock Invoke-PersonalSteps { }
 		Mock Test-AdminPrivileges { }
 		Mock Start-Logging { $global:startTime = Get-Date }
 		Mock Stop-Logging { }
@@ -123,63 +123,11 @@ Describe "Bootstrap" {
 		Should -Invoke Configure-WSLSSH -Times 1 -Exactly
 	}
 
-	It "runs resolvable PersonalSteps and warns on unresolvable ones" {
+	It "runs the fork-defined personal steps via Invoke-PersonalSteps" {
 		$global:MachineType = 'Test'
-		# Rename-Machine is a real exported command that plain Bootstrap (no -WithInitialSetup)
-		# never calls, so it doubles as a clean probe that PersonalSteps invoked it exactly once.
-		$global:Configuration.BootstrapConfig = @{ PersonalSteps = @('Rename-Machine', 'Install-MissingPersonalTool') }
 
 		Bootstrap
 
-		Should -Invoke Rename-Machine -Times 1 -Exactly
-		Should -Invoke Write-LogWarning -Times 1 -Exactly -ParameterFilter { $Message -like "*Install-MissingPersonalTool*" }
-	}
-
-	It "treats an empty PersonalSteps list as a no-op" {
-		$global:MachineType = 'Test'
-		$global:Configuration.BootstrapConfig = @{ PersonalSteps = @() }
-
-		Bootstrap
-
-		Should -Invoke Write-LogWarning -Times 0 -ParameterFilter { $Message -like "*Personal step*" }
-	}
-
-	It "runs hashtable PersonalSteps whose Machine scope covers the machine type and skips the rest" {
-		$global:MachineType = 'Test'
-		$global:Configuration.ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test')
-		# Rename-Machine / Start-Win11Debloat are real exported commands that plain Bootstrap
-		# (no -WithInitialSetup) never calls, so they cleanly probe which entries actually ran.
-		$global:Configuration.BootstrapConfig = @{
-			PersonalSteps = @(
-				@{ Function = 'Rename-Machine'; Machine = 'Test' },
-				@{ Function = 'Start-Win11Debloat'; Machine = 'PC/Laptop' }
-			)
-		}
-
-		Bootstrap
-
-		Should -Invoke Rename-Machine -Times 1 -Exactly
-		Should -Invoke Start-Win11Debloat -Times 0
-		Should -Invoke Write-LogWarning -Times 0 -ParameterFilter { $Message -like "*Personal step*" }
-	}
-
-	It "reports invalid machine tokens in a personal step scope and does not run the step" {
-		$global:MachineType = 'Test'
-		$global:Configuration.ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test')
-		$global:Configuration.BootstrapConfig = @{ PersonalSteps = @(@{ Function = 'Rename-Machine'; Machine = 'Tset' }) }
-
-		Bootstrap
-
-		Should -Invoke Rename-Machine -Times 0
-		Should -Invoke Write-LogError -Times 1 -Exactly -ParameterFilter { $Message -like "*Tset*" }
-	}
-
-	It "warns on a personal step entry without a Function name" {
-		$global:MachineType = 'Test'
-		$global:Configuration.BootstrapConfig = @{ PersonalSteps = @(@{ Machine = 'All' }) }
-
-		Bootstrap
-
-		Should -Invoke Write-LogWarning -Times 1 -Exactly -ParameterFilter { $Message -like "*no Function name*" }
+		Should -Invoke Invoke-PersonalSteps -Times 1 -Exactly
 	}
 }

--- a/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Invoke-PersonalSteps.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Invoke-PersonalSteps.Tests.ps1
@@ -1,0 +1,112 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$script:OriginalConfiguration = $global:Configuration
+	$script:OriginalMachineType = $global:MachineType
+
+	$BootstrapFunctionsPath = Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions"
+	. "$BootstrapFunctionsPath\Invoke-PersonalSteps.ps1"
+	# Dot-source the machine-scope gate so gating resolves even in sessions whose imported
+	# Bootstrap module predates the Test-MachineTypeScope export.
+	. "$BootstrapFunctionsPath\Test-MachineTypeScope.ps1"
+}
+
+AfterAll {
+	$global:Configuration = $script:OriginalConfiguration
+	$global:MachineType = $script:OriginalMachineType
+}
+
+Describe "Invoke-PersonalSteps" {
+	BeforeEach {
+		$global:MachineType = 'Test'
+		$global:Configuration = @{ BootstrapConfig = @{ PersonalSteps = @() } }
+
+		Mock Write-Host { }
+		Mock Test-AdminPrivileges { }
+		Mock Write-LogTitle { }
+		Mock Write-LogWarning { }
+		Mock Write-LogError { }
+		Mock Write-LogDebug { }
+		# Rename-Machine / Start-Win11Debloat are real exported commands that nothing in this
+		# test file calls otherwise, so they cleanly probe which entries actually ran.
+		Mock Rename-Machine { }
+		Mock Start-Win11Debloat { }
+	}
+
+	It "verifies administrator privileges before running any step" {
+		Invoke-PersonalSteps
+
+		Should -Invoke Test-AdminPrivileges -Times 1 -Exactly
+	}
+
+	It "runs resolvable string entries and warns on unresolvable ones" {
+		$global:Configuration.BootstrapConfig = @{ PersonalSteps = @('Rename-Machine', 'Install-MissingPersonalTool') }
+
+		Invoke-PersonalSteps
+
+		Should -Invoke Rename-Machine -Times 1 -Exactly
+		Should -Invoke Write-LogWarning -Times 1 -Exactly -ParameterFilter { $Message -like "*Install-MissingPersonalTool*" }
+	}
+
+	It "warns and runs nothing when no personal steps are configured" {
+		Invoke-PersonalSteps
+
+		$global:Configuration = @{ BootstrapConfig = @{ } }
+		Invoke-PersonalSteps
+
+		Should -Invoke Rename-Machine -Times 0
+		Should -Invoke Write-LogWarning -Times 2 -Exactly -ParameterFilter { $Message -like "*No personal steps configured*" }
+		Should -Invoke Write-LogError -Times 0
+	}
+
+	It "warns when no configured step applies to the machine type" {
+		$global:Configuration.ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test')
+		$global:Configuration.BootstrapConfig = @{
+			PersonalSteps = @(
+				@{ Function = 'Rename-Machine'; Machine = 'PC/Laptop' },
+				@{ Function = 'Start-Win11Debloat'; Machine = 'Work' }
+			)
+		}
+
+		Invoke-PersonalSteps
+
+		Should -Invoke Rename-Machine -Times 0
+		Should -Invoke Start-Win11Debloat -Times 0
+		Should -Invoke Write-LogWarning -Times 1 -Exactly -ParameterFilter { $Message -like "*No personal steps configured for this ?Test? machine*" }
+	}
+
+	It "runs hashtable entries whose Machine scope covers the machine type and skips the rest" {
+		$global:Configuration.ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test')
+		$global:Configuration.BootstrapConfig = @{
+			PersonalSteps = @(
+				@{ Function = 'Rename-Machine'; Machine = 'Test' },
+				@{ Function = 'Start-Win11Debloat'; Machine = 'PC/Laptop' }
+			)
+		}
+
+		Invoke-PersonalSteps
+
+		Should -Invoke Rename-Machine -Times 1 -Exactly
+		Should -Invoke Start-Win11Debloat -Times 0
+		Should -Invoke Write-LogWarning -Times 0
+	}
+
+	It "reports invalid machine tokens in an entry scope and does not run the step" {
+		$global:Configuration.ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test')
+		$global:Configuration.BootstrapConfig = @{ PersonalSteps = @(@{ Function = 'Rename-Machine'; Machine = 'Tset' }) }
+
+		Invoke-PersonalSteps
+
+		Should -Invoke Rename-Machine -Times 0
+		Should -Invoke Write-LogError -Times 1 -Exactly -ParameterFilter { $Message -like "*Tset*" }
+		Should -Invoke Write-LogWarning -Times 1 -Exactly -ParameterFilter { $Message -like "*No personal steps configured*" }
+	}
+
+	It "warns on an entry without a Function name" {
+		$global:Configuration.BootstrapConfig = @{ PersonalSteps = @(@{ Machine = 'All' }) }
+
+		Invoke-PersonalSteps
+
+		Should -Invoke Write-LogWarning -Times 1 -Exactly -ParameterFilter { $Message -like "*no Function name*" }
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Test-MachineTypeScope.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Test-MachineTypeScope.Tests.ps1
@@ -1,0 +1,79 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$script:OriginalConfiguration = $global:Configuration
+	$script:OriginalMachineType = $global:MachineType
+
+	$BootstrapFunctionsPath = Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions"
+	. "$BootstrapFunctionsPath\Test-MachineTypeScope.ps1"
+}
+
+AfterAll {
+	$global:Configuration = $script:OriginalConfiguration
+	$global:MachineType = $script:OriginalMachineType
+}
+
+Describe "Test-MachineTypeScope" {
+	BeforeEach {
+		$global:Configuration = @{ ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test') }
+		Mock Write-Host { }
+		Mock Write-LogError { }
+	}
+
+	It "matches every machine type when the scope is All" {
+		Test-MachineTypeScope -Scope 'All' -MachineType 'Work' | Should -BeTrue
+		Should -Invoke Write-LogError -Times 0
+	}
+
+	It "matches when a multi-token scope contains the machine type" {
+		Test-MachineTypeScope -Scope 'PC/Laptop' -MachineType 'Laptop' | Should -BeTrue
+		Should -Invoke Write-LogError -Times 0
+	}
+
+	It "matches case-insensitively for both tokens and the wildcard" {
+		Test-MachineTypeScope -Scope 'laptop' -MachineType 'Laptop' | Should -BeTrue
+		Test-MachineTypeScope -Scope 'all' -MachineType 'Work' | Should -BeTrue
+		Should -Invoke Write-LogError -Times 0
+	}
+
+	It "does not match a valid scope naming other machine types, without reporting errors" {
+		Test-MachineTypeScope -Scope 'PC/Work' -MachineType 'Laptop' | Should -BeFalse
+		Should -Invoke Write-LogError -Times 0
+	}
+
+	It "reports an unknown token and returns false" {
+		Test-MachineTypeScope -Scope 'Labtop' -MachineType 'Laptop' -Context 'WinGetApps.csv [MyApp]' | Should -BeFalse
+		Should -Invoke Write-LogError -Times 1 -Exactly -ParameterFilter { $Message -like '*Labtop*' -and $Message -like '*WinGetApps.csv ?MyApp?*' }
+	}
+
+	It "still matches on the valid tokens while reporting the unknown ones" {
+		Test-MachineTypeScope -Scope 'Labtop/Laptop' -MachineType 'Laptop' | Should -BeTrue
+		Should -Invoke Write-LogError -Times 1 -Exactly -ParameterFilter { $Message -like '*Labtop*' }
+	}
+
+	It "reports a blank scope and never matches it" {
+		Test-MachineTypeScope -Scope '' -MachineType 'Laptop' | Should -BeFalse
+		Test-MachineTypeScope -Scope '  /  ' -MachineType 'Laptop' | Should -BeFalse
+		Should -Invoke Write-LogError -Times 2 -Exactly
+	}
+
+	It "skips token validation when the configuration has no ValidMachineTypes" {
+		$global:Configuration = @{ }
+
+		Test-MachineTypeScope -Scope 'PC' -MachineType 'PC' | Should -BeTrue
+		Test-MachineTypeScope -Scope 'Labtop' -MachineType 'Laptop' | Should -BeFalse
+		Should -Invoke Write-LogError -Times 0
+	}
+
+	It "defaults the machine type to the global machine type" {
+		$global:MachineType = 'Work'
+
+		Test-MachineTypeScope -Scope 'Work' | Should -BeTrue
+		Test-MachineTypeScope -Scope 'PC' | Should -BeFalse
+	}
+
+	It "matches only All when the machine type is empty" {
+		Test-MachineTypeScope -Scope 'All' -MachineType '' | Should -BeTrue
+		Test-MachineTypeScope -Scope 'PC' -MachineType '' | Should -BeFalse
+	}
+}

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -620,10 +620,14 @@ Settings used during the Bootstrap process.
   (`"All"` / `"Private"` / `"Work"` / `"None"`; `Default` covers unlisted types; absent → `"All"`).
 - `WSLSetup` - Whether Bootstrap provisions WSL, per machine type (`$true`/`$false`; `Default`
   covers unlisted types; absent → `$true`). The shipped `Test` profile skips WSL.
-- `PersonalSteps` - Fork-defined optional bootstrap steps (function names) run right after
-  `Upgrade-All`. The base ships an empty list, so a vanilla bootstrap runs none; a fork lists
-  its personal tools in `Configuration.local.psd1`. Steps that do not resolve are skipped with
-  a warning.
+- `PersonalSteps` - Fork-defined optional bootstrap steps run right after `Upgrade-All`. Each
+  entry is either a function name string (runs on every machine type) or a hashtable
+  `@{ Function = "Install-MyTool"; Machine = "PC/Laptop" }` gated per machine type exactly like
+  the app CSVs' `Machine` column (`All` covers every machine; tokens are validated via
+  `Test-MachineTypeScope`, so unknown machine types are reported instead of silently never
+  matching). The base ships an empty list, so a vanilla bootstrap runs none; a fork lists its
+  personal tools in `Configuration.local.psd1`. Steps that do not resolve are skipped with a
+  warning.
 - `ExternalScripts` / `LocalScripts` - URLs and vendored script paths used by optional steps
   (Microsoft Activation Scripts, Win11Debloat).
 - `PromptForActivation` / `PromptForDebloat` - Whether the optional first-run steps prompt.

--- a/docs/docs_overview.md
+++ b/docs/docs_overview.md
@@ -65,7 +65,7 @@ The authoritative, always-current function reference is the set of per-module pa
 | Config Section                                     | Used By                                            |
 | -------------------------------------------------- | -------------------------------------------------- |
 | `GitConfig` (WingetPackageId, UserName, UserEmail) | `Install-Git`                                      |
-| `HostnameToMachineType`, `ValidMachineTypes`       | `DetermineMachineType`                             |
+| `HostnameToMachineType`, `ValidMachineTypes`       | `DetermineMachineType`, `Test-MachineTypeScope`    |
 | `BasePaths`, `PathTemplates`                       | `Expand-ConfigPaths`, all path-dependent functions |
 | `SymbolicLinks`                                    | `SymbolicLinkMaker`                                |
 | `RepositoryGroups`                                 | `Update-Repositories`, `Initialize-Repository`     |

--- a/docs/modules/application.md
+++ b/docs/modules/application.md
@@ -30,7 +30,7 @@ Get-VSCodeWorkspaceNames
 
 ## [Install-ChocolateyApps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Install-ChocolateyApps.ps1)
 
-- **Description:** Installs Chocolatey-managed apps from the WinuX CSV, filtered by machine type. Reads the app list from `ChocolateyApps.csv`, installs entries matching the current machine type (plus any "All" entries), and skips the rest. Requires administrator privileges and is called automatically by Bootstrap.
+- **Description:** Installs Chocolatey-managed apps from the WinuX CSV, filtered by machine type. Reads the app list from `ChocolateyApps.csv`, installs entries matching the current machine type (plus any "All" entries), and skips the rest. `Machine`-column tokens are validated via `Test-MachineTypeScope` - unknown machine types are reported and never match. Requires administrator privileges and is called automatically by Bootstrap.
 - **Usage:** `Install-ChocolateyApps`
 
 Reads the app list from the CSV at `BootstrapConfig.DataFiles.ChocolateyApps` in `Configuration.psd1`. Each row specifies an app ID and the machine types it applies to ("All", "PC", "Laptop", etc.), and may also carry optional `Version`, `Params`, and `Force` columns that are passed through to `choco install`. Apps for the current machine type and All-type apps are installed; others are skipped. Administrator privileges are verified up front via `Test-AdminPrivileges`.
@@ -123,7 +123,7 @@ Install-PowerShellModules
 
 ## [Install-ScoopApps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Install-ScoopApps.ps1)
 
-- **Description:** Installs Scoop-managed apps from the WinuX CSV, filtered by the current machine type. Apps matching the current machine type (or marked `All`) are installed; others are skipped. Requires administrator privileges and is called automatically by Bootstrap.
+- **Description:** Installs Scoop-managed apps from the WinuX CSV, filtered by the current machine type. Apps matching the current machine type (or marked `All`) are installed; others are skipped. `Machine`-column tokens are validated via `Test-MachineTypeScope` - unknown machine types are reported and never match. Requires administrator privileges and is called automatically by Bootstrap.
 - **Usage:** `Install-ScoopApps`
 
 Reads the app list from the CSV at `BootstrapConfig.DataFiles.ScoopApps` in `Configuration.psd1`. Each row specifies an app name, optional bucket, version, global flag, and the machine types it applies to. The function determines the current machine type, queries `scoop export` for already-installed apps, and for each applicable row either installs the app, updates it (when already installed and not version-pinned), or skips it (when already installed with a pinned version).
@@ -147,7 +147,7 @@ Install-ScoopPackageManager
 
 ## [Install-WingetApps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Install-WingetApps.ps1)
 
-- **Description:** Installs WinGet-managed apps from the WinuX CSV, filtered by machine type. Reads the app list from `BootstrapConfig.DataFiles.WinGetApps` in `Configuration.psd1`; apps matching the current machine type (or marked `All`) are installed, others are skipped. Requires administrator privileges and is called automatically by Bootstrap.
+- **Description:** Installs WinGet-managed apps from the WinuX CSV, filtered by machine type. Reads the app list from `BootstrapConfig.DataFiles.WinGetApps` in `Configuration.psd1`; apps matching the current machine type (or marked `All`) are installed, others are skipped. `Machine`-column tokens are validated via `Test-MachineTypeScope` - unknown machine types are reported and never match. Requires administrator privileges and is called automatically by Bootstrap.
 - **Usage:** `Install-WingetApps`
 
 Each CSV row specifies an app ID, version, installation scope (`d` default / `m` machine / `u` user), interactive flag, source (`w` winget / `s` msstore), and the machine types it applies to. The machine type is resolved at runtime and rows whose `Machine` column does not include the current type or `All` are skipped. For apps pinned at `Latest`, an existing WinGet pin is removed first so the latest version can install cleanly.

--- a/docs/modules/bootstrap.md
+++ b/docs/modules/bootstrap.md
@@ -184,6 +184,18 @@ Invoked automatically by Bootstrap as the first of the package-manager setup ste
 Install-WinGetPackageManager
 ```
 
+## [Invoke-PersonalSteps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Bootstrap/Functions/Invoke-PersonalSteps.ps1)
+
+- **Description:** Runs the fork-defined personal install steps from `BootstrapConfig.PersonalSteps`. Each entry is either a plain function name (runs on every machine type) or `@{ Function = "Name"; Machine = "PC/Laptop" }` gated per machine type exactly like the app CSVs' `Machine` column, with scope tokens validated via `Test-MachineTypeScope`. Entries without a `Function` name and entries that do not resolve to an exported command are skipped with a warning; out-of-scope entries are skipped silently. When nothing applies - the list is empty (the base config ships it empty) or every entry is gated to other machine types - it reports so with a warning naming the current machine type. Requires administrator privileges (asserted up front via `Test-AdminPrivileges`, so a non-elevated run fails fast instead of mid-step). Called automatically by `Bootstrap` right after `Upgrade-All`.
+- **Usage:** `Invoke-PersonalSteps`
+
+```powershell
+# Run every configured personal step applicable to the current machine type
+Invoke-PersonalSteps
+```
+
+**See also:** [Test-MachineTypeScope](#test-machinetypescope)
+
 ## [Load-PathConfiguration](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Bootstrap/Functions/Load-PathConfiguration.ps1)
 
 - **Description:** Loads `Configuration.psd1`, detects the machine type, expands path placeholders, and registers the custom Modules directory for autoload. Called automatically by the PowerShell profile on every shell start and by Bootstrap during provisioning; not intended for direct invocation in normal use.
@@ -241,7 +253,7 @@ Merge-Hashtable -Target $config -Overrides $overrides
 
 ## [Test-MachineTypeScope](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Bootstrap/Functions/Test-MachineTypeScope.ps1)
 
-- **Description:** Tests whether a machine-scope string (`All`, `PC`, `PC/Laptop`, ...) applies to a machine type, validating every token against `ValidMachineTypes` plus the `All` wildcard. Unknown tokens - e.g. a `Labtop` typo - are reported via `Write-LogError` together with the valid values and contribute nothing to the match, so a misspelled scope can never silently install or skip anything. Matching is case-insensitive. The single gate behind the app CSVs' `Machine` column (`Install-WingetApps`, `Install-ScoopApps`, `Install-ChocolateyApps`) and `BootstrapConfig.PersonalSteps` entries.
+- **Description:** Tests whether a machine-scope string (`All`, `PC`, `PC/Laptop`, ...) applies to a machine type, validating every token against `ValidMachineTypes` plus the `All` wildcard. Unknown tokens - e.g. a `Labtop` typo - are reported via `Write-LogError` together with the valid values and contribute nothing to the match, so a misspelled scope can never silently install or skip anything. Matching is case-insensitive. The single gate behind the app CSVs' `Machine` column (`Install-WingetApps`, `Install-ScoopApps`, `Install-ChocolateyApps`) and `BootstrapConfig.PersonalSteps` entries (via `Invoke-PersonalSteps`).
 - **Parameters:** -Scope, -MachineType, -Context
 - **Usage:** `Test-MachineTypeScope -Scope "PC/Laptop" -MachineType "Laptop"`
 

--- a/docs/modules/bootstrap.md
+++ b/docs/modules/bootstrap.md
@@ -19,7 +19,7 @@ Execution sequence:
 5. Nerd Font, PowerShell modules, special folder redirections
 6. WSL configuration
 7. WinGet, Scoop, and Chocolatey - install package managers then apps from CSVs
-8. Upgrade all packages, fork-defined personal steps (BootstrapConfig.PersonalSteps), .NET EF CLI
+8. Upgrade all packages, fork-defined personal steps (BootstrapConfig.PersonalSteps, each entry optionally machine-gated like the app CSVs' `Machine` column), .NET EF CLI
 9. Environment variables, Conda environments, NuGet config, taskbar pins
 10. WSL environment initialization, symbolic links, WSL SSH setup
 11. Lock taskbar layout, restart Explorer, restart machine
@@ -238,6 +238,28 @@ Merge-Hashtable -Target $config -Overrides $overrides
 ```
 
 **See also:** [Expand-ConfigPaths](#expand-configpaths)
+
+## [Test-MachineTypeScope](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Bootstrap/Functions/Test-MachineTypeScope.ps1)
+
+- **Description:** Tests whether a machine-scope string (`All`, `PC`, `PC/Laptop`, ...) applies to a machine type, validating every token against `ValidMachineTypes` plus the `All` wildcard. Unknown tokens - e.g. a `Labtop` typo - are reported via `Write-LogError` together with the valid values and contribute nothing to the match, so a misspelled scope can never silently install or skip anything. Matching is case-insensitive. The single gate behind the app CSVs' `Machine` column (`Install-WingetApps`, `Install-ScoopApps`, `Install-ChocolateyApps`) and `BootstrapConfig.PersonalSteps` entries.
+- **Parameters:** -Scope, -MachineType, -Context
+- **Usage:** `Test-MachineTypeScope -Scope "PC/Laptop" -MachineType "Laptop"`
+
+| Parameter      | Description                                                                                                     |
+| -------------- | --------------------------------------------------------------------------------------------------------------- |
+| `-Scope`       | Machine-scope string: machine types separated by `/`, or `All`. A blank scope is reported and never matches.    |
+| `-MachineType` | Machine type to test the scope against. Defaults to `$global:MachineType`; when empty, only `All` scopes match. |
+| `-Context`     | Optional data-source label (e.g. `WinGetApps.csv [Git.Git]`) included in error messages for instant diagnosis.  |
+
+```powershell
+# True - the scope covers Laptop
+Test-MachineTypeScope -Scope "PC/Laptop" -MachineType "Laptop"
+
+# False, and reports the unknown token [Labtop] with the list of valid values
+Test-MachineTypeScope -Scope "Labtop" -MachineType "Laptop" -Context "WinGetApps.csv [MyApp]"
+```
+
+**See also:** [DetermineMachineType](#determinemachinetype)
 
 ## Two-Stage Architecture
 

--- a/docs/modules/helper.md
+++ b/docs/modules/helper.md
@@ -1041,7 +1041,7 @@ Show-FunctionDetails -FunctionName "Open-Browser" -FunctionInfo $info
 - **Parameters:** -CheckOnly
 - **Usage:** `Test-AdminPrivileges`, `if (Test-AdminPrivileges -CheckOnly) { ... }`
 
-When invoked without `-CheckOnly` and the session is not elevated, it captures the current directory and the calling command from the PowerShell call stack, then offers (via `Resolve-Selection`) to relaunch in an Administrator shell that re-runs the original command in place. It throws a `PipelineStoppedException` to halt the non-elevated pipeline. Use `-CheckOnly` as a lightweight, non-interactive guard that returns `$true`/`$false` without prompting or elevating.
+When invoked without `-CheckOnly` and the session is not elevated, it captures the current directory and the originally typed command - the outermost call-stack frame, falling back to the immediate caller when the host records no line (inner frames would replay engine source lines like `& $stepName` that do not exist in a fresh shell) - then offers (via `Resolve-Selection`) to relaunch in an Administrator shell that re-runs the original command in place. It throws a `PipelineStoppedException` to halt the non-elevated pipeline. Use `-CheckOnly` as a lightweight, non-interactive guard that returns `$true`/`$false` without prompting or elevating.
 
 | Parameter    | Description                                                                                              |
 | ------------ | -------------------------------------------------------------------------------------------------------- |

--- a/docs/reference/software-list.md
+++ b/docs/reference/software-list.md
@@ -16,6 +16,8 @@ page documents the shipped template.
 - **Scope**: `d` (default), `m` (machine-wide), `u` (user). **Source**: `w` (winget), `s` (msstore).
 - **Machine** is matched against the machine types you define in `Configuration.psd1` - only
   `All` is special, and `/` combines several types (`PC/Laptop`). The base config ships only `Test`.
+  Tokens are validated against `ValidMachineTypes` via `Test-MachineTypeScope` - unknown machine
+  types are reported via `Write-LogError` and never match.
 - All three package managers are installed by Bootstrap even when their CSV is empty - add rows
   and re-run to install more.
 


### PR DESCRIPTION
## Description

Gates `BootstrapConfig.PersonalSteps` per machine type the same way the app CSVs already are, and introduces **`Test-MachineTypeScope`** (Bootstrap module) as the single gate behind every machine-scoped data source - the `Machine` column of the WinGet/Scoop/Chocolatey CSVs and the PersonalSteps entries.

### Why

Two gaps:

1. PersonalSteps ran unconditionally on every machine type, unlike every other machine-scoped surface (the app CSVs).
2. No layer validated machine-scope tokens. A typo like `Labtop` (or a machine type that was renamed in `ValidMachineTypes` but not in the data) silently never matched, so the app or step was quietly skipped with no signal anywhere.

**How it works.**

- `Test-MachineTypeScope -Scope "PC/Laptop" -MachineType "Laptop"` splits the scope on `/`, matches case-insensitively, and returns whether the scope names `All` or the given machine type.
- Every token is validated against `ValidMachineTypes` plus the `All` wildcard. Unknown tokens are reported via `Write-LogError` together with the data-source context (e.g. `WinGetApps.csv [MyApp]`) and the list of valid values, and contribute nothing to the match - a misspelled scope can never silently install or skip anything. Blank scopes are reported the same way and never match.
- A `PersonalSteps` entry is now either a plain function name (runs on every machine type, exactly as before) or `@{ Function = "Install-MyTool"; Machine = "PC/Laptop" }` - mirroring the CSVs' `Machine` column.
- PersonalSteps execution lives in its own exported function, **`Invoke-PersonalSteps`** (Bootstrap module) - `Bootstrap` just calls it, keeping the orchestrator thin per the no-inline-logic convention. It asserts admin up front via `Test-AdminPrivileges` (personal steps install software), so a non-elevated standalone run fails fast instead of mid-step.
- Fixes a latent `Test-AdminPrivileges` bug its elevate-and-rerun path had at call depth >= 2: it replayed the immediate caller's source line (e.g. `& $stepName`), which does not exist in the fresh elevated shell and died with "The expression after '&' ... was not valid". It now replays the outermost call-stack frame that recorded a line - the command the user actually typed - with behavior at depth 1 (all existing callers) unchanged.
- `Install-WingetApps`, `Install-ScoopApps`, and `Install-ChocolateyApps` drop their triplicated inline machine filter for the shared helper, so the CSVs gain the same token validation.
- Backward compatible: string PersonalSteps entries and all existing CSV rows behave exactly as before, and configurations without `ValidMachineTypes` (synthetic test configs) skip token validation and keep pure matching behavior.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [ ] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

## Quality bar

- [x] The change is **minimal and focused** (one logical change; the helper replaces three duplicated inline filters, no duplication).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` - the gating reads `ValidMachineTypes` and `BootstrapConfig.PersonalSteps`; no new config keys, and the base still ships `PersonalSteps = @()`.

## Tests

```powershell
Run-Tests -TestName "Test-MachineTypeScope"
Run-Tests -TestName "Invoke-PersonalSteps"
Run-Tests -TestName "Bootstrap"
Run-Tests -TestName "Install-"
Run-Tests
```

- `Test-MachineTypeScope` (new, 10 cases: wildcard, multi-token, case-insensitivity, unknown-token reporting, mixed valid/invalid, blank scope, no-ValidMachineTypes fallback, machine-type defaulting)
- `Invoke-PersonalSteps` (new, 7 cases: admin asserted up front, string entries + unresolvable warning, empty/absent list warns, nothing-applies-to-this-machine-type warns naming the machine, hashtable gating in/out, invalid token reported and step not run, entry without Function warned)
- `Bootstrap` (delegation case: personal steps run via `Invoke-PersonalSteps`)
- App installers (new unknown-token case in `Install-WingetApps`)
- Full suite: **All tests pass**

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/` (added `Bootstrap/Test-MachineTypeScope.Tests.ps1` and `Bootstrap/Invoke-PersonalSteps.Tests.ps1`; extended `Bootstrap.Tests.ps1` and `Application/Install-WingetApps.Tests.ps1`).
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text.
- [ ] N/A - no testable behavior changed (docs/chore only).

## Documentation & manifests

- [x] I updated `docs/modules/bootstrap.md` (new `Test-MachineTypeScope` and `Invoke-PersonalSteps` entries, Bootstrap step 8), `docs/modules/application.md` (all three installer entries), `docs/modules/helper.md` (`Test-AdminPrivileges` rerun capture), plus `docs/configuration/configuration-reference.md` (`PersonalSteps`) and `docs/reference/software-list.md` (`Machine` column validation).
- [x] I updated the module `.psd1` `FunctionsToExport` (`Bootstrap.psd1`).
- [x] I updated `docs/docs_overview.md` (`ValidMachineTypes` consumer row); no page added/removed, so `_sidebar.md` is unchanged.
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds.
- [ ] N/A - no exported function changed.

## Tested on

- Windows version: Windows 11 (26200)
- PowerShell version: 7.6.3
- Machine type(s): Work via a private fork 

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] This PR contains no secrets or personal data (tokens, real paths/hostnames/emails).

## Additional notes / screenshots

- Pre-flight: every `Machine` token in the shipped CSVs already validates, so the new enforcement introduces zero errors on existing installs.
- The `Test-AdminPrivileges` rerun-capture fix has no automated test: the non-elevated branch is interactive (prompts via `Resolve-Selection`, spawns an elevated shell) and cannot run under an elevated test session. It was verified by simulation - the verbatim capture algorithm run against the failing depth-3 call topology (typed command -> `& $stepName` -> step -> admin check) captures the typed command where the old code captured `& $stepName`, and is byte-for-byte identical to the old behavior at depth 1 (all existing callers). The existing `-CheckOnly` test still covers the non-interactive path.
