### PR TITLE
Add Start-Application -RequireMainWindow and fix Open-WhatsApp falsely reporting WhatsApp as already running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.11] - 2026-07-24
+
+### Added
+
+- `Start-Application -RequireMainWindow` (Application module): scopes the "already running" check to processes that own a visible main window, for apps that keep a windowless helper alive under their own process name. Sibling to `-ProcessPathFilter`, which solves the same class of false positive for apps that share a process name with something else.
+
+### Fixed
+
+- `Open-WhatsApp` (Application module) no longer reports "WhatsApp is already running!" and opens nothing when no WhatsApp window exists. When a notification arrives while WhatsApp is closed, Windows COM-activates a background push notification host (`WhatsApp.Root.exe -RegisterForBGTaskServer /nowindow /pushnotification -Embedding`) that owns no window but runs under the same `WhatsApp.Root` process name as the UI, so the process-name check matched it. That made the failure intermittent (it depended on whether Windows had activated the host) and unfixable via `Kill-All`, which only clears the host until the next notification. `Open-WhatsApp` now passes `-RequireMainWindow`.
+
 ## [0.1.10] - 2026-07-24
 
 ### Added
@@ -190,7 +200,8 @@ The first public release of WinuX.
 - Governance and licensing: MIT license, contributor guide, code of conduct, security policy, and third-party notices.
 - CI: the full Pester suite on every pull request, and a release workflow that builds `WinuX.exe` from every version tag and attaches it - with a SHA-256 checksum - to the GitHub release.
 
-[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.10...HEAD
+[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.11...HEAD
+[0.1.11]: https://github.com/IvanPavlak/WinuX/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/IvanPavlak/WinuX/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/IvanPavlak/WinuX/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/IvanPavlak/WinuX/compare/v0.1.7...v0.1.8

--- a/Windows/PowerShell/Modules/Application/Functions/Open-WhatsApp.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Open-WhatsApp.ps1
@@ -5,7 +5,13 @@ function Open-WhatsApp {
 
 	.DESCRIPTION
 		Starts WhatsApp by activating its UWP package via its AppUserModelID using Start-Application.
-		Does nothing if WhatsApp is already running.
+		Does nothing if a WhatsApp window is already open.
+
+		The "already running" check requires a visible main window (-RequireMainWindow). Windows
+		COM-activates "WhatsApp.Root.exe -RegisterForBGTaskServer /nowindow /pushnotification" as a
+		push notification host that lingers with no UI, and it runs under the same "WhatsApp.Root"
+		process name the UI does, so a plain process-name check reports "already running" while
+		nothing is on screen.
 
 	.EXAMPLE
 		Open-WhatsApp
@@ -15,5 +21,6 @@ function Open-WhatsApp {
 		-AppName "WhatsApp" `
 		-ProcessName "WhatsApp.Root" `
 		-StartMethod AppxPackage `
-		-PackageName "WhatsApp"
+		-PackageName "WhatsApp" `
+		-RequireMainWindow
 }

--- a/Windows/PowerShell/Modules/Application/Functions/Start-Application.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Start-Application.ps1
@@ -47,6 +47,14 @@ function Start-Application {
         count as running. Useful when several apps share a process name (e.g. Claude Desktop and
         the Claude Code CLI both run as "claude"), so launching one is not blocked by the other.
 
+    .PARAMETER RequireMainWindow
+        Only counts a process as "already running" when it owns a visible main window. Some apps
+        keep a windowless helper alive under the same process name, so the plain name check reports
+        "already running" while nothing is on screen. WhatsApp is the reference case: Windows
+        COM-activates "WhatsApp.Root.exe -RegisterForBGTaskServer /nowindow /pushnotification" as a
+        push notification host, and that host reuses the very same process name (and later the very
+        same process) as the UI.
+
     .PARAMETER SkipPathValidation
         Skips the executable path existence check (DirectPath method).
 
@@ -65,8 +73,9 @@ function Start-Application {
         # Starts VirtualBox (non-blocking by default)
 
     .EXAMPLE
-        Start-Application -AppName "WhatsApp" -ProcessName "WhatsApp.Root" -StartMethod AppxPackage -PackageName "WhatsApp"
-        # Activates the WhatsApp UWP app via its AppUserModelID (non-blocking by default)
+        Start-Application -AppName "WhatsApp" -ProcessName "WhatsApp.Root" -StartMethod AppxPackage -PackageName "WhatsApp" -RequireMainWindow
+        # Activates the WhatsApp UWP app via its AppUserModelID (non-blocking by default), ignoring
+        # the windowless push notification host that runs under the same process name
 
     .EXAMPLE
         Start-Application -AppName "Docker" -ProcessName "Docker Desktop" -StartMethod DirectPath -ExecutablePath $dockerExe -Sync
@@ -106,6 +115,9 @@ function Start-Application {
 		[string]$ProcessPathFilter,
 
 		[Parameter()]
+		[switch]$RequireMainWindow,
+
+		[Parameter()]
 		[switch]$SkipPathValidation,
 
 		[Parameter()]
@@ -126,6 +138,15 @@ function Start-Application {
 		if ($ProcessPathFilter) {
 			$runningProcesses = $runningProcesses | Where-Object {
 				try { $_.Path -like $ProcessPathFilter } catch { $false }
+			}
+		}
+
+		# MainWindowHandle is the first visible, unowned top-level window of the process, so a
+		# windowless background host resolves to zero while the same process reports a real handle
+		# once its UI is up. GetProcessesByName hands back fresh objects, so this is never stale.
+		if ($RequireMainWindow) {
+			$runningProcesses = $runningProcesses | Where-Object {
+				try { $_.MainWindowHandle -ne [IntPtr]::Zero } catch { $false }
 			}
 		}
 

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Open-WhatsApp.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Open-WhatsApp.Tests.ps1
@@ -20,4 +20,12 @@ Describe "Open-WhatsApp" {
 			$PackageName -eq 'WhatsApp'
 		}
 	}
+
+	It "requires a visible main window so the windowless push notification host is ignored" {
+		Open-WhatsApp
+
+		Should -Invoke Start-Application -Times 1 -Exactly -ParameterFilter {
+			$RequireMainWindow -eq $true
+		}
+	}
 }

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Start-Application.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Start-Application.Tests.ps1
@@ -86,6 +86,45 @@ Describe "Start-Application" {
 
 			Should -Invoke Start-Process -Times 0
 		}
+
+		It "Should ignore a running windowless process when RequireMainWindow is set" {
+			Mock Start-Process { }
+
+			# Background hosts (WhatsApp's push notification host is the reference case) run under
+			# a normal process name but own no visible window, so they must not block a launch.
+			$windowless = Get-Process | Group-Object -Property ProcessName |
+				Where-Object { @($_.Group | Where-Object { $_.MainWindowHandle -ne [IntPtr]::Zero }).Count -eq 0 } |
+				Select-Object -First 1
+
+			if (-not $windowless) {
+				Set-ItResult -Skipped -Because "no windowless process available in this session"
+				return
+			}
+
+			Start-Application -AppName "TestApp" -ProcessName $windowless.Name `
+				-StartMethod DirectPath -ExecutablePath "C:\test.exe" -SkipPathValidation `
+				-RequireMainWindow
+
+			Should -Invoke Start-Process -Times 1
+		}
+
+		It "Should treat a process owning a main window as already running with RequireMainWindow" {
+			Mock Start-Process { }
+
+			$withWindow = Get-Process | Where-Object { $_.MainWindowHandle -ne [IntPtr]::Zero } |
+				Select-Object -First 1
+
+			if (-not $withWindow) {
+				Set-ItResult -Skipped -Because "no window-owning process available in this session"
+				return
+			}
+
+			Start-Application -AppName "TestApp" -ProcessName $withWindow.ProcessName `
+				-StartMethod DirectPath -ExecutablePath "C:\test.exe" -SkipPathValidation `
+				-RequireMainWindow
+
+			Should -Invoke Start-Process -Times 0
+		}
 	}
 
 	Context "ConfigPath Method" {

--- a/docs/modules/application.md
+++ b/docs/modules/application.md
@@ -495,8 +495,10 @@ Open-VSCodeWorkspace Consolidation
 
 ## [Open-WhatsApp](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Open-WhatsApp.ps1)
 
-- **Description:** Opens the WhatsApp Microsoft Store app by activating its UWP package via its AppUserModelID using `Start-Application`. Does nothing if WhatsApp is already running.
+- **Description:** Opens the WhatsApp Microsoft Store app by activating its UWP package via its AppUserModelID using `Start-Application`. Does nothing if a WhatsApp window is already open. The "already running" check requires a visible main window, so the windowless push notification host Windows keeps alive under the same process name does not suppress the launch.
 - **Usage:** `Open-WhatsApp`
+
+When a WhatsApp notification arrives while the app is closed, Windows COM-activates `WhatsApp.Root.exe -RegisterForBGTaskServer /nowindow /pushnotification` as a background push notification host. It owns no visible window but runs under the same `WhatsApp.Root` process name the UI does, so a plain process-name check reports "already running" with nothing on screen - and it survives `Kill-All`, since Windows respawns it on the next notification. `-RequireMainWindow` scopes the check to processes that actually own a visible main window.
 
 ## [Open-WSLTab](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Open-WSLTab.ps1)
 
@@ -506,10 +508,10 @@ Open-VSCodeWorkspace Consolidation
 ## [Start-Application](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Start-Application.ps1)
 
 - **Description:** Common (DRY) helper to start applications with standardized error handling, process checking, and user feedback. Supports four start methods: ConfigPath (resolves `$Configuration.Universal.[ConfigKey]`), AppxPackage (activates UWP/Store apps via their AppUserModelID, resolved from `Get-AppxPackage`), DirectPath (a direct executable path), and Custom (a scriptblock for complex scenarios). Applications are non-blocking by default since `Start-Process` is inherently async; use `-Sync` to wait for the process to exit before continuing.
-- **Parameters:** -AppName, -ProcessName, -StartMethod, -ConfigKey, -PackageName, -ExecutablePath, -Arguments, -NoNewWindow, -SkipProcessCheck, -ProcessPathFilter, -SkipPathValidation, -Sync, -SuppressOutput, -CustomStartLogic
-- **Usage:** `Start-Application -AppName "VirtualBox" -ProcessName "VirtualBox" -StartMethod ConfigPath -ConfigKey "VirtualBoxExe" -NoNewWindow`, `Start-Application -AppName "WhatsApp" -ProcessName "WhatsApp.Root" -StartMethod AppxPackage -PackageName "WhatsApp"`, `Start-Application -AppName "Docker" -ProcessName "Docker Desktop" -StartMethod DirectPath -ExecutablePath $dockerExe -Sync`, `Start-Application -AppName "Docker Desktop" -ProcessName "Docker Desktop" -StartMethod ConfigPath -ConfigKey "DockerExe" -Arguments "--minimized" -SuppressOutput`
+- **Parameters:** -AppName, -ProcessName, -StartMethod, -ConfigKey, -PackageName, -ExecutablePath, -Arguments, -NoNewWindow, -SkipProcessCheck, -ProcessPathFilter, -RequireMainWindow, -SkipPathValidation, -Sync, -SuppressOutput, -CustomStartLogic
+- **Usage:** `Start-Application -AppName "VirtualBox" -ProcessName "VirtualBox" -StartMethod ConfigPath -ConfigKey "VirtualBoxExe" -NoNewWindow`, `Start-Application -AppName "WhatsApp" -ProcessName "WhatsApp.Root" -StartMethod AppxPackage -PackageName "WhatsApp" -RequireMainWindow`, `Start-Application -AppName "Docker" -ProcessName "Docker Desktop" -StartMethod DirectPath -ExecutablePath $dockerExe -Sync`, `Start-Application -AppName "Docker Desktop" -ProcessName "Docker Desktop" -StartMethod ConfigPath -ConfigKey "DockerExe" -Arguments "--minimized" -SuppressOutput`
 
-A generic application launcher that consolidates the common patterns of checking whether a process is already running, starting it via one of four methods, and reporting success or failure. Before launching it checks for an existing process (unless `-SkipProcessCheck`) and short-circuits with a notice if the app is already running. When two apps share a process name (e.g. Claude Desktop and the Claude Code CLI both run as `claude`), pass `-ProcessPathFilter` to scope that check to a specific install location so one app is not mistaken for the other. The `ConfigPath` and `DirectPath` methods share consistent handling of `-Arguments`, `-Sync` (maps to `-Wait`), `-NoNewWindow`, and `-SuppressOutput` (redirects stdout/stderr to temp files, silencing console noise from chatty apps such as Electron-based Docker Desktop). The `AppxPackage` method activates the package through the shell and ignores those launch options. It caches the resolved AUMID (`PackageFamilyName!AppId`) per package name for the session - the wildcard `Get-AppxPackage` query plus manifest parse costs 0.5-2 s per launch - and a stale cached AUMID (after a package update) is evicted and the error rethrown.
+A generic application launcher that consolidates the common patterns of checking whether a process is already running, starting it via one of four methods, and reporting success or failure. Before launching it checks for an existing process (unless `-SkipProcessCheck`) and short-circuits with a notice if the app is already running. When two apps share a process name (e.g. Claude Desktop and the Claude Code CLI both run as `claude`), pass `-ProcessPathFilter` to scope that check to a specific install location so one app is not mistaken for the other. When an app keeps a windowless helper alive under its own process name (WhatsApp's push notification host is the reference case), pass `-RequireMainWindow` so only processes owning a visible main window count as running. The `ConfigPath` and `DirectPath` methods share consistent handling of `-Arguments`, `-Sync` (maps to `-Wait`), `-NoNewWindow`, and `-SuppressOutput` (redirects stdout/stderr to temp files, silencing console noise from chatty apps such as Electron-based Docker Desktop). The `AppxPackage` method activates the package through the shell and ignores those launch options. It caches the resolved AUMID (`PackageFamilyName!AppId`) per package name for the session - the wildcard `Get-AppxPackage` query plus manifest parse costs 0.5-2 s per launch - and a stale cached AUMID (after a package update) is evicted and the error rethrown.
 
 | Method        | Description                                                                                                                                        |
 | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -530,6 +532,7 @@ A generic application launcher that consolidates the common patterns of checking
 | `-NoNewWindow`        | Passes `-NoNewWindow` to `Start-Process`.                                                                                                 |
 | `-SkipProcessCheck`   | Skips the "already running" process check.                                                                                                |
 | `-ProcessPathFilter`  | Wildcard pattern scoping the "already running" check to processes launched from a specific location (for apps that share a process name). |
+| `-RequireMainWindow`  | Only counts a process as running when it owns a visible main window (for apps with a windowless background host under the same name).      |
 | `-SkipPathValidation` | Skips the executable path existence check (DirectPath method).                                                                            |
 | `-Sync`               | Waits for the process to exit before returning (uses `-Wait`).                                                                            |
 | `-SuppressOutput`     | Redirects stdout/stderr to temp files, silencing console output from the launched process.                                                |
@@ -562,6 +565,11 @@ Start-Application -AppName "Docker Desktop" -ProcessName "Docker Desktop" `
 Start-Application -AppName "Claude" -ProcessName "claude" `
     -ProcessPathFilter "$env:LOCALAPPDATA\AnthropicClaude\*" `
     -StartMethod DirectPath -ExecutablePath "$env:LOCALAPPDATA\AnthropicClaude\claude.exe"
+
+# Require a visible window so a windowless background host under the same
+# process name (e.g. WhatsApp's push notification host) does not block the launch
+Start-Application -AppName "WhatsApp" -ProcessName "WhatsApp.Root" `
+    -StartMethod AppxPackage -PackageName "WhatsApp" -RequireMainWindow
 ```
 
 ## [Start-FancyZones](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Start-FancyZones.ps1)

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -189,6 +189,26 @@ Test-Path "WinuX\Server\.ssh\config"
 wsl mkdir -p /home/you/.ssh
 ```
 
+## Application Launch Issues
+
+### "WhatsApp is already running!" With No WhatsApp Window
+
+**Problem:** `Open-WhatsApp` (directly, or as a workspace action) reports `WhatsApp is already running!` and opens nothing, even though no WhatsApp window is on screen. It happens intermittently - sometimes the same workspace opens WhatsApp fine.
+
+**Why it happens:** When a WhatsApp notification arrives while the app is closed, Windows COM-activates a background push notification host: `WhatsApp.Root.exe -RegisterForBGTaskServer /nowindow /pushnotification -Embedding`. That host owns no visible window, but it runs under the same `WhatsApp.Root` process name the UI does, so a process-name-only check treats it as a running app. It is intermittent because the host only exists once Windows has activated it, and `Kill-All` only clears it until the next notification.
+
+**Solution:** This is handled - `Open-WhatsApp` passes `-RequireMainWindow` to `Start-Application`, so only a process owning a visible main window counts as running. To inspect the state yourself:
+
+```powershell
+# A background-only host shows MainWindowHandle 0; a real UI shows a non-zero handle
+Get-Process WhatsApp.Root | Select-Object Id, MainWindowHandle, MainWindowTitle
+
+# Confirm it is the push notification host
+Get-CimInstance Win32_Process -Filter "Name = 'WhatsApp.Root.exe'" | Select-Object CommandLine
+```
+
+The same `-RequireMainWindow` switch applies to any app that keeps a windowless helper alive under its own process name.
+
 ## Window Layout Issues
 
 ### Windows Not Positioning


### PR DESCRIPTION
# Description

`Open-WhatsApp` intermittently reported `WhatsApp is already running!` and opened nothing, with no WhatsApp window anywhere on screen - including as a workspace action, where it silently dropped WhatsApp from the layout.

## **Root cause** 

When a WhatsApp notification arrives while the app is closed, Windows COM-activates a background push notification host:

`WhatsApp.Root.exe -RegisterForBGTaskServer /nowindow /pushnotification -Embedding` (parent: `svchost.exe`)

That host owns no visible window - captured live, it had `MainWindowHandle = 0` and only two invisible helper windows (`.NET-BroadcastEventWindow`, `Default IME`) - but it runs under the same `WhatsApp.Root` process name as the UI. `Start-Application`'s check is `GetProcessesByName(...).Count -gt 0`, so the host matched and the launch short-circuited.

Two properties made it hard to pin down:

- **Intermittent** 
  - The host only exists once Windows has activated it, so whether a workspace open hits it is luck of the draw.
- **Not fixable by `Kill-All`**
  -  `WhatsApp.Root` is in `TerminateProcessNames`, but Windows respawns the host on the next notification.

Neither existing escape hatch fits: `-ProcessPathFilter` cannot help (both the host and the UI run from the same `WindowsApps` package path), and the command line cannot discriminate either - the shell reuses the *same* background process for the UI, so `/nowindow /pushnotification` stays on the command line even with the window up (verified: PID 18844 went from `MainWindowHandle 0` to `133420` without a new process). The presence of a visible top-level window is the only reliable signal.

## **Fix**

- `Start-Application -RequireMainWindow` (new switch) narrows the "already running" check to processes that own a visible main window. `Process.MainWindowHandle` is the first *visible*, unowned top-level window, so it is zero for a windowless background host and non-zero once the UI is up; minimized windows keep `WS_VISIBLE`, so a minimized app still counts as running. `GetProcessesByName` returns fresh objects, so the handle is never stale.
- `Open-WhatsApp` passes `-RequireMainWindow`.

It is a deliberate sibling to `-ProcessPathFilter`: same class of false positive (process name is too coarse), different discriminator (window ownership rather than install location). Opt-in, so no other caller changes behavior.

## **Verification** 

Reproduced the real bug state live (the background host above), confirmed the old predicate says "already running" on it and the new one does not. End-to-end round trip of the real function: with WhatsApp closed it opened a window; called again with the window up it correctly short-circuited with no second process - so the genuine already-open path does not regress.

## **Caveat** 

The background host cannot be triggered on demand (it needs an inbound notification), so the live round trip covered closed -> launch and open -> skip. The background-host -> launch case rests on the captured bug state plus a unit test that drives the real code path against a genuinely windowless process.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [ ] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

## Quality bar

- [x] The change is **minimal and focused** (one switch on the existing shared launcher; no new function, no duplicated logic).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` using placeholder paths. <!-- N/A: no new configuration settings -->

## Tests

```powershell
Run-Tests -TestName "Start-Application"
Run-Tests -TestName "Open-WhatsApp"
```

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/` (3 new).
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text (windowless process is ignored and the launch proceeds; a window-owning process still short-circuits; `Open-WhatsApp` passes the switch). The two `Start-Application` tests pick their target process from live session state and `Set-ItResult -Skipped` when the environment offers no such process, matching the existing window-dependent tests in the Helper suite.
- [ ] N/A - no testable behavior changed (docs/chore only).

## Documentation & manifests

- [x] I updated `docs/modules/application.md` (`Open-WhatsApp` and `Start-Application` entries: description, parameter list, prose, parameter table, example) plus a new "Application Launch Issues" section in `docs/reference/troubleshooting.md`.
- [x] I updated the module `.psd1` `FunctionsToExport`. <!-- N/A: no function added, renamed, or removed; Test-ManifestCompleteness passes (all 11 manifests) -->
- [x] `docs/docs_overview.md` / `docs/_sidebar.md`. <!-- N/A: no page added or removed; the troubleshooting change is a new section on an existing page -->
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds.
- [ ] N/A - no exported function changed.

## Tested on

- Windows version: Windows 11 Pro (build 26200)
- PowerShell version: 7.6.3
- Machine type(s): PC from a private fork

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the Code of Conduct.
- [x] This PR contains no secrets or personal data (verified: no tokens, real paths, hostnames, or emails in the diff).