### PR TITLE
Fix Reset-Windows centering windows on the monitor they drifted to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.13] - 2026-07-25
+
+### Added
+
+- `Resolve-TargetMonitor` (Window module): shared resolver that turns a monitor specifier into a monitor object. Accepts a 1-based index following `Get-MonitorInfo` order, a standardized label from `Get-MonitorSpecs` (`Primary`, `Secondary`, `Monitor3`, ...), or an exact device name. Extracted from `Move-Windows` so it and `Center-Windows` resolve `-Monitor` through one set of rules. It writes no console output, returning the resolved monitor alongside a ready-to-log `ErrorMessage` so each caller keeps its own logging and control flow; an empty specifier resolves to "no targeting requested" rather than an error.
+- `Center-Windows -Monitor` (Window module): centers every matched window on one explicit monitor instead of deriving a monitor per window from its current position. `-OnPrimary` remains the shorthand for the primary monitor; the two are mutually exclusive parameter sets.
+
+### Fixed
+
+- `Reset-Windows` (Window module) no longer leaves a subset of windows centered on the wrong monitor. Collapsing the virtual desktops makes Windows migrate windows off the removed desktops, and FancyZones reacts to those arrivals by restoring each window to its remembered zone from `app-zone-history.json` - which records a monitor. `Center-Windows` then ran last and re-derived each window's monitor from its CURRENT position, so it centered the strays where they had drifted to, cementing the placement. Verified with an A/B on the same 35 windows: the move pass alone misplaced 0, and prefixing it with `Remove-VirtualDesktops` misplaced 8. `Reset-Windows` now passes its configured monitor through to `Center-Windows`, so the last pass re-asserts the intended target and the reset self-corrects regardless of what moved a window mid-run. Monitor identity is unreliable to begin with when two displays are the same model: identical panels can report the same EDID code and serial number, which is why `applied-layouts.json` accumulates several device identities for one physical monitor (`Get-DuplicateMonitorEdid` already detects the EDID collision for `Apply-FancyZones`, but the zone history has no such guard).
+- `Move-Windows -Monitor` (Window module) now preserves each window's relative placement instead of slamming every window into a corner of the destination work area. The clamp read `[math]::Max(0, [math]::Min(1, $relativeX))`, and because the literals were integers PowerShell bound the `(int, int)` overloads and rounded the relative fraction to 0 or 1. Every coordinate the pass produced was therefore `0` or the work-area maximum, on every window, which the "preserve relative placement" logic was written specifically to avoid. The clamp now uses double literals.
+- `Move-Windows` (Window module) verifies each monitor placement with `Wait-WindowRect` and re-applies it once when the window did not hold its position. `SetWindowPos` reports success for the CALL, so a window moved straight back by another window manager was still counted as repositioned.
+- `Move-Windows` and `Reset-Windows` (Window module) no longer hide failures in normal mode. `Move-Windows` reported only moved / already-there / monitor-moved counts outside `Set-LogLevel Verbose`, so windows that failed to move or would not stay on the target monitor were silently dropped from the summary and a partial pass looked identical to a complete one; both are now reported with the affected windows listed. `Reset-Windows` also ignored `Remove-VirtualDesktops`' return value, so a failed desktop collapse - which changes how much work the move pass has to do - passed unnoticed; it now warns and continues.
+
 ## [0.1.12] - 2026-07-25
 
 ### Added
@@ -210,7 +224,8 @@ The first public release of WinuX.
 - Governance and licensing: MIT license, contributor guide, code of conduct, security policy, and third-party notices.
 - CI: the full Pester suite on every pull request, and a release workflow that builds `WinuX.exe` from every version tag and attaches it - with a SHA-256 checksum - to the GitHub release.
 
-[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.12...HEAD
+[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.13...HEAD
+[0.1.13]: https://github.com/IvanPavlak/WinuX/compare/v0.1.12...v0.1.13
 [0.1.12]: https://github.com/IvanPavlak/WinuX/compare/v0.1.11...v0.1.12
 [0.1.11]: https://github.com/IvanPavlak/WinuX/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/IvanPavlak/WinuX/compare/v0.1.9...v0.1.10

--- a/Windows/PowerShell/Modules/Tests/Modules/Window/Center-Windows.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Window/Center-Windows.Tests.ps1
@@ -8,6 +8,8 @@ BeforeAll {
 	# Center-Windows filters via Get-WindowHandle (same path as Move-Windows); load the real
 	# helper so filtering is exercised against the mocked Get-CachedWindows.
 	. "$FunctionsPath\Get-WindowHandle.ps1"
+	# -Monitor resolution is delegated to Resolve-TargetMonitor (shared with Move-Windows).
+	. "$FunctionsPath\Resolve-TargetMonitor.ps1"
 }
 
 Describe "Center-Windows" {
@@ -94,6 +96,91 @@ Describe "Center-Windows" {
 			# work area starts at X=1920, so X = 1920 + (1920-768)/2 = 2496.
 			Center-Windows -ProcessName "WindowsTerminal"
 
+			Should -Invoke Resize-Windows -Times 1 -ParameterFilter {
+				$TargetX -eq 2496
+			}
+		}
+	}
+
+	Context "-Monitor" {
+		BeforeEach {
+			$primary = [PSCustomObject]@{
+				DeviceName = '\\.\DISPLAY1'
+				Left = 0; Top = 0; Right = 1920; Bottom = 1080
+				Width = 1920; Height = 1080
+				WorkAreaLeft = 0; WorkAreaTop = 0; WorkAreaRight = 1920; WorkAreaBottom = 1040
+				WorkAreaWidth = 1920; WorkAreaHeight = 1040
+				IsPrimary  = $true
+			}
+			$secondary = [PSCustomObject]@{
+				DeviceName = '\\.\DISPLAY2'
+				Left = 1920; Top = 0; Right = 3840; Bottom = 1080
+				Width = 1920; Height = 1080
+				WorkAreaLeft = 1920; WorkAreaTop = 0; WorkAreaRight = 3840; WorkAreaBottom = 1040
+				WorkAreaWidth = 1920; WorkAreaHeight = 1040
+				IsPrimary  = $false
+			}
+
+			Mock Get-MonitorInfo { @($primary, $secondary) }
+			Mock Get-MonitorSpecs {
+				[PSCustomObject]@{
+					Primary   = [PSCustomObject]@{ X = 0; Y = 0; Width = 1920; Height = 1080 }
+					Secondary = [PSCustomObject]@{ X = 1920; Y = 0; Width = 1920; Height = 1080 }
+				}
+			}
+			Mock Get-WindowDisplayName { 'Chrome' }
+			Mock Write-LogError { }
+
+			# A window currently living on the secondary monitor.
+			Mock Get-CachedWindows {
+				@([PSCustomObject]@{
+						Handle      = [IntPtr]2
+						Title       = 'New Tab - Google Chrome'
+						ProcessName = 'chrome'
+						Left = 2200; Top = 200; Width = 800; Height = 600
+					})
+			}
+		}
+
+		It "pulls a secondary-monitor window onto the monitor named by index" {
+			# Monitor 1 is the primary work area: X = (1920-768)/2 = 576, Y = (1040-520)/2 = 260.
+			Center-Windows -ProcessName "chrome" -Monitor 1
+
+			Should -Invoke Resize-Windows -Times 1 -ParameterFilter {
+				$TargetX -eq 576 -and $TargetY -eq 260
+			}
+		}
+
+		It "accepts a monitor label as well as an index" {
+			Center-Windows -ProcessName "chrome" -Monitor "Primary"
+
+			Should -Invoke Resize-Windows -Times 1 -ParameterFilter {
+				$TargetX -eq 576
+			}
+		}
+
+		It "keeps a window on the target monitor it already occupies" {
+			# Secondary work area starts at X=1920 => X = 1920 + (1920-768)/2 = 2496.
+			Center-Windows -ProcessName "chrome" -Monitor 2
+
+			Should -Invoke Resize-Windows -Times 1 -ParameterFilter {
+				$TargetX -eq 2496
+			}
+		}
+
+		It "reports an error and centers nothing when the monitor cannot be resolved" {
+			Center-Windows -ProcessName "chrome" -Monitor "Monitor9"
+
+			Should -Invoke Write-LogError -Times 1
+			Should -Invoke Resize-Windows -Times 0
+		}
+
+		It "treats an empty monitor specifier as no targeting" {
+			# Reset-Windows passes no -Monitor when none is configured, but an empty string
+			# must not abort the pass either: the window stays on its current monitor.
+			Center-Windows -ProcessName "chrome" -Monitor ""
+
+			Should -Invoke Write-LogError -Times 0
 			Should -Invoke Resize-Windows -Times 1 -ParameterFilter {
 				$TargetX -eq 2496
 			}

--- a/Windows/PowerShell/Modules/Tests/Modules/Window/Move-Windows.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Window/Move-Windows.Tests.ps1
@@ -5,6 +5,9 @@ BeforeAll {
 	$FunctionsPath = Join-Path $ModuleRoot "Window\Functions"
 
 	. "$FunctionsPath\Move-Windows.ps1"
+	# -Monitor resolution is delegated to Resolve-TargetMonitor; load the real helper so the
+	# index/label/device-name rules are exercised rather than stubbed.
+	. "$FunctionsPath\Resolve-TargetMonitor.ps1"
 
 	# VirtualDesktop cmdlets come from an optional external module absent on CI runners.
 	# Stub the ones these tests mock so Mock can attach (no-op where the real module exists).
@@ -26,6 +29,15 @@ Describe "Move-Windows" {
 		Mock Get-MonitorInfo { @() }
 		Mock Get-MonitorSpecs { $null }
 		Mock Set-WindowPosition { $true }
+		Mock Get-WindowDisplayName { 'Test Window' }
+		# Monitor placement is verified via Wait-WindowRect (real GetWindowRect is unavailable
+		# here); report the requested bounds as verified unless a test overrides this.
+		Mock Wait-WindowRect {
+			[PSCustomObject]@{
+				Verified = $true; X = $ExpectedX; Y = $ExpectedY
+				Width = $ExpectedWidth; Height = $ExpectedHeight; ElapsedMs = 0
+			}
+		}
 		Mock Invoke-WithOptionalRetry {
 			param($EnableRetry, $ScriptBlock, $MaxAttempts, $InitialDelayMs)
 			& $ScriptBlock
@@ -107,8 +119,62 @@ Describe "Move-Windows" {
 
 		{ Move-Windows -VirtualDesktop 1 -Monitor 2 } | Should -Not -Throw
 
+		# Relative placement must be PRESERVED, not rounded to a work-area corner.
+		# Source work area 1920x1040, window 800x600 at (200,200):
+		#   relativeX = 200 / (1920-800) = 0.1786 -> 1920 + round(0.1786 * 1120) = 2120
+		#   relativeY = 200 / (1040-600) = 0.4545 ->    0 + round(0.4545 *  440) =  200
+		# Clamping with int literals ([math]::Min(1, $x)) rounds the fraction to 0/1 and
+		# yields the corner (1920, 0) instead - this asserts the double-literal clamp.
 		Should -Invoke Set-WindowPosition -Times 1 -ParameterFilter {
-			$WindowHandle -eq [IntPtr]1111 -and $X -ge 1920 -and $Y -ge 0
+			$WindowHandle -eq [IntPtr]1111 -and $X -eq 2120 -and $Y -eq 200
+		}
+	}
+
+	It "re-applies the monitor placement when the window does not hold its position" {
+		Mock Import-VirtualDesktopModule { $true }
+		Mock Get-DesktopCount { 2 }
+		Mock Get-DesktopFromWindow { [PSCustomObject]@{ Name = 'Desktop1' } }
+		Mock Get-DesktopIndex { 0 }
+		Mock Switch-Desktop { }
+		Mock Test-LogVerbose { $false }
+		Mock Write-LogWarning { }
+		Mock Write-LogList { }
+		Mock Write-LogSuccess { }
+		# Placement never sticks: something keeps moving the window back.
+		Mock Wait-WindowRect {
+			[PSCustomObject]@{ Verified = $false; X = 100; Y = 100; Width = 800; Height = 600; ElapsedMs = 150 }
+		}
+		Mock Get-CachedWindows {
+			@(
+				[PSCustomObject]@{
+					Handle = [IntPtr]2222; Title = 'Drifting Window'; ProcessName = 'chrome'
+					Left = 200; Top = 200; Width = 800; Height = 600
+				}
+			)
+		}
+		Mock Get-MonitorInfo {
+			@(
+				[PSCustomObject]@{
+					DeviceName = '\\.\DISPLAY1'; Left = 0; Top = 0; Right = 1920; Bottom = 1080
+					Width = 1920; Height = 1080
+					WorkAreaLeft = 0; WorkAreaTop = 0; WorkAreaRight = 1920; WorkAreaBottom = 1040
+					WorkAreaWidth = 1920; WorkAreaHeight = 1040; IsPrimary = $true
+				},
+				[PSCustomObject]@{
+					DeviceName = '\\.\DISPLAY2'; Left = 1920; Top = 0; Right = 3840; Bottom = 1080
+					Width = 1920; Height = 1080
+					WorkAreaLeft = 1920; WorkAreaTop = 0; WorkAreaRight = 3840; WorkAreaBottom = 1040
+					WorkAreaWidth = 1920; WorkAreaHeight = 1040; IsPrimary = $false
+				}
+			)
+		}
+
+		{ Move-Windows -VirtualDesktop 1 -Monitor 2 } | Should -Not -Throw
+
+		# Two attempts, and the unstuck window is reported instead of counted as moved.
+		Should -Invoke Set-WindowPosition -Times 2
+		Should -Invoke Write-LogWarning -Times 1 -ParameterFilter {
+			$Message -match 'did not stay on monitor'
 		}
 	}
 

--- a/Windows/PowerShell/Modules/Tests/Modules/Window/Reset-Windows.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Window/Reset-Windows.Tests.ps1
@@ -1,0 +1,110 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$FunctionsPath = Join-Path $ModuleRoot "Window\Functions"
+
+	. "$FunctionsPath\Reset-Windows.ps1"
+}
+
+Describe "Reset-Windows" {
+	BeforeEach {
+		Mock DetermineMachineType { 'PC' }
+		Mock Remove-VirtualDesktops { }
+		Mock Move-Windows { }
+		Mock Center-Windows { }
+		Mock Focus-TerminalTab { }
+		Mock Write-LogWarning { }
+		Mock Write-Host { }
+
+		$global:Configuration = @{
+			ResetAllWindowsDefaults = @{
+				PC      = @{ VirtualDesktop = 1; Monitor = "2" }
+				Laptop  = @{ VirtualDesktop = 1; Monitor = "" }
+				Default = @{ VirtualDesktop = 1; Monitor = "" }
+			}
+		}
+	}
+
+	Context "monitor target propagation" {
+		It "passes the configured monitor on to Center-Windows" {
+			# The whole point of the fix: Center-Windows runs last, so it must re-assert the
+			# intended monitor instead of re-deriving one from each window's current position.
+			Reset-Windows
+
+			Should -Invoke Move-Windows -Times 1 -ParameterFilter { $Monitor -eq "2" }
+			Should -Invoke Center-Windows -Times 1 -ParameterFilter { $Monitor -eq "2" }
+		}
+
+		It "omits -Monitor for a machine configured without monitor targeting" {
+			Mock DetermineMachineType { 'Laptop' }
+
+			Reset-Windows
+
+			Should -Invoke Center-Windows -Times 1 -ParameterFilter {
+				-not $Monitor
+			}
+		}
+
+		It "propagates an explicit -Monitor override to both passes" {
+			Reset-Windows -Monitor "Primary"
+
+			Should -Invoke Move-Windows -Times 1 -ParameterFilter { $Monitor -eq "Primary" }
+			Should -Invoke Center-Windows -Times 1 -ParameterFilter { $Monitor -eq "Primary" }
+		}
+
+		It "skips monitor targeting entirely when -Monitor is an empty string" {
+			Reset-Windows -Monitor ""
+
+			Should -Invoke Move-Windows -Times 1 -ParameterFilter {
+				-not $Monitor
+			}
+			Should -Invoke Center-Windows -Times 1 -ParameterFilter {
+				-not $Monitor
+			}
+		}
+
+		It "falls back to the Default entry for an unlisted machine type" {
+			Mock DetermineMachineType { 'Work' }
+
+			Reset-Windows
+
+			Should -Invoke Move-Windows -Times 1 -ParameterFilter { $VirtualDesktop -eq 1 }
+			Should -Invoke Center-Windows -Times 1 -ParameterFilter {
+				-not $Monitor
+			}
+		}
+	}
+
+	Context "virtual desktop cleanup result" {
+		It "warns and continues when the desktop collapse reports failure" {
+			Mock Remove-VirtualDesktops { $false }
+
+			Reset-Windows
+
+			Should -Invoke Write-LogWarning -Times 1 -ParameterFilter {
+				$Message -match 'Virtual desktop cleanup did not complete'
+			}
+			# The reset still runs: a partial collapse is reported, not fatal.
+			Should -Invoke Move-Windows -Times 1
+			Should -Invoke Center-Windows -Times 1
+		}
+
+		It "does not warn when the desktop collapse succeeds" {
+			Reset-Windows
+
+			Should -Invoke Write-LogWarning -Times 0 -ParameterFilter {
+				$Message -match 'Virtual desktop cleanup did not complete'
+			}
+		}
+	}
+
+	It "runs the reset steps in order, ending with the terminal refocus" {
+		Reset-Windows
+
+		Should -Invoke Remove-VirtualDesktops -Times 1
+		Should -Invoke Move-Windows -Times 1
+		Should -Invoke Center-Windows -Times 1
+		Should -Invoke Focus-TerminalTab -Times 1
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/Window/Resolve-TargetMonitor.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Window/Resolve-TargetMonitor.Tests.ps1
@@ -1,0 +1,122 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$FunctionsPath = Join-Path $ModuleRoot "Window\Functions"
+
+	. "$FunctionsPath\Resolve-TargetMonitor.ps1"
+}
+
+Describe "Resolve-TargetMonitor" {
+	BeforeEach {
+		# Primary on the left, secondary on the right; both 1920x1080 with a 40px
+		# taskbar reserved at the bottom of the work area.
+		$script:primary = [PSCustomObject]@{
+			DeviceName = '\\.\DISPLAY1'
+			Left = 0; Top = 0; Right = 1920; Bottom = 1080
+			Width = 1920; Height = 1080
+			WorkAreaLeft = 0; WorkAreaTop = 0; WorkAreaWidth = 1920; WorkAreaHeight = 1040
+			IsPrimary = $true
+		}
+		$script:secondary = [PSCustomObject]@{
+			DeviceName = '\\.\DISPLAY2'
+			Left = 1920; Top = 0; Right = 3840; Bottom = 1080
+			Width = 1920; Height = 1080
+			WorkAreaLeft = 1920; WorkAreaTop = 0; WorkAreaWidth = 1920; WorkAreaHeight = 1040
+			IsPrimary = $false
+		}
+		$script:monitors = @($script:primary, $script:secondary)
+
+		Mock Get-MonitorInfo { $script:monitors }
+		Mock Get-MonitorSpecs {
+			[PSCustomObject]@{
+				Primary   = [PSCustomObject]@{ X = 0; Y = 0; Width = 1920; Height = 1080 }
+				Secondary = [PSCustomObject]@{ X = 1920; Y = 0; Width = 1920; Height = 1080 }
+			}
+		}
+	}
+
+	Context "no targeting requested" {
+		It "reports Requested false for an empty specifier" {
+			$result = Resolve-TargetMonitor -Monitor "" -MonitorInfo $script:monitors
+
+			$result.Requested | Should -BeFalse
+			$result.Monitor | Should -BeNullOrEmpty
+			$result.ErrorMessage | Should -BeNullOrEmpty
+		}
+
+		It "reports Requested false for whitespace and never enumerates monitors" {
+			$result = Resolve-TargetMonitor -Monitor "   "
+
+			$result.Requested | Should -BeFalse
+			Should -Invoke Get-MonitorInfo -Times 0
+		}
+	}
+
+	Context "resolution by index" {
+		It "resolves a 1-based index against enumeration order" {
+			$result = Resolve-TargetMonitor -Monitor "2" -MonitorInfo $script:monitors
+
+			$result.Monitor.DeviceName | Should -Be '\\.\DISPLAY2'
+			$result.Label | Should -Be 'Monitor2'
+			$result.ErrorMessage | Should -BeNullOrEmpty
+		}
+
+		It "returns an error message for an out-of-range index without throwing" {
+			$result = Resolve-TargetMonitor -Monitor "5" -MonitorInfo $script:monitors
+
+			$result.Monitor | Should -BeNullOrEmpty
+			$result.Requested | Should -BeTrue
+			$result.ErrorMessage | Should -Match 'out of range'
+		}
+	}
+
+	Context "resolution by label and device name" {
+		It "resolves Primary to whichever monitor is currently primary" {
+			$result = Resolve-TargetMonitor -Monitor "Primary" -MonitorInfo $script:monitors
+
+			$result.Monitor.DeviceName | Should -Be '\\.\DISPLAY1'
+			$result.Label | Should -Be 'Primary'
+		}
+
+		It "resolves a standardized label through Get-MonitorSpecs geometry" {
+			$result = Resolve-TargetMonitor -Monitor "Secondary" -MonitorInfo $script:monitors
+
+			$result.Monitor.DeviceName | Should -Be '\\.\DISPLAY2'
+			$result.Label | Should -Be 'Secondary'
+		}
+
+		It "resolves an exact device name case-insensitively" {
+			$result = Resolve-TargetMonitor -Monitor '\\.\display2' -MonitorInfo $script:monitors
+
+			$result.Monitor.DeviceName | Should -Be '\\.\DISPLAY2'
+			$result.Label | Should -Be '\\.\DISPLAY2'
+		}
+
+		It "returns an error message listing available labels when unresolved" {
+			$result = Resolve-TargetMonitor -Monitor "Monitor7" -MonitorInfo $script:monitors
+
+			$result.Monitor | Should -BeNullOrEmpty
+			$result.ErrorMessage | Should -Match 'Could not resolve monitor'
+			$result.ErrorMessage | Should -Match 'Secondary'
+		}
+	}
+
+	Context "monitor enumeration" {
+		It "enumerates monitors itself when MonitorInfo is omitted" {
+			$result = Resolve-TargetMonitor -Monitor "1"
+
+			Should -Invoke Get-MonitorInfo -Times 1
+			$result.Monitor.DeviceName | Should -Be '\\.\DISPLAY1'
+		}
+
+		It "reports an error when no monitors can be detected" {
+			Mock Get-MonitorInfo { @() }
+
+			$result = Resolve-TargetMonitor -Monitor "1"
+
+			$result.Monitor | Should -BeNullOrEmpty
+			$result.ErrorMessage | Should -Match 'Could not detect any monitors'
+		}
+	}
+}

--- a/Windows/PowerShell/Modules/Window/Functions/Center-Windows.ps1
+++ b/Windows/PowerShell/Modules/Window/Functions/Center-Windows.ps1
@@ -8,6 +8,13 @@ function Center-Windows {
 		window is currently on (based on its center point), then moves and resizes
 		every window to a centered position within that monitor's work area.
 
+		Pass -Monitor to center every matched window on ONE explicit monitor instead
+		of deriving a monitor per window. This matters when centering follows a
+		monitor consolidation pass (Reset-Windows): deriving the monitor from each
+		window's current rectangle re-homes any window that something else moved in
+		the meantime, cementing the stray placement, whereas an explicit target
+		re-asserts the intended monitor and makes the pass self-correcting.
+
 		By default, windows are resized to 40% of the monitor work area width and
 		50% of the height. Use -WidthPercent and -HeightPercent to customize.
 
@@ -24,6 +31,7 @@ function Center-Windows {
 		- Get-WindowHandle for pattern-based window filtering (wildcard, regex, exact)
 		- Get-CachedWindows for fast window enumeration (when no filters)
 		- Get-MonitorInfo for monitor bounds and work areas
+		- Resolve-TargetMonitor for -Monitor resolution (index, label, device name)
 		- Resize-Windows for reliable, centralized window placement
 		- Ensure-WindowsFormsLoaded for System.Windows.Forms dependency
 
@@ -51,7 +59,14 @@ function Center-Windows {
 		If specified, every matched window is centered on the primary monitor
 		(whichever monitor is currently primary), regardless of which monitor it
 		is currently on. Without this switch, each window is centered on the
-		monitor it already lives on.
+		monitor it already lives on. Cannot be combined with -Monitor.
+
+	.PARAMETER Monitor
+		Centers every matched window on this monitor, regardless of which monitor
+		it is currently on. Accepts a 1-based index ("2"), a label ("Primary",
+		"Secondary", "Monitor3"), or a device name ("\\.\DISPLAY1") - resolved by
+		Resolve-TargetMonitor, the same path Move-Windows uses. Cannot be combined
+		with -OnPrimary.
 
 	.EXAMPLE
 		Center-Windows
@@ -85,8 +100,13 @@ function Center-Windows {
 		Center-Windows -ProcessName "WindowsTerminal" -OnPrimary
 		Centers Windows Terminal on the primary monitor, pulling it back from a
 		secondary monitor if it currently lives there.
+
+	.EXAMPLE
+		Center-Windows -Monitor 2
+		Centers every window on monitor 2, pulling back any window that currently
+		sits on another monitor.
 	#>
-	[CmdletBinding()]
+	[CmdletBinding(DefaultParameterSetName = 'CurrentMonitor')]
 	param (
 		[Parameter()]
 		[ValidateRange(10, 100)]
@@ -102,8 +122,12 @@ function Center-Windows {
 		[Parameter()]
 		[string]$WindowTitle,
 
-		[Parameter()]
-		[switch]$OnPrimary
+		[Parameter(ParameterSetName = 'OnPrimary')]
+		[switch]$OnPrimary,
+
+		[Parameter(ParameterSetName = 'TargetMonitor')]
+		[AllowEmptyString()]
+		[string]$Monitor
 	)
 
 	begin {
@@ -124,14 +148,30 @@ function Center-Windows {
 			return
 		}
 
-		# When -OnPrimary is set, resolve the primary monitor once and force every
-		# matched window onto it, regardless of which monitor it currently lives on.
+		# Resolve the forced target monitor once, if any: -OnPrimary is the shorthand for
+		# "whichever monitor is currently primary", -Monitor takes an index, label, or device
+		# name. With neither, each window is centered on the monitor it currently occupies.
 		$forcedMonitor = $null
+		$forcedMonitorLabel = $null
 		if ($OnPrimary) {
 			$forcedMonitor = $monitors | Where-Object { $_.IsPrimary } | Select-Object -First 1
 			if (-not $forcedMonitor) {
 				$forcedMonitor = $monitors[0]
 			}
+			$forcedMonitorLabel = 'Primary'
+		}
+		elseif (-not [string]::IsNullOrWhiteSpace($Monitor)) {
+			$resolvedMonitor = Resolve-TargetMonitor -Monitor $Monitor -MonitorInfo $monitors
+			if (-not $resolvedMonitor.Monitor) {
+				Write-LogError $resolvedMonitor.ErrorMessage
+				return
+			}
+			$forcedMonitor = $resolvedMonitor.Monitor
+			$forcedMonitorLabel = $resolvedMonitor.Label
+		}
+
+		if ($forcedMonitorLabel) {
+			Write-LogDebug "Centering on monitor $forcedMonitorLabel ($($forcedMonitor.DeviceName))"
 		}
 
 		if (Test-LogVerbose) {
@@ -202,8 +242,8 @@ function Center-Windows {
 
 			$totalEligibleWindows++
 
-			# Determine the target monitor. With -OnPrimary every window is forced
-			# onto the primary monitor; otherwise pick the monitor the window is
+			# Determine the target monitor. With -OnPrimary or -Monitor every window is
+			# forced onto the resolved monitor; otherwise pick the monitor the window is
 			# currently on based on its center point.
 			if ($forcedMonitor) {
 				$targetMonitor = $forcedMonitor

--- a/Windows/PowerShell/Modules/Window/Functions/Move-Windows.ps1
+++ b/Windows/PowerShell/Modules/Window/Functions/Move-Windows.ps1
@@ -18,7 +18,13 @@ function Move-Windows {
 
 		When monitor targeting is enabled, window position is preserved relative
 		to the source monitor work area and then clamped to the destination
-		monitor work area for safe placement.
+		monitor work area for safe placement. Each placement is verified with
+		Wait-WindowRect and re-applied once when the window did not land on the
+		target monitor, because SetWindowPos reports success for the call even
+		when an external window manager moves the window straight back.
+
+		Windows that could not be moved, or that would not stay on the target
+		monitor, are reported in normal mode as well as under verbose logging.
 
 		Use -Current to move windows to the same virtual desktop as the
 		calling terminal, without needing to know which desktop number it is.
@@ -32,6 +38,8 @@ function Move-Windows {
 		- Get-WindowHandle for pattern-based window filtering (wildcard, regex, exact)
 		- Get-CachedWindows for fast window enumeration (when no filters)
 		- Move-WindowToVirtualDesktop for reliable virtual desktop placement
+		- Resolve-TargetMonitor for -Monitor resolution (index, label, device name)
+		- Wait-WindowRect for post-placement verification of the monitor move
 		- Import-VirtualDesktopModule for VirtualDesktop module availability
 
 	.PARAMETER VirtualDesktop
@@ -199,62 +207,19 @@ function Move-Windows {
 		$allMonitors = $null
 
 		if ($Monitor) {
+			# Monitor matching (index / label / device name) lives in Resolve-TargetMonitor so
+			# Move-Windows and Center-Windows share one set of rules.
 			$allMonitors = Get-MonitorInfo -Quiet
-			if (-not $allMonitors -or $allMonitors.Count -eq 0) {
-				Write-LogError "Error: Could not detect any monitors for -Monitor targeting!"
+			$resolvedMonitor = Resolve-TargetMonitor -Monitor $Monitor -MonitorInfo $allMonitors
+
+			if (-not $resolvedMonitor.Monitor) {
+				Write-LogError $resolvedMonitor.ErrorMessage
 				$abortProcessing = $true
 				return
 			}
 
-			$monitorInput = $Monitor.Trim()
-			$monitorIndex = 0
-			$isNumericMonitor = [int]::TryParse($monitorInput, [ref]$monitorIndex)
-
-			if ($isNumericMonitor) {
-				if ($monitorIndex -lt 1 -or $monitorIndex -gt $allMonitors.Count) {
-					Write-LogError "Error: Monitor index [$monitorIndex] is out of range. Available monitor indices: 1..$($allMonitors.Count)."
-					$abortProcessing = $true
-					return
-				}
-				$targetMonitor = $allMonitors[$monitorIndex - 1]
-				$monitorTargetLabel = "Monitor$monitorIndex"
-			}
-
-			if (-not $targetMonitor -and $monitorInput -ieq 'Primary') {
-				$targetMonitor = $allMonitors | Where-Object { $_.IsPrimary } | Select-Object -First 1
-				$monitorTargetLabel = 'Primary'
-			}
-
-			if (-not $targetMonitor) {
-				$monitorSpecs = Get-MonitorSpecs -MonitorInfo $allMonitors
-				if ($monitorSpecs -and ($monitorSpecs.PSObject.Properties.Name -contains $monitorInput)) {
-					$targetSpec = $monitorSpecs.$monitorInput
-					$targetMonitor = $allMonitors | Where-Object {
-						$_.Left -eq $targetSpec.X -and $_.Top -eq $targetSpec.Y -and
-						$_.Width -eq $targetSpec.Width -and $_.Height -eq $targetSpec.Height
-					} | Select-Object -First 1
-					if ($targetMonitor) {
-						$monitorTargetLabel = $monitorInput
-					}
-				}
-			}
-
-			if (-not $targetMonitor) {
-				$targetMonitor = $allMonitors | Where-Object { $_.DeviceName -ieq $monitorInput } | Select-Object -First 1
-				if ($targetMonitor) {
-					$monitorTargetLabel = $targetMonitor.DeviceName
-				}
-			}
-
-			if (-not $targetMonitor) {
-				$availableLabels = @('Primary')
-				for ($i = 2; $i -le $allMonitors.Count; $i++) {
-					$availableLabels += if ($i -eq 2) { 'Secondary' } else { "Monitor$i" }
-				}
-				Write-LogError "Error: Could not resolve monitor [$Monitor]. Available labels: $($availableLabels -join ', ')."
-				$abortProcessing = $true
-				return
-			}
+			$targetMonitor = $resolvedMonitor.Monitor
+			$monitorTargetLabel = $resolvedMonitor.Label
 
 			Write-LogDebug "Target monitor resolved => $monitorTargetLabel ($($targetMonitor.DeviceName))"
 		}
@@ -312,12 +277,21 @@ function Move-Windows {
 		$movedLabels = @()
 		$alreadyCount = 0
 		$skippedCount = 0
+		$skippedLabels = @()
 		$monitorMovedCount = 0
 		$monitorSkippedCount = 0
+		$monitorSkippedLabels = @()
 		$excludedTitleCount = 0
 		$excludedInvalidSizeCount = 0
 		$totalEnumeratedWindows = @($allWindows).Count
 		$totalEligibleWindows = 0
+
+		# Monitor placement is verified and re-applied rather than trusted: an external window
+		# manager can pull a window back to another monitor immediately after the move while
+		# SetWindowPos still reports success. Two attempts with a short verification budget keep
+		# the worst case bounded for a full-desktop pass.
+		$monitorPlacementAttempts = 2
+		$monitorVerifyTimeoutMs = 150
 
 		foreach ($window in $allWindows) {
 			$handle = $window.Handle
@@ -389,6 +363,7 @@ function Move-Windows {
 				}
 				else {
 					$skippedCount++
+					$skippedLabels += Get-WindowDisplayName -ProcessName $procName -Title $title
 					$reason = if ($moveFailureMessage) { ": $moveFailureMessage" } elseif ($moveErr) { ": $($moveErr[0].Exception.Message)" } else { '' }
 					Write-LogDebug "     ✗ Failed to move [$title] ($procName)$reason" -Style Warning
 					continue
@@ -420,10 +395,14 @@ function Move-Windows {
 				$maxSourceXSpan = [math]::Max(1, $sourceMonitor.WorkAreaWidth - $window.Width)
 				$maxSourceYSpan = [math]::Max(1, $sourceMonitor.WorkAreaHeight - $window.Height)
 
-				$relativeX = ($window.Left - $sourceMonitor.WorkAreaLeft) / $maxSourceXSpan
-				$relativeY = ($window.Top - $sourceMonitor.WorkAreaTop) / $maxSourceYSpan
-				$relativeX = [math]::Max(0, [math]::Min(1, $relativeX))
-				$relativeY = [math]::Max(0, [math]::Min(1, $relativeY))
+				# The clamp literals MUST be doubles. With int literals PowerShell binds the
+				# [math]::Min(int, int) / [math]::Max(int, int) overloads and rounds the relative
+				# fraction to 0 or 1, which slams every window into a corner of the destination
+				# work area instead of preserving its relative placement.
+				$relativeX = [double](($window.Left - $sourceMonitor.WorkAreaLeft) / $maxSourceXSpan)
+				$relativeY = [double](($window.Top - $sourceMonitor.WorkAreaTop) / $maxSourceYSpan)
+				$relativeX = [math]::Max(0.0, [math]::Min(1.0, $relativeX))
+				$relativeY = [math]::Max(0.0, [math]::Min(1.0, $relativeY))
 
 				$newWidth = [math]::Min($window.Width, $targetMonitor.WorkAreaWidth)
 				$newHeight = [math]::Min($window.Height, $targetMonitor.WorkAreaHeight)
@@ -438,14 +417,43 @@ function Move-Windows {
 				$newX = [math]::Max($targetMonitor.WorkAreaLeft, [math]::Min($maxX, $newX))
 				$newY = [math]::Max($targetMonitor.WorkAreaTop, [math]::Min($maxY, $newY))
 
-				$monitorMoveResult = Set-WindowPosition -WindowHandle $handle -X $newX -Y $newY -Width $newWidth -Height $newHeight
+				# Verify the window actually landed on the target monitor instead of trusting
+				# SetWindowPos' return value, and re-apply when it did not. SetWindowPos reports
+				# success for the CALL; an external window manager (for example FancyZones with
+				# "keep windows in their zones" enabled) can move the window back to a remembered
+				# zone on another monitor right afterwards. Wait-WindowRect is the same
+				# verification the snap pipeline uses.
+				$monitorMoveResult = $false
+				$lastObserved = $null
+
+				for ($placementAttempt = 1; $placementAttempt -le $monitorPlacementAttempts; $placementAttempt++) {
+					if (-not (Set-WindowPosition -WindowHandle $handle -X $newX -Y $newY -Width $newWidth -Height $newHeight)) {
+						continue
+					}
+
+					$placementCheck = Wait-WindowRect -WindowHandle $handle `
+						-ExpectedX $newX -ExpectedY $newY `
+						-ExpectedWidth $newWidth -ExpectedHeight $newHeight `
+						-TimeoutMs $monitorVerifyTimeoutMs
+
+					if ($placementCheck.Verified) {
+						$monitorMoveResult = $true
+						break
+					}
+
+					$lastObserved = $placementCheck
+					Write-LogDebug "     ! [$title] ($procName) did not hold monitor $monitorTargetLabel on attempt $placementAttempt (observed $($placementCheck.X), $($placementCheck.Y))" -Style Warning
+				}
+
 				if ($monitorMoveResult) {
 					$monitorMovedCount++
 					Write-LogDebug "     ✓ Repositioned [$title] ($procName) => monitor $monitorTargetLabel" -Style Success
 				}
 				else {
 					$monitorSkippedCount++
-					Write-LogDebug "     ✗ Failed to reposition [$title] ($procName) on monitor $monitorTargetLabel" -Style Warning
+					$monitorSkippedLabels += Get-WindowDisplayName -ProcessName $procName -Title $title
+					$observedText = if ($lastObserved) { " (last observed $($lastObserved.X), $($lastObserved.Y))" } else { '' }
+					Write-LogDebug "     ✗ Failed to reposition [$title] ($procName) on monitor $monitorTargetLabel$observedText" -Style Warning
 				}
 			}
 		}
@@ -483,8 +491,18 @@ function Move-Windows {
 			if ($alreadyCount -gt 0) {
 				Write-LogWarning "$alreadyCount window(s) already on Virtual Desktop $VirtualDesktop."
 			}
+			# Failures are reported in normal mode too: silently dropping them made a partial
+			# pass look identical to a complete one.
+			if ($skippedCount -gt 0) {
+				Write-LogWarning "$skippedCount window(s) could not be moved to Virtual Desktop $VirtualDesktop."
+				Write-LogList -Items $skippedLabels
+			}
 			if ($targetMonitor -and $monitorMovedCount -gt 0) {
 				Write-LogSuccess "$monitorMovedCount window(s) moved to monitor $monitorTargetLabel."
+			}
+			if ($targetMonitor -and $monitorSkippedCount -gt 0) {
+				Write-LogWarning "$monitorSkippedCount window(s) did not stay on monitor $monitorTargetLabel."
+				Write-LogList -Items $monitorSkippedLabels
 			}
 		}
 	}

--- a/Windows/PowerShell/Modules/Window/Functions/Reset-Windows.ps1
+++ b/Windows/PowerShell/Modules/Window/Functions/Reset-Windows.ps1
@@ -9,7 +9,19 @@ function Reset-Windows {
 		  1. Remove-VirtualDesktops  - collapse down to a single virtual desktop
 		  2. Move-Windows            - move every window to the target virtual
 		                               desktop (and, optionally, a target monitor)
-		  3. Center-Windows          - center every window on its monitor
+		  3. Center-Windows          - center every window on the target monitor
+		                               (or on its current monitor when no monitor
+		                               is configured)
+
+		The configured monitor is passed on to Center-Windows rather than letting it
+		re-derive a monitor per window. Because Center-Windows runs last, that makes
+		the reset self-correcting: a window that something else moved to another
+		monitor during the run - notably FancyZones restoring a remembered zone after
+		the virtual desktops collapse - is pulled back to the configured monitor
+		instead of being centered wherever it drifted to.
+
+		A failed Remove-VirtualDesktops is surfaced as a warning instead of being
+		ignored, since it changes how much work the move pass has to do.
 
 		This reproduces the manual sequence:
 		  PC      => Remove-VirtualDesktops; Move-Windows -Monitor 2 -VirtualDesktop 1; Center-Windows
@@ -83,7 +95,12 @@ function Reset-Windows {
 		Write-LogDebug "MachineType => $machineType, VirtualDesktop => $VirtualDesktop, Monitor => $monitorText"
 	}
 
-	Remove-VirtualDesktops
+	# A failed collapse is reported instead of ignored: when it fails the move pass has to
+	# relocate every window itself, so the run behaves very differently from a clean reset.
+	$desktopCleanupResult = Remove-VirtualDesktops
+	if (@($desktopCleanupResult) -contains $false) {
+		Write-LogWarning "Virtual desktop cleanup did not complete - windows may still be spread across desktops."
+	}
 
 	$moveParams = @{
 		VirtualDesktop = $VirtualDesktop
@@ -94,7 +111,17 @@ function Reset-Windows {
 
 	Move-Windows @moveParams
 
-	Center-Windows
+	# Center on the CONFIGURED monitor rather than letting Center-Windows re-derive one per
+	# window. Center-Windows runs last, so passing the target makes the reset self-correcting:
+	# any window that something else (for example FancyZones restoring a remembered zone after
+	# the desktop collapse) pulled onto another monitor is brought back here instead of being
+	# centered where it drifted to.
+	$centerParams = @{}
+	if ($Monitor) {
+		$centerParams.Monitor = $Monitor
+	}
+
+	Center-Windows @centerParams
 
 	Focus-TerminalTab
 }

--- a/Windows/PowerShell/Modules/Window/Functions/Resolve-TargetMonitor.ps1
+++ b/Windows/PowerShell/Modules/Window/Functions/Resolve-TargetMonitor.ps1
@@ -1,0 +1,144 @@
+function Resolve-TargetMonitor {
+	<#
+	.SYNOPSIS
+		Resolves a monitor specifier (index, label, or device name) to a monitor object.
+
+	.DESCRIPTION
+		Shared monitor-targeting resolver for the placement functions. Accepts the three
+		forms callers expose through their own -Monitor parameter:
+		- 1-based monitor index following Get-MonitorInfo order (for example: 1, 2)
+		- standardized labels from Get-MonitorSpecs (Primary, Secondary, Monitor3, ...)
+		- exact monitor device name (for example: \\.\DISPLAY1)
+
+		Extracted from Move-Windows so Move-Windows and Center-Windows resolve -Monitor
+		through one set of matching rules instead of each carrying its own copy. This
+		function writes no console output: it returns the resolved monitor together with a
+		ready-to-log ErrorMessage, leaving logging and control flow (abort, return, or
+		fall back) to the caller.
+
+		Note that a numeric index is POSITIONAL - it follows Get-MonitorInfo /
+		Screen.AllScreens enumeration order, which is not guaranteed to match the numbering
+		shown in Windows display settings and can change when displays are re-enumerated.
+		Labels and device names are stable identifiers; prefer them when the target must
+		survive a display reconfiguration.
+
+	.PARAMETER Monitor
+		The monitor specifier: 1-based index, label, or device name. Empty, whitespace-only,
+		or absent input resolves to "no targeting requested" - Monitor and ErrorMessage are
+		both $null and Requested is $false.
+
+	.PARAMETER MonitorInfo
+		Monitor objects from Get-MonitorInfo. When omitted, Get-MonitorInfo -Quiet is called.
+		Pass an already-retrieved set to avoid enumerating the monitors twice.
+
+	.OUTPUTS
+		PSCustomObject with:
+		- Monitor      : the resolved monitor object, or $null when unresolved / not requested
+		- Label        : display label for the resolved monitor (for example "Monitor2")
+		- ErrorMessage : why resolution failed, or $null on success / no request
+		- Requested    : $true when a non-empty specifier was supplied
+
+	.EXAMPLE
+		$resolved = Resolve-TargetMonitor -Monitor "2" -MonitorInfo $monitors
+		if (-not $resolved.Monitor) { Write-LogError $resolved.ErrorMessage; return }
+
+	.EXAMPLE
+		Resolve-TargetMonitor -Monitor "Primary"
+		Resolves the currently primary monitor, enumerating monitors on demand.
+
+	.EXAMPLE
+		(Resolve-TargetMonitor -Monitor "").Requested
+		# => False (no monitor targeting requested)
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Position = 0)]
+		[AllowEmptyString()]
+		[AllowNull()]
+		[string]$Monitor,
+
+		[Parameter()]
+		[AllowNull()]
+		[object[]]$MonitorInfo
+	)
+
+	$result = [PSCustomObject]@{
+		Monitor      = $null
+		Label        = $null
+		ErrorMessage = $null
+		Requested    = $false
+	}
+
+	if ([string]::IsNullOrWhiteSpace($Monitor)) {
+		return $result
+	}
+
+	$result.Requested = $true
+
+	$allMonitors = @($MonitorInfo | Where-Object { $null -ne $_ })
+	if ($allMonitors.Count -eq 0) {
+		$allMonitors = @(Get-MonitorInfo -Quiet)
+	}
+
+	if ($allMonitors.Count -eq 0) {
+		$result.ErrorMessage = "Error: Could not detect any monitors for -Monitor targeting!"
+		return $result
+	}
+
+	$monitorInput = $Monitor.Trim()
+	$targetMonitor = $null
+	$monitorLabel = $null
+
+	# 1-based index into the enumeration order.
+	$monitorIndex = 0
+	if ([int]::TryParse($monitorInput, [ref]$monitorIndex)) {
+		if ($monitorIndex -lt 1 -or $monitorIndex -gt $allMonitors.Count) {
+			$result.ErrorMessage = "Error: Monitor index [$monitorIndex] is out of range. Available monitor indices: 1..$($allMonitors.Count)."
+			return $result
+		}
+		$targetMonitor = $allMonitors[$monitorIndex - 1]
+		$monitorLabel = "Monitor$monitorIndex"
+	}
+
+	# "Primary" tracks whichever monitor is currently primary.
+	if (-not $targetMonitor -and $monitorInput -ieq 'Primary') {
+		$targetMonitor = $allMonitors | Where-Object { $_.IsPrimary } | Select-Object -First 1
+		$monitorLabel = 'Primary'
+	}
+
+	# Standardized labels (Secondary, Monitor3, ...) matched through Get-MonitorSpecs geometry.
+	if (-not $targetMonitor) {
+		$monitorSpecs = Get-MonitorSpecs -MonitorInfo $allMonitors
+		if ($monitorSpecs -and ($monitorSpecs.PSObject.Properties.Name -contains $monitorInput)) {
+			$targetSpec = $monitorSpecs.$monitorInput
+			$targetMonitor = $allMonitors | Where-Object {
+				$_.Left -eq $targetSpec.X -and $_.Top -eq $targetSpec.Y -and
+				$_.Width -eq $targetSpec.Width -and $_.Height -eq $targetSpec.Height
+			} | Select-Object -First 1
+			if ($targetMonitor) {
+				$monitorLabel = $monitorInput
+			}
+		}
+	}
+
+	# Exact device name.
+	if (-not $targetMonitor) {
+		$targetMonitor = $allMonitors | Where-Object { $_.DeviceName -ieq $monitorInput } | Select-Object -First 1
+		if ($targetMonitor) {
+			$monitorLabel = $targetMonitor.DeviceName
+		}
+	}
+
+	if (-not $targetMonitor) {
+		$availableLabels = @('Primary')
+		for ($i = 2; $i -le $allMonitors.Count; $i++) {
+			$availableLabels += if ($i -eq 2) { 'Secondary' } else { "Monitor$i" }
+		}
+		$result.ErrorMessage = "Error: Could not resolve monitor [$Monitor]. Available labels: $($availableLabels -join ', ')."
+		return $result
+	}
+
+	$result.Monitor = $targetMonitor
+	$result.Label = $monitorLabel
+	return $result
+}

--- a/Windows/PowerShell/Modules/Window/Window.psd1
+++ b/Windows/PowerShell/Modules/Window/Window.psd1
@@ -52,6 +52,7 @@
 		'Resolve-CenteredWindowPercent',
 		'Resolve-LayoutTokens',
 		'Resolve-PositionedWindowHandle',
+		'Resolve-TargetMonitor',
 		'Reset-VirtualDesktopComProxy',
 		'Reset-VirtualDesktopState',
 		'Save-CurrentLayout',

--- a/docs/modules/window.md
+++ b/docs/modules/window.md
@@ -90,9 +90,9 @@ Center-Terminal
 
 ## [Center-Windows](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Window/Functions/Center-Windows.ps1)
 
-- **Description:** Centers all open windows on their respective monitors. Enumerates all visible application windows, determines which monitor each window is currently on based on its center point, then moves and resizes every window to a centered position within that monitor's work area. By default windows are resized to 40% of the monitor work area width and 50% of the height (override with `-WidthPercent` / `-HeightPercent`). Off-screen windows are automatically moved to the primary monitor. Pass `-OnPrimary` to force every matched window onto the primary monitor (whichever is currently primary), regardless of where it currently lives. Optionally restrict centering to matching windows with `-ProcessName` and/or `-WindowTitle` (exact, wildcard, or regex; OR logic when both are given), delegated to `Get-WindowHandle` - the same filtering path as `Move-Windows`. The actual move/resize is delegated to `Resize-Windows` in target-bounds mode (with `-InsetPercent 0` for exact placement), so all window placement flows through a single shared path (DRY).
-- **Parameters:** -WidthPercent, -HeightPercent, -ProcessName, -WindowTitle, -OnPrimary
-- **Usage:** `Center-Windows`, `Center-Windows -WidthPercent 60 -HeightPercent 70`, `Center-Windows -ProcessName "chrome"`, `Center-Windows -ProcessName "*chrome*"`, `Center-Windows -ProcessName "(chrome|firefox|msedge)"`, `Center-Windows -WindowTitle "*YouTube*"`, `Center-Windows -ProcessName "WindowsTerminal" -OnPrimary`
+- **Description:** Centers all open windows on their respective monitors. Enumerates all visible application windows, determines which monitor each window is currently on based on its center point, then moves and resizes every window to a centered position within that monitor's work area. By default windows are resized to 40% of the monitor work area width and 50% of the height (override with `-WidthPercent` / `-HeightPercent`). Off-screen windows are automatically moved to the primary monitor. Pass `-OnPrimary` to force every matched window onto the primary monitor (whichever is currently primary), or `-Monitor` to force them onto a specific monitor by index, label, or device name (resolved by `Resolve-TargetMonitor`, the same path `Move-Windows` uses); the two are mutually exclusive. Forcing a target instead of deriving one per window is what makes a consolidation pass self-correcting - see the note below. Optionally restrict centering to matching windows with `-ProcessName` and/or `-WindowTitle` (exact, wildcard, or regex; OR logic when both are given), delegated to `Get-WindowHandle` - the same filtering path as `Move-Windows`. The actual move/resize is delegated to `Resize-Windows` in target-bounds mode (with `-InsetPercent 0` for exact placement), so all window placement flows through a single shared path (DRY).
+- **Parameters:** -WidthPercent, -HeightPercent, -ProcessName, -WindowTitle, -OnPrimary, -Monitor
+- **Usage:** `Center-Windows`, `Center-Windows -WidthPercent 60 -HeightPercent 70`, `Center-Windows -ProcessName "chrome"`, `Center-Windows -ProcessName "*chrome*"`, `Center-Windows -ProcessName "(chrome|firefox|msedge)"`, `Center-Windows -WindowTitle "*YouTube*"`, `Center-Windows -ProcessName "WindowsTerminal" -OnPrimary`, `Center-Windows -Monitor 2`
 
 Builds on existing module helpers: `Get-WindowHandle` for pattern filtering when `-ProcessName`/`-WindowTitle` is supplied (otherwise `Get-CachedWindows` enumerates all windows; the cache is cleared first to read fresh positions), `Get-MonitorInfo` for monitor bounds and work areas, `Resize-Windows` (target-bounds mode, `-InsetPercent 0`) for reliable, centralized placement, and `Ensure-WindowsFormsLoaded` for the `System.Windows.Forms` dependency. System and shell windows (Program Manager, Windows Input Experience, search/start surfaces, overlays, etc.) and windows with no meaningful size are skipped. Under `Set-LogLevel Verbose` it prints a per-window trace plus a diagnostics summary with enumerated, eligible, centered, and skipped counts and exclusion counts (skip-title and invalid-size) to explain why some windows were not centered.
 
@@ -103,10 +103,16 @@ Builds on existing module helpers: `Get-WindowHandle` for pattern filtering when
 | `-ProcessName`   | Only center windows whose process matches this pattern (without `.exe`). Supports exact names, wildcards (`*`, `?`), and regex. Omit to center all visible windows.                                 |
 | `-WindowTitle`   | Only center windows whose title matches this pattern. Supports wildcards (`*`, `?`) and regex. Combine with `-ProcessName` (OR logic). Omit (with no `-ProcessName`) to center all visible windows. |
 | `-OnPrimary`     | Force every matched window onto the primary monitor (whichever is currently primary), pulling it back from a secondary monitor if needed. Omit to center each window on its current monitor.        |
+| `-Monitor`       | Force every matched window onto this monitor: 1-based index (`2`), label (`Primary`, `Secondary`, `Monitor3`), or device name (`\\.\DISPLAY1`). An empty string means no targeting. Excludes `-OnPrimary`. |
+
+Deriving the monitor per window (the default) reads each window's CURRENT position, so it re-homes a window wherever it happens to sit. After a consolidation pass that is the wrong behavior: any window that something else moved in the meantime - notably FancyZones restoring a remembered zone - gets centered on the monitor it drifted to, cementing the stray placement. `-Monitor` re-asserts the intended target instead, which is why `Reset-Windows` passes its configured monitor through.
 
 ```powershell
 # Center every window at the default 40% x 50% on its current monitor
 Center-Windows
+
+# Pull every window onto monitor 2 and center it there
+Center-Windows -Monitor 2
 
 # Use larger centered tiles
 Center-Windows -WidthPercent 60 -HeightPercent 70
@@ -124,7 +130,7 @@ Center-Windows -ProcessName "(chrome|firefox|msedge)"
 Center-Windows -ProcessName "WindowsTerminal" -OnPrimary
 ```
 
-**See also:** [Reset-Windows](window.md#reset-windows)
+**See also:** [Reset-Windows](window.md#reset-windows), [Resolve-TargetMonitor](window.md#resolve-targetmonitor)
 
 ## [Center-Text](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Window/Functions/Center-Text.ps1)
 
@@ -805,11 +811,13 @@ Initialize-WorkspaceWindowLayoutRerun
 
 ## [Move-Windows](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Window/Functions/Move-Windows.ps1)
 
-- **Description:** Enumerates all visible application windows and moves each one to a specified virtual desktop (1-based; desktop 1 is the first). If the target desktop does not exist it is created automatically, and after the move pass focus is switched to the destination desktop. Use `-Current` to target the calling terminal's own desktop without knowing its number. Optional `-Monitor` repositions windows onto a target physical monitor in the same pass, preserving each window's relative placement from its source monitor work area and clamping to the destination work area for safe multi-resolution placement. Filtering by `-ProcessName` and/or `-WindowTitle` supports exact, wildcard, and regex matching (delegated to `Get-WindowHandle`); when both are given, windows matching either criterion are moved (OR logic). Windows already on the target desktop are skipped unless monitor repositioning is requested.
+- **Description:** Enumerates all visible application windows and moves each one to a specified virtual desktop (1-based; desktop 1 is the first). If the target desktop does not exist it is created automatically, and after the move pass focus is switched to the destination desktop. Use `-Current` to target the calling terminal's own desktop without knowing its number. Optional `-Monitor` repositions windows onto a target physical monitor in the same pass (resolved by `Resolve-TargetMonitor`), preserving each window's relative placement from its source monitor work area and clamping to the destination work area for safe multi-resolution placement. Each monitor placement is verified with `Wait-WindowRect` and re-applied once if the window did not hold its position, because `SetWindowPos` reports success for the call even when an external window manager moves the window straight back. Filtering by `-ProcessName` and/or `-WindowTitle` supports exact, wildcard, and regex matching (delegated to `Get-WindowHandle`); when both are given, windows matching either criterion are moved (OR logic). Windows already on the target desktop are skipped unless monitor repositioning is requested. Windows that could not be moved, or that would not stay on the target monitor, are reported in normal mode as well as under verbose logging.
 - **Parameters:** -VirtualDesktop, -Current, -ProcessName, -WindowTitle, -Monitor
 - **Usage:** `Move-Windows`, `Move-Windows -VirtualDesktop 2`, `Move-Windows -Current`, `Move-Windows -Current -ProcessName "chrome"`, `Move-Windows -WindowTitle "*YouTube*"`, `Move-Windows -ProcessName "chrome" -WindowTitle "*GitHub*"`, `Move-Windows -Current -Monitor Secondary`, `Move-Windows -VirtualDesktop 2 -Monitor 1`
 
 Moves every visible window to a target virtual desktop and, optionally, a target physical monitor. The `-VirtualDesktop` and `-Current` parameters are mutually exclusive (separate parameter sets). Missing desktops are created on demand via `Ensure-VirtualDesktops`. Monitor targeting accepts a 1-based index (`1`, `2`), standardized labels (`Primary`, `Secondary`, `Monitor3`, ...), or an exact device name (for example `\\.\DISPLAY1`). System and shell windows (Program Manager, Start, Search, overlays, zero-size windows, etc.) are excluded. Under `Set-LogLevel Verbose`, a per-window trace plus a summary of moved, already-there, skipped, enumerated, eligible, and exclusion (skip-title / invalid-size) counts is printed. VirtualDesktop calls are wrapped with optional exponential-backoff retries (`Invoke-WithRetry`) to absorb transient RPC failures such as `0x800706BA`.
+
+Note that a numeric `-Monitor` index is POSITIONAL: it follows `Get-MonitorInfo` / `Screen.AllScreens` enumeration order, which is not guaranteed to match the numbering in Windows display settings and can change when displays are re-enumerated. Prefer a label or device name when the target must survive a display reconfiguration.
 
 | Parameter         | Type   | Default | Description                                                                                                       |
 | ----------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------- |
@@ -839,7 +847,7 @@ Move-Windows -ProcessName "chrome" -WindowTitle "*GitHub*"
 Move-Windows -VirtualDesktop 2 -Monitor 1
 ```
 
-**See also:** [Reset-Windows](window.md), [Move-WindowToVirtualDesktop](window.md)
+**See also:** [Reset-Windows](window.md#reset-windows), [Move-WindowToVirtualDesktop](window.md#move-windowtovirtualdesktop), [Resolve-TargetMonitor](window.md#resolve-targetmonitor), [Wait-WindowRect](window.md#wait-windowrect)
 
 ## [Move-WindowToVirtualDesktop](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Window/Functions/Move-WindowToVirtualDesktop.ps1)
 
@@ -889,7 +897,7 @@ Reset-KeyboardModifiers -IncludeMouseButton
 
 ## [Reset-Windows](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Window/Functions/Reset-Windows.ps1)
 
-- **Description:** Convenience wrapper that resets the window layout to a clean slate for layout testing. Runs four steps in order: `Remove-VirtualDesktops` (collapse down to a single virtual desktop), `Move-Windows` (move every window to the target virtual desktop and, optionally, a target monitor), `Center-Windows` (center every window on its monitor), and finally `Focus-TerminalTab` (focuses Windows Terminal to continue working). Defaults for `-VirtualDesktop` and `-Monitor` are read per machine from configuration.
+- **Description:** Convenience wrapper that resets the window layout to a clean slate for layout testing. Runs four steps in order: `Remove-VirtualDesktops` (collapse down to a single virtual desktop), `Move-Windows` (move every window to the target virtual desktop and, optionally, a target monitor), `Center-Windows` (center every window on the configured monitor, or on its current monitor when none is configured), and finally `Focus-TerminalTab` (focuses Windows Terminal to continue working). The configured monitor is passed on to `Center-Windows` so the last pass re-asserts the intended target rather than re-deriving one per window, which makes the reset self-correcting when something moves a window mid-run. A `Remove-VirtualDesktops` failure is surfaced as a warning instead of being ignored. Defaults for `-VirtualDesktop` and `-Monitor` are read per machine from configuration.
 - **Parameters:** -VirtualDesktop (default: per-machine config), -Monitor (default: per-machine config)
 - **Usage:** `Reset-Windows`, `Reset-Windows -VirtualDesktop 2 -Monitor Primary`, `Reset-Windows -Monitor ""`
 
@@ -899,11 +907,13 @@ This replaces the manual sequences:
 
 ```powershell
 # PC
-Remove-VirtualDesktops; Move-Windows -Monitor 2 -VirtualDesktop 1; Center-Windows
+Remove-VirtualDesktops; Move-Windows -Monitor 2 -VirtualDesktop 1; Center-Windows -Monitor 2
 
 # Laptop / Work
 Remove-VirtualDesktops; Move-Windows -VirtualDesktop 1; Center-Windows
 ```
+
+Collapsing the virtual desktops makes Windows migrate the windows off the removed desktops, and FancyZones reacts to those arrivals by restoring each window to its remembered zone - which can be on a different monitor. Passing the configured monitor to `Center-Windows` (the last pass) is what corrects that: without it, `Center-Windows` derives each window's monitor from its current position and centers strays where they landed. See [Windows Land On The Wrong Monitor After Reset-Windows](../reference/troubleshooting.md) in troubleshooting.
 
 | Parameter         | Type   | Default            | Description                                                                                                                                                                                                      |
 | ----------------- | ------ | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1087,6 +1097,43 @@ Enumerates the window list once via `Get-CachedWindows` (instead of issuing mult
 $fresh = Resolve-PositionedWindowHandle -WindowState $tracked
 if ($fresh) { $handle = $fresh.Handle }
 ```
+
+## [Resolve-TargetMonitor](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Window/Functions/Resolve-TargetMonitor.ps1)
+
+- **Description:** Resolves a monitor specifier to a monitor object for the placement functions. Accepts a 1-based index following `Get-MonitorInfo` order (`1`, `2`), a standardized label from `Get-MonitorSpecs` (`Primary`, `Secondary`, `Monitor3`, ...), or an exact device name (`\\.\DISPLAY1`). Shared by `Move-Windows` and `Center-Windows` so both resolve `-Monitor` through one set of rules. Writes no console output: it returns the resolved monitor together with a ready-to-log `ErrorMessage`, leaving logging and control flow (abort, return, or fall back) to the caller. An empty or whitespace-only specifier resolves to "no targeting requested" rather than an error.
+- **Parameters:** -Monitor, -MonitorInfo
+- **Usage:** `Resolve-TargetMonitor -Monitor "2" -MonitorInfo $monitors`, `Resolve-TargetMonitor -Monitor "Primary"`
+
+| Parameter       | Type     | Default | Description                                                                                                     |
+| --------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------- |
+| `-Monitor`      | string   | -       | Monitor specifier: 1-based index, label, or device name. Empty/whitespace means no targeting requested.          |
+| `-MonitorInfo`  | object[] | -       | Monitor objects from `Get-MonitorInfo`. Omit to enumerate on demand; pass a set to avoid a second enumeration.   |
+
+Returns a `PSCustomObject` with:
+
+| Member         | Description                                                                       |
+| -------------- | --------------------------------------------------------------------------------- |
+| `Monitor`      | The resolved monitor object, or `$null` when unresolved or not requested.          |
+| `Label`        | Display label for the resolved monitor (for example `Monitor2`).                   |
+| `ErrorMessage` | Why resolution failed, or `$null` on success / no request.                         |
+| `Requested`    | `$true` when a non-empty specifier was supplied.                                   |
+
+A numeric index is POSITIONAL - it follows `Get-MonitorInfo` / `Screen.AllScreens` enumeration order, which is not guaranteed to match the numbering shown in Windows display settings and can change when displays are re-enumerated. Labels and device names are stable identifiers; prefer them when the target must survive a display reconfiguration.
+
+```powershell
+# Resolve and act on the caller's own terms
+$resolved = Resolve-TargetMonitor -Monitor "2" -MonitorInfo $monitors
+if (-not $resolved.Monitor) {
+    Write-LogError $resolved.ErrorMessage
+    return
+}
+"Targeting $($resolved.Label) ($($resolved.Monitor.DeviceName))"
+
+# Empty specifier means "no monitor targeting", not a failure
+(Resolve-TargetMonitor -Monitor "").Requested   # => False
+```
+
+**See also:** [Move-Windows](window.md#move-windows), [Center-Windows](window.md#center-windows), [Get-MonitorSpecs](window.md#get-monitorspecs)
 
 ## [Save-CurrentLayout](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Window/Functions/Save-CurrentLayout.ps1)
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -261,6 +261,28 @@ Test-VirtualDesktopComHealth
 
 Opening a new shell also works (a fresh process builds fresh COM connections), but is no longer necessary.
 
+### Windows Land On The Wrong Monitor After Reset-Windows
+
+**Problem:** `Reset-Windows` consolidates onto the configured monitor, but a handful of windows end up centered on a different monitor. The verbose log shows every window moved successfully (`monitor moved [35]`), yet `Center-Windows` then reports target zones on the other monitor.
+
+**Why it happens:** Collapsing the virtual desktops makes Windows migrate the windows off the removed desktops onto the surviving one. FancyZones reacts to those arrivals by restoring each window to its remembered zone from `app-zone-history.json` - and that record includes a monitor. Running the move pass WITHOUT the desktop collapse does not reproduce it; adding the collapse does.
+
+Which monitor FancyZones picks is unreliable when two displays are the same model: identical panels report the same EDID code and can report the same serial number, so `applied-layouts.json` accumulates several device identities for the same physical monitor. `Get-DuplicateMonitorEdid` detects the EDID collision (`Apply-FancyZones` uses it to stop false "already applied" skips), but the zone history has no such guard.
+
+**Solution:** This now self-corrects. `Reset-Windows` passes its configured monitor to `Center-Windows`, which runs last, so any window pulled onto another monitor mid-run is brought back to the intended one. `Move-Windows` also verifies each placement with `Wait-WindowRect` and re-applies it once, and reports windows that would not stay put instead of counting them as moved.
+
+To confirm what happened on a specific run:
+
+```powershell
+# Per-window trace plus moved / skipped / monitor-failed counts
+Set-LogLevel Verbose { Reset-Windows }
+
+# Re-assert the target monitor on its own
+Center-Windows -Monitor 2
+```
+
+If windows still drift, the FancyZones re-apply behaviors are the trigger - `fancyzones_displayOrWorkAreaChange_moveWindows` and `fancyzones_zoneSetChange_moveWindows` in `FancyZones/settings.json`. Turning them off stops the drift at the source, but they are load-bearing for workspace layouts, so prefer the self-correcting path above.
+
 ### FancyZones Not Running
 
 **Problem:** Zone snapping doesn't work.


### PR DESCRIPTION
## Description

`Reset-Windows` sometimes left a handful of windows centered on the wrong monitor, and reported
complete success while doing it.

The pipeline is `Remove-VirtualDesktops` -> `Move-Windows` -> `Center-Windows` ->
`Focus-TerminalTab`. `Move-Windows` moved every window to the configured monitor correctly, but
`Center-Windows` ran last and re-derived each window's monitor from its **current** position. Any
window that something else moved in between was therefore centered on the monitor it had drifted
to, cementing the stray placement rather than correcting it.

The trigger is the desktop collapse. Removing the virtual desktops makes Windows migrate windows
off the removed desktops, and FancyZones reacts to those arrivals by restoring each window to its
remembered zone from `app-zone-history.json` - which records a monitor.
`fancyzones_displayOrWorkAreaChange_moveWindows` and `fancyzones_zoneSetChange_moveWindows` are
both on by default in the shipped FancyZones settings, and nothing excludes apps from it.

Verified with an A/B on the same 35 windows, back to back:

| Run | Windows centered on the wrong monitor |
| --- | ------------------------------------- |
| `Move-Windows -VirtualDesktop 1 -Monitor 2; Center-Windows` (31 real cross-desktop moves, 0 failures) | **0 / 35** |
| `Remove-VirtualDesktops` first, then the same two commands | **8 / 35** |

Ruled out along the way, each by experiment rather than reasoning: settle/timing races (a single
Chrome window's `SetWindowPos` holds from t+0 ms; ten windows moved in a 19 ms tight loop all
reported correct rects at +0 ms), batch congestion, the `VirtualDesktop` module's wrong-window
fallback (zero move failures in any run), and virtual-desktop work-area churn on its own.

Monitor identity is unreliable to begin with when two displays are the same model: identical panels
can report the same EDID code **and** the same serial number, so `applied-layouts.json` accumulates
several device identities for one physical monitor. `Get-DuplicateMonitorEdid` already detects the
EDID collision for `Apply-FancyZones`, but the zone history has no such guard. That is why the
fix does not try to out-argue FancyZones about which monitor is which - it simply re-asserts the
configured target last.

**What changed**

1. **`Center-Windows -Monitor`** (new parameter) centers every matched window on one explicit
   monitor instead of deriving one per window. `Reset-Windows` passes its configured monitor
   through. Because `Center-Windows` runs last, the reset is now self-correcting regardless of what
   moves a window mid-run. `-OnPrimary` still works and is now a mutually exclusive parameter set,
   so `Center-Terminal` is unaffected.
2. **`Resolve-TargetMonitor`** (new function) holds the monitor matching rules (1-based index,
   `Primary` / `Secondary` / `Monitor3`, or device name) that `Move-Windows` carried inline, so both
   callers resolve `-Monitor` through one path instead of two copies. It writes no console output -
   it returns the resolved monitor plus a ready-to-log `ErrorMessage`, leaving logging and control
   flow to the caller.
3. **Relative-placement clamp fixed.** `Move-Windows` read
   `[math]::Max(0, [math]::Min(1, $relativeX))`. Because the literals were integers, PowerShell
   bound the `(int, int)` overloads and rounded the relative fraction to 0 or 1, so **every**
   coordinate the pass produced was `0` or the work-area maximum - every window slammed into a
   corner, which is exactly what "preserve relative placement" exists to avoid. Confirmed live: all
   35 placements in the verbose log were corners. With double literals, a window at `(200, -1200)`
   now maps to `(200, 240)` instead of `(0, 0)`, and `(1400, 400)` to `(1400, 400)` instead of
   `(2540, 0)`.
4. **Monitor placement is verified.** `SetWindowPos` reports success for the *call*, so a window
   moved straight back by another window manager still counted as repositioned. `Move-Windows` now
   confirms each placement with `Wait-WindowRect` (the same verification the snap pipeline already
   uses) and re-applies once, with a bounded budget: 2 attempts, 150 ms each.
5. **Failures are no longer silent.** `Move-Windows` reported only moved / already-there /
   monitor-moved counts outside `Set-LogLevel Verbose`, so a partial pass looked identical to a
   complete one. Skipped desktop moves and windows that would not stay on the target monitor are
   now reported in normal mode with the affected windows listed. `Reset-Windows` also ignored
   `Remove-VirtualDesktops`' return value - a failed collapse changes how much work the move pass
   has to do, so it now warns and continues.

Items 3 to 5 are in the same functions and the same failure story as item 1, which is why they are
here rather than in a follow-up.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [ ] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

`Center-Windows` gains a parameter set, but `-OnPrimary` and the no-argument form behave exactly as
before, so nothing existing breaks.

## Quality bar

- [x] The change is **minimal and focused** (one logical change; reuses existing helpers, no duplication / DRY).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` using placeholder paths (`{Dev}`, `{User}`, `{MachineType}`, `{RepoRoot}`, `{AppData}`).

Notes:

- DRY: `Resolve-TargetMonitor` removes ~55 duplicated lines rather than adding a second copy of the
  matching rules, and the new verification reuses the existing `Wait-WindowRect`.
- No new configuration key: the behavior is driven by the existing
  `ResetAllWindowsDefaults.<MachineType>.Monitor`.

## Tests

```powershell
Run-Tests -TestName "Resolve-TargetMonitor"
Run-Tests -TestName "Reset-Windows"
Run-Tests -TestName "Move-Windows"
Run-Tests -TestName "Center-Windows"
Run-Tests -TestName "Center-Terminal"
```

`Center-Terminal` is included because it calls `Center-Windows -OnPrimary`, which is now a parameter
set.

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/`.
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text.
- [ ] N/A - no testable behavior changed (docs/chore only).

New and updated tests:

| File | Coverage |
| ---- | -------- |
| `Resolve-TargetMonitor.Tests.ps1` (new) | 11 cases: index / `Primary` / label / device name, out-of-range, unresolvable, empty and whitespace specifiers, on-demand vs supplied monitor list, no monitors detected. |
| `Reset-Windows.Tests.ps1` (new) | 8 cases: configured monitor reaches `Center-Windows`, omitted for machines without targeting, explicit override, empty string, `Default` fallback, cleanup-failure warning, step order. |
| `Move-Windows.Tests.ps1` (updated) | The existing monitor assertion is pinned to the exact relative coordinates `(2120, 200)`, which **fails against the old int-literal clamp** (it produced the corner `(1920, 0)`); plus a new case for placement that never holds -> 2 attempts and a normal-mode warning. |
| `Center-Windows.Tests.ps1` (updated) | New `-Monitor` context: by index, by label, already on target, unresolvable monitor errors and centers nothing, empty string means no targeting. |

## Documentation & manifests

- [x] I updated `docs/modules/<Module>.md` for any added/renamed/removed/changed function.
- [x] I updated the module `.psd1` `FunctionsToExport`.
- [ ] I updated `docs/docs_overview.md` (and `docs/_sidebar.md` if a page was added/removed).
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds.
- [ ] N/A - no exported function changed.

Docs updated:

- `docs/modules/window.md` - new `Resolve-TargetMonitor` entry (placed alphabetically between
  `Resolve-PositionedWindowHandle` and `Save-CurrentLayout`), plus updated `Center-Windows` (new
  parameter, description, parameter table, examples, and a note on why an explicit target matters),
  `Move-Windows` (verification, positional-index caveat, failure reporting, cross-references), and
  `Reset-Windows` (monitor pass-through, cleanup warning).
- `docs/reference/troubleshooting.md` - new entry "Windows Land On The Wrong Monitor After
  Reset-Windows" describing the symptom, the FancyZones/duplicate-EDID mechanism, and the
  confirmation commands.

## Tested on

- Windows version: Windows 11 Pro 25H2 (build 26200)
- PowerShell version: 7.6.3
- Machine type(s): PC via a private fork (two 3440x1440 displays stacked vertically, identical model)

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] This PR contains no secrets or personal data (tokens, real paths/hostnames/emails).
