### PR TITLE
Add the machine-local app list overlay

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,13 +14,14 @@
 # deep-merged over the base at load. Upstream never tracks that file, so it never conflicts. (Commit it
 # in your fork if you want it to sync across your machines.)
 #
+# The three app-list CSVs used to be merge=ours and deliberately no longer are. They now work exactly
+# like Configuration.psd1: WinGetApps.csv / ScoopApps.csv / ChocolateyApps.csv stay the generic base and
+# SHOULD track upstream, and your own apps go in the sibling <name>.local.csv overlay, which Import-AppCsv
+# layers over the base at read time. Upstream never tracks the overlays, so they never conflict - and
+# because the base is no longer pinned, your fork keeps receiving upstream's base-list changes.
+#
 # NOTE for WinuX maintainers: these rules apply to this repo too, so a LOCAL merge of a PR that edits
 # one of these files would keep the repo's version. Merge such PRs on GitHub, or reconcile by hand.
-
-# Application install lists - each fork curates its own; WinuX ships a minimal example set.
-Windows/PowerShell/Modules/Bootstrap/Data/WinGetApps.csv       merge=ours
-Windows/PowerShell/Modules/Bootstrap/Data/ScoopApps.csv        merge=ours
-Windows/PowerShell/Modules/Bootstrap/Data/ChocolateyApps.csv   merge=ours
 
 # Personal payload configs - your real values; WinuX ships generic/blank templates.
 Git/.gitconfig                                                 merge=ours

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,18 @@ Obsidian/workspace.json
 # identity and paths, and must never be published even if a stray/older copy sits in another dir.
 Configuration.local.psd1
 
+# Personal app-list overlays - exactly the same idea as Configuration.local.psd1, for the three
+# app CSVs. Import-AppCsv layers <name>.local.csv over the committed <name>.csv at read time and
+# Save-AppCsvOverlay writes it, so a fork's own app choices never touch a tracked file. WinuX
+# ships only the base lists, so the overlays are ignored here. A fork that runs several machines
+# can commit its own overlays (see docs/contributing/fork-model.md) - upstream never tracks them,
+# so committing them downstream never conflicts on a pull.
+Windows/PowerShell/Modules/Bootstrap/Data/*.local.csv
+
+# The one-click undo copies the writers leave behind. Noise everywhere, upstream and forks alike.
+Configuration.local.psd1.bak
+Windows/PowerShell/Modules/Bootstrap/Data/*.local.csv.bak
+
 # Logging module - generated logs (kept locally for inspection, never committed)
 Windows/PowerShell/Modules/Logging/Logs/*
 !Windows/PowerShell/Modules/Logging/Logs/.gitkeep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.21] - 2026-08-02
+
+### Added
+
+- `Import-AppCsv` (Bootstrap module): the single read path for the three app lists. It parses the committed CSV named by `BootstrapConfig.DataFiles`, layers a sibling machine-local `<name>.local.csv` over it when one exists, and returns the combined active rows. This is for app lists exactly what `Configuration.local.psd1` is for settings, and it exists for the same reason: until now a fork's own apps could only live in the tracked CSVs, so every fork edited a file upstream also owns. The `merge=ours` attribute those three files carried made that survivable but not good - it pinned the fork's copy permanently, which meant the fork never received an upstream base-list change either. With the overlay the two concerns separate cleanly: the committed CSV stays the shipped baseline upstream can keep improving, and everything chosen for this machine sits beside it. An overlay row whose `App` matches a base row **replaces** it (pin a version, change the scope, re-target the `Machine` column), a new `App` is **added** after the shipped rows so the committed install order is preserved, and an `App` written as `-<id>` **removes** a shipped row - without which there would be no way to opt out of an app the base ships, since a layer that can only add or replace cannot subtract. Matching is case-insensitive because package ids are; a removal beats a replacement of the same `App` whichever order the rows are written in; comment and blank rows are dropped from both files, which is the filtering all three installers previously each did for themselves. A missing overlay is the normal case and not an error; a missing base file is, since it is tracked.
+- `Save-AppCsvOverlay` (Configuration module): the only writer of an overlay. It replaces `<name>.local.csv` wholesale from the rows it is given, having first proved - against a candidate held in memory, so a refusal leaves the live file byte-identical - that every row carries an `App`, that every `Machine` cell is `All` or known machine types joined with `/` (each token checked, since one good token would otherwise hide a typo in the rest of the cell, and a cell that matches nothing would sit in the overlay looking installed and never install), and that the result round-trips through `Import-Csv` with the same row count. Only then is the previous overlay copied to `<name>.local.csv.bak` and the candidate moved over it, staged in the destination folder so the replace is a same-volume rename no reader can observe half-written. The column header is written as line 1 with the comment banner after it, because `Import-Csv` takes line 1 as the header unconditionally - a leading comment would become the column names and the whole overlay would then parse as empty rows and be silently discarded. Columns come from the committed file's header, so an overlay can never drift into a shape the installer does not read.
+
+### Changed
+
+- `Install-WinGetApps`, `Install-ScoopApps` and `Install-ChocolateyApps` (Application module) read their list through `Import-AppCsv` instead of a plain `Import-Csv`, so the machine-local overlay applies and the comment/blank-row filtering lives in one place instead of being repeated three times. No behaviour changes for a setup without an overlay.
+- `Get-PinnedApps` (System module) reads through `Import-AppCsv` as well, and takes `-DataFileKey` (`WinGetApps` / `ScoopApps` / `ChocolateyApps`) in place of `-CsvFileName`. This is what keeps `Upgrade-All`'s pinning honest once overlays exist, and it matters in both directions: a version pinned only in the overlay is invisible in the committed file, so a direct reader would let `Upgrade-All` upgrade straight past the pin - the exact outcome pinning exists to prevent - and an app the overlay removed would still be reported as pinned and handed to `winget pin add`.
+- The three committed app lists now hold only the software WinuX itself needs, with their commented example rows replaced by a pointer to the overlay. The examples were an invitation to edit a tracked file, which is precisely what the overlay removes the need for; the catalogue of suggested package ids moved to `docs/reference/software-list.md`.
+- `.gitignore` ignores `Windows/PowerShell/Modules/Bootstrap/Data/*.local.csv` and the writers' `.bak` files, exactly as it ignores `Configuration.local.psd1`. A fork that runs several machines can commit its own overlays; upstream never tracks those paths, so committing them downstream never conflicts on a pull.
+
+### Breaking
+
+- The `merge=ours` attribute is removed from `WinGetApps.csv`, `ScoopApps.csv` and `ChocolateyApps.csv`. They are now ordinary upstream-tracked files, like `Configuration.psd1`, which is what lets a fork keep receiving base-list improvements instead of pinning its own copy forever. **A fork that still keeps its apps in the committed CSVs will have them overwritten by its next `git merge upstream/master`.** Migrating is a one-time copy: move your added rows into a new `<name>.local.csv` (same header on line 1), write `-<id>` rows for any shipped app you had deleted, then restore the committed files with `git checkout upstream/master -- Windows/PowerShell/Modules/Bootstrap/Data/`. The step-by-step note is in [the fork model](docs/contributing/fork-model.md#keeping-your-own-app-lists-the-localcsv-overlay). The payload configs (`Git/.gitconfig`, `NuGet/nuget.config`, `Firefox/user.js`, `docs/custom/README.md`) keep `merge=ours`; they have no base-plus-override split and are wholly the fork's.
+
 ## [0.1.20] - 2026-08-01
 
 ### Added
@@ -300,7 +318,8 @@ The first public release of WinuX.
 - Governance and licensing: MIT license, contributor guide, code of conduct, security policy, and third-party notices.
 - CI: the full Pester suite on every pull request, and a release workflow that builds `WinuX.exe` from every version tag and attaches it - with a SHA-256 checksum - to the GitHub release.
 
-[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.20...HEAD
+[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.21...HEAD
+[0.1.21]: https://github.com/IvanPavlak/WinuX/compare/v0.1.20...v0.1.21
 [0.1.20]: https://github.com/IvanPavlak/WinuX/compare/v0.1.19...v0.1.20
 [0.1.19]: https://github.com/IvanPavlak/WinuX/compare/v0.1.18...v0.1.19
 [0.1.18]: https://github.com/IvanPavlak/WinuX/compare/v0.1.17...v0.1.18

--- a/Windows/PowerShell/Modules/Application/Functions/Install-ChocolateyApps.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Install-ChocolateyApps.ps1
@@ -4,10 +4,11 @@ function Install-ChocolateyApps {
 		Installs Chocolatey-managed apps from the WinuX CSV, filtered by machine type.
 
 	.DESCRIPTION
-		Reads the app list from the CSV file at `BootstrapConfig.DataFiles.ChocolateyApps`
-		in Configuration.psd1. Each row specifies an app ID and the machine types it applies
-		to ("All", "PC", "Laptop", etc.). Apps for the current machine type and All-type apps
-		are installed; others are skipped.
+		Reads the app list through `Import-AppCsv`, which parses the committed CSV named by
+		`BootstrapConfig.DataFiles.ChocolateyApps` in Configuration.psd1 and layers the machine-local
+		`ChocolateyApps.local.csv` over it. Each row specifies an app ID and the machine types it
+		applies to ("All", "PC", "Laptop", etc.). Apps for the current machine type and All-type
+		apps are installed; others are skipped.
 
 		Requires administrator privileges. Called automatically by Bootstrap.
 
@@ -21,8 +22,9 @@ function Install-ChocolateyApps {
 
 	$MachineType = DetermineMachineType
 
-	$csvPath = Join-Path -Path $MachineSpecificPaths.Projects.Self.Root -ChildPath $global:Configuration.BootstrapConfig.DataFiles.ChocolateyApps
-	$chocoApps = Import-Csv $csvPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_.App) -and -not $_.App.TrimStart().StartsWith('#') }
+	# Import-AppCsv layers the machine-local ChocolateyApps.local.csv over the committed list, so a
+	# fork's own app choices apply without the tracked CSV ever being edited.
+	$chocoApps = @(Import-AppCsv -DataFileKey ChocolateyApps)
 
 	foreach ($app in $chocoApps) {
 		if (-not (Test-MachineTypeScope -Scope "$($app.Machine)" -MachineType $MachineType -Context "ChocolateyApps.csv [$($app.App)]")) { continue }

--- a/Windows/PowerShell/Modules/Application/Functions/Install-ScoopApps.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Install-ScoopApps.ps1
@@ -4,10 +4,11 @@ function Install-ScoopApps {
 		Installs Scoop-managed apps from the WinuX CSV, filtered by machine type.
 
 	.DESCRIPTION
-		Reads the app list from the CSV file at `BootstrapConfig.DataFiles.ScoopApps` in
-		Configuration.psd1. Each row specifies an app name, optional bucket, and the machine
-		types it applies to. Apps for the current machine type and All-type apps are installed;
-		others are skipped.
+		Reads the app list through `Import-AppCsv`, which parses the committed CSV named by
+		`BootstrapConfig.DataFiles.ScoopApps` in Configuration.psd1 and layers the machine-local
+		`ScoopApps.local.csv` over it. Each row specifies an app name, optional bucket, and the
+		machine types it applies to. Apps for the current machine type and All-type apps are
+		installed; others are skipped.
 
 		Requires administrator privileges. Called automatically by Bootstrap.
 
@@ -21,8 +22,9 @@ function Install-ScoopApps {
 
 	$MachineType = DetermineMachineType
 
-	$csvPath = Join-Path -Path $MachineSpecificPaths.Projects.Self.Root -ChildPath $global:Configuration.BootstrapConfig.DataFiles.ScoopApps
-	$scoopApps = Import-Csv $csvPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_.App) -and -not $_.App.TrimStart().StartsWith('#') }
+	# Import-AppCsv layers the machine-local ScoopApps.local.csv over the committed list, so a fork's
+	# own app choices apply without the tracked CSV ever being edited.
+	$scoopApps = @(Import-AppCsv -DataFileKey ScoopApps)
 
 	$installedApps = @()
 	try {

--- a/Windows/PowerShell/Modules/Application/Functions/Install-WingetApps.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Install-WingetApps.ps1
@@ -4,10 +4,11 @@ function Install-WinGetApps {
 		Installs WinGet-managed apps from the WinuX CSV, filtered by machine type.
 
 	.DESCRIPTION
-		Reads the app list from the CSV file at `BootstrapConfig.DataFiles.WinGetApps` in
-		Configuration.psd1. Each row specifies an app ID, installation scope (machine/user/default),
-		and the machine types it applies to. Apps for the current machine type and All-type apps
-		are installed; others are skipped.
+		Reads the app list through `Import-AppCsv`, which parses the committed CSV named by
+		`BootstrapConfig.DataFiles.WinGetApps` in Configuration.psd1 and layers the machine-local
+		`WinGetApps.local.csv` over it. Each row specifies an app ID, installation scope
+		(machine/user/default), and the machine types it applies to. Apps for the current machine
+		type and All-type apps are installed; others are skipped.
 
 		Requires administrator privileges. Called automatically by Bootstrap.
 
@@ -21,8 +22,9 @@ function Install-WinGetApps {
 
 	$MachineType = DetermineMachineType
 
-	$csvPath = Join-Path -Path $MachineSpecificPaths.Projects.Self.Root -ChildPath $global:Configuration.BootstrapConfig.DataFiles.WinGetApps
-	$wingetApps = Import-Csv $csvPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_.App) -and -not $_.App.TrimStart().StartsWith('#') }
+	# Import-AppCsv layers the machine-local WinGetApps.local.csv over the committed list, so a fork's
+	# own app choices apply without the tracked CSV ever being edited.
+	$wingetApps = @(Import-AppCsv -DataFileKey WinGetApps)
 
 	# Accept every WinGet source agreement up front, non-interactively, so no per-app call can block
 	# on WinGet's first-run prompt. The `msstore` source shows a hard, one-time agreement (including a

--- a/Windows/PowerShell/Modules/Bootstrap/Bootstrap.psd1
+++ b/Windows/PowerShell/Modules/Bootstrap/Bootstrap.psd1
@@ -8,6 +8,7 @@
 		'DetermineMachineType',
 		'Expand-ConfigPaths',
 		'Expand-Hashtable',
+		'Import-AppCsv',
 		'Initialize-Configuration',
 		'Install-WinGetPackageManager',
 		'Invoke-PersonalSteps',

--- a/Windows/PowerShell/Modules/Bootstrap/Data/ChocolateyApps.csv
+++ b/Windows/PowerShell/Modules/Bootstrap/Data/ChocolateyApps.csv
@@ -1,6 +1,22 @@
 App,Version,Params,Force,Machine
 
-# Chocolatey packages. Columns: App,Version,Params,Force,Machine
-# (Machine = "All", "Test", or your own types, combinable like "PC/Laptop").
-# Empty by default - add your own below, e.g.:
-#someapp,latest,,false,All
+# Chocolatey packages. WinuX needs none of its own, so this list ships empty.
+#
+# DO NOT add your own apps here. This file is upstream's baseline and tracks WinuX, so an edit
+# here is a conflict waiting for the next `git merge upstream/master`. Your own apps belong in
+# the sibling ChocolateyApps.local.csv, which Import-AppCsv layers over this list at read time
+# and upstream never tracks:
+#
+#   App,Version,Params,Force,Machine
+#
+#   nvm,latest,,false,All    # a new App is added after any rows below
+#   -someapp,latest,,false,All   # a leading - opts this machine out of a row below
+#
+# See docs/reference/software-list.md for the full overlay reference.
+#
+# Columns:
+#   App     chocolatey package id
+#   Version empty for latest, or a specific version
+#   Params  passed through to choco install --params (quote it if it contains a comma)
+#   Force   true / false
+#   Machine where to install: "All", "Test", or your own types, combinable like "PC/Laptop"

--- a/Windows/PowerShell/Modules/Bootstrap/Data/ScoopApps.csv
+++ b/Windows/PowerShell/Modules/Bootstrap/Data/ScoopApps.csv
@@ -1,5 +1,21 @@
 App,Version,Global,Machine
 
-# Scoop packages. Columns: App,Version,Global,Machine
-# (Machine = "All", "Test", or your own types, combinable like "PC/Laptop").
-# Add your own below.
+# Scoop packages. WinuX needs none of its own, so this list ships empty.
+#
+# DO NOT add your own apps here. This file is upstream's baseline and tracks WinuX, so an edit
+# here is a conflict waiting for the next `git merge upstream/master`. Your own apps belong in
+# the sibling ScoopApps.local.csv, which Import-AppCsv layers over this list at read time and
+# upstream never tracks:
+#
+#   App,Version,Global,Machine
+#
+#   ripgrep,latest,false,All   # a new App is added after any rows below
+#   -neovim,latest,false,All   # a leading - opts this machine out of a row below
+#
+# See docs/reference/software-list.md for the full overlay reference.
+#
+# Columns:
+#   App     scoop package name (bucket/name for a non-default bucket)
+#   Version "latest" or a specific version
+#   Global  true / false (install for all users)
+#   Machine where to install: "All", "Test", or your own types, combinable like "PC/Laptop"

--- a/Windows/PowerShell/Modules/Bootstrap/Data/WinGetApps.csv
+++ b/Windows/PowerShell/Modules/Bootstrap/Data/WinGetApps.csv
@@ -1,7 +1,20 @@
 App,Version,Scope,Interactive,Source,Machine
 
-# Minimal essential set so a fresh WinuX install works end-to-end. (Git is installed
-# separately by Install-Git; the Nerd Font by Configure-NerdFont.) Add your own apps below.
+# The minimal set a WinuX install needs to work end-to-end. (Git is installed separately by
+# Install-Git; the Nerd Font by Configure-NerdFont.)
+#
+# DO NOT add your own apps here. This file is upstream's baseline and tracks WinuX, so an edit
+# here is a conflict waiting for the next `git merge upstream/master`. Your own apps belong in
+# the sibling WinGetApps.local.csv, which Import-AppCsv layers over this list at read time and
+# upstream never tracks:
+#
+#   App,Version,Scope,Interactive,Source,Machine
+#
+#   Obsidian.Obsidian,Latest,d,n,w,All      # a new App is added after the rows below
+#   Microsoft.PowerShell,7.4.6,d,n,w,All    # an App below is replaced (here to pin a version)
+#   -Microsoft.PowerToys,Latest,d,n,w,All   # a leading - opts this machine out of a row below
+#
+# See docs/reference/software-list.md for the full overlay reference.
 #
 # Columns:
 #   App         winget package id (or msstore product id with Source=s)
@@ -10,7 +23,6 @@ App,Version,Scope,Interactive,Source,Machine
 #   Interactive y / n
 #   Source      w (winget), s (msstore)
 #   Machine     where to install: "All", "Test", or your own types, combinable like "PC/Laptop"
-# --- Dependecies Required for full WinuX utilization 
 Microsoft.WindowsTerminal,Latest,d,n,w,All
 Microsoft.PowerShell,Latest,d,n,w,All
 JanDeDobbeleer.OhMyPosh,Latest,d,n,w,All
@@ -18,31 +30,3 @@ fastfetch,Latest,d,n,w,All
 Microsoft.VisualStudioCode,Latest,d,n,w,All
 Mozilla.Firefox,Latest,d,n,w,All
 Microsoft.PowerToys,Latest,d,n,w,All
-
-# --- Add your own applications below. Examples (uncomment what you want): ---
-# Editors / dev toolchains:
-#Neovim.Neovim,Latest,d,n,w,All
-#Microsoft.VisualStudio.Community,Latest,d,n,w,All
-#Microsoft.DotNet.SDK.9,Latest,d,n,w,All
-#OpenJS.NodeJS.LTS,Latest,d,n,w,All
-#Python.Python.3.13,Latest,d,n,w,All
-#Docker.DockerDesktop,Latest,d,n,w,All
-#Oracle.VirtualBox,Latest,d,n,w,All
-# CLI utilities:
-#7zip.7zip,Latest,d,n,w,All
-#BurntSushi.ripgrep.MSVC,Latest,d,n,w,All
-#junegunn.fzf,Latest,d,n,w,All
-#ajeetdsouza.zoxide,Latest,d,n,w,All
-#sharkdp.fd,Latest,d,n,w,All
-#jqlang.jq,Latest,d,n,w,All
-#JesseDuffield.lazygit,Latest,d,n,w,All
-# Apps:
-#Obsidian.Obsidian,Latest,d,n,w,All
-#Notepad++.Notepad++,Latest,d,n,w,All
-#Microsoft.PowerToys,Latest,d,n,w,All
-#Mozilla.Firefox,Latest,d,n,w,All
-#VideoLAN.VLC,Latest,d,n,w,All
-# Tor Browser (used by Open-SecureBrowser) always installs as a portable build onto the
-# Desktop; move the "Tor Browser" folder to "{User}\Tor Browser" - the path the default
-# Universal.Browsers.Tor entry expects - so Open-Browser can launch it.
-#TorProject.TorBrowser,Latest,d,n,w,All

--- a/Windows/PowerShell/Modules/Bootstrap/Functions/Import-AppCsv.ps1
+++ b/Windows/PowerShell/Modules/Bootstrap/Functions/Import-AppCsv.ps1
@@ -1,0 +1,159 @@
+function Import-AppCsv {
+	<#
+	.SYNOPSIS
+		Reads an app list CSV, layering a machine-local overlay over the committed one.
+
+	.DESCRIPTION
+		The single read path for the three app lists. It parses the committed CSV named by
+		`BootstrapConfig.DataFiles`, then layers a sibling `<name>.local.csv` over it when one exists,
+		and returns the combined active rows.
+
+		This mirrors, for app lists, exactly what `Configuration.local.psd1` does for settings. The
+		committed CSV stays the shipped baseline that upstream can keep improving, and everything a
+		person chose for this machine lives in the overlay beside it. A fork therefore never has to edit
+		a tracked file to change its own app list, and pulling upstream never conflicts on one.
+
+		Layering rules:
+
+		- An overlay row whose `App` matches a base row **replaces** it. That is what lets the overlay
+		  pin a version, change the install scope, or re-target a machine without touching the base.
+		  Matching is case-insensitive, because package ids are.
+		- An overlay row with a new `App` is **added**.
+		- An overlay row whose `App` is `-` (or blank after the marker) **removes** the base row. Without
+		  this there would be no way to opt out of a shipped app, since a layer that can only add or
+		  replace cannot subtract.
+		- Comment rows (`App` starting with `#`) and blank `App` cells are dropped from both files, which
+		  is what the callers used to do individually.
+
+		Row order is base-first, then overlay-only additions, so the shipped install order is preserved
+		and a user's own apps follow.
+
+		A missing overlay is the normal case and is not an error. A missing base file is, since it is a
+		tracked file the repository is supposed to ship.
+
+	.PARAMETER DataFileKey
+		Which list to read: `WinGetApps`, `ScoopApps` or `ChocolateyApps`. Resolved through
+		`BootstrapConfig.DataFiles`, so the location stays configuration-driven.
+
+	.PARAMETER RepoRoot
+		Repository root the relative data-file path is resolved against. Defaults to the running
+		repository.
+
+	.EXAMPLE
+		Import-AppCsv -DataFileKey WinGetApps
+		Returns the active WinGet rows, with any machine-local overlay applied.
+
+	.EXAMPLE
+		Import-AppCsv -DataFileKey ScoopApps | Where-Object { $_.Global -eq 'true' }
+		Filters the combined list the same way a caller would filter a plain Import-Csv result.
+
+	.NOTES
+		This only reads. `Save-AppCsvOverlay` writes the overlay, and the committed CSV is never
+		modified by either.
+	#>
+	[CmdletBinding()]
+	[OutputType([psobject[]])]
+	param(
+		[Parameter(Mandatory = $true, Position = 0)]
+		[ValidateSet('WinGetApps', 'ScoopApps', 'ChocolateyApps')]
+		[string]$DataFileKey,
+
+		[Parameter(Mandatory = $false)]
+		[string]$RepoRoot
+	)
+
+	if (-not $RepoRoot) {
+		$RepoRoot = $global:MachineSpecificPaths.Projects.Self.Root
+	}
+
+	if (-not $RepoRoot) {
+		throw "Cannot locate the repository - pass -RepoRoot."
+	}
+
+	$relativePath = $global:Configuration.BootstrapConfig.DataFiles.$DataFileKey
+	if ([string]::IsNullOrWhiteSpace($relativePath)) {
+		throw "BootstrapConfig.DataFiles.$DataFileKey is not configured."
+	}
+
+	$basePath = Join-Path -Path $RepoRoot -ChildPath $relativePath
+	if (-not (Test-Path -Path $basePath)) {
+		throw "App list not found => [$basePath]"
+	}
+
+	# The overlay sits beside the base file: WinGetApps.csv -> WinGetApps.local.csv
+	$overlayPath = [System.IO.Path]::ChangeExtension($basePath, $null) + 'local.csv'
+
+	$baseRows = @(Import-Csv -Path $basePath | Where-Object {
+			-not [string]::IsNullOrWhiteSpace($_.App) -and -not $_.App.TrimStart().StartsWith('#')
+		})
+
+	# The casts on the two no-overlay returns are what keep every exit path on the declared OutputType:
+	# `@(...)` is an Object[], while the layered path below returns psobject[] from the List. Without
+	# them the function advertises one element type and hands back another depending on whether an
+	# overlay happened to exist.
+	if (-not (Test-Path -Path $overlayPath)) {
+		return [psobject[]]$baseRows
+	}
+
+	$overlayRows = @(Import-Csv -Path $overlayPath | Where-Object {
+			-not [string]::IsNullOrWhiteSpace($_.App) -and -not $_.App.TrimStart().StartsWith('#')
+		})
+
+	if ($overlayRows.Count -eq 0) {
+		return [psobject[]]$baseRows
+	}
+
+	# Index the overlay by app id so a base row can be replaced or removed in one pass.
+	$replacements = @{}
+	$removals = @{}
+
+	foreach ($row in $overlayRows) {
+		$appId = "$($row.App)".Trim()
+
+		# A leading '-' marks a removal, which is the only way to opt out of a shipped app.
+		if ($appId.StartsWith('-')) {
+			$target = $appId.Substring(1).Trim()
+			if (-not [string]::IsNullOrWhiteSpace($target)) {
+				$removals[$target.ToLowerInvariant()] = $true
+			}
+			continue
+		}
+
+		$replacements[$appId.ToLowerInvariant()] = $row
+	}
+
+	$result = [System.Collections.Generic.List[psobject]]::new()
+	$consumed = @{}
+
+	foreach ($row in $baseRows) {
+		$key = "$($row.App)".Trim().ToLowerInvariant()
+
+		if ($removals.ContainsKey($key)) { continue }
+
+		if ($replacements.ContainsKey($key)) {
+			$result.Add($replacements[$key])
+			$consumed[$key] = $true
+			continue
+		}
+
+		$result.Add($row)
+	}
+
+	# Overlay rows that matched nothing in the base are this machine's own additions, kept in the
+	# order the overlay lists them and appended after the shipped set.
+	foreach ($row in $overlayRows) {
+		$appId = "$($row.App)".Trim()
+		if ($appId.StartsWith('-')) { continue }
+
+		$key = $appId.ToLowerInvariant()
+		if ($consumed.ContainsKey($key)) { continue }
+		if ($removals.ContainsKey($key)) { continue }
+
+		$result.Add($row)
+		$consumed[$key] = $true
+	}
+
+	Write-LogDebug "[$DataFileKey] $($baseRows.Count) base row(s), $($overlayRows.Count) overlay row(s) => $($result.Count) active"
+
+	return $result.ToArray()
+}

--- a/Windows/PowerShell/Modules/Configuration/Configuration.psd1
+++ b/Windows/PowerShell/Modules/Configuration/Configuration.psd1
@@ -1,7 +1,7 @@
 @{
 	ModuleVersion     = "1.0"
 	Author            = "Ivan Pavlak"
-	Description       = "Functions for modifying Configuration.psd1 and window layout files"
+	Description       = "Functions for modifying Configuration.psd1, window layout files, and the machine-local app list overlays"
 	RootModule        = "Configuration.psm1"
 	RequiredModules   = @()
 	FunctionsToExport = @(
@@ -13,6 +13,7 @@
 		'Add-Project',
 		'Add-SymbolicLink',
 		'Add-WindowLayout',
+		'Save-AppCsvOverlay',
 		'Test-ConfigurationSchema'
 	)
 }

--- a/Windows/PowerShell/Modules/Configuration/Functions/Save-AppCsvOverlay.ps1
+++ b/Windows/PowerShell/Modules/Configuration/Functions/Save-AppCsvOverlay.ps1
@@ -1,0 +1,225 @@
+function Save-AppCsvOverlay {
+	<#
+	.SYNOPSIS
+		Writes the machine-local app list overlay, validating before it replaces anything.
+
+	.DESCRIPTION
+		The only function that writes an app overlay. It replaces `<name>.local.csv` wholesale from the
+		rows it is given, having first proved the result parses and that every row is something the
+		installers can actually act on.
+
+		Only the overlay is written. The committed CSV is read to validate against and never modified,
+		which is what keeps a fork's app choices out of a tracked file and stops an upstream pull from
+		conflicting on one. `Import-AppCsv` then layers what is written here over the shipped list,
+		exactly as the shell layers `Configuration.local.psd1` over `Configuration.psd1`.
+
+		Validation, in order, all against a candidate in memory:
+
+		1. Every row must carry a non-empty `App`.
+		2. Every `Machine` cell must be composed of `All` or known machine types, joined with `/`. A blank
+		   or unknown token silently matches nothing, so a row with one would look installed and never be,
+		   which is the most confusing possible outcome.
+		3. The candidate must round-trip through `Import-Csv` and come back with the same row count.
+
+		Only then is the existing overlay copied to `<name>.local.csv.bak` and the candidate moved over
+		it, staged in the destination folder so the replace is a same-volume rename a reader can never
+		observe half-written. Restoring the `.bak` is a complete undo.
+
+		A removal is expressed as a row whose `App` is `-<id>`, which is how the overlay opts out of an
+		app the committed list ships. `Import-AppCsv` applies that; nothing here needs to know the base
+		file's contents beyond validating machine tokens.
+
+		Passing no rows writes an empty overlay (header only), which is the correct way to say "this
+		machine adds nothing", and is different from deleting the overlay.
+
+	.PARAMETER DataFileKey
+		Which list to write: `WinGetApps`, `ScoopApps` or `ChocolateyApps`.
+
+	.PARAMETER Row
+		The overlay rows. Each must have an `App`; the remaining columns are taken from the committed
+		file's header so the shape always matches what the installer reads.
+
+	.PARAMETER RepoRoot
+		Repository root the data-file path is resolved against. Defaults to the running repository.
+
+	.PARAMETER NoBackup
+		Skip the `.bak` copy. Not recommended; it removes the one-click undo.
+
+	.EXAMPLE
+		Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(
+			@{ App = 'Obsidian.Obsidian'; Version = 'Latest'; Scope = 'd'; Interactive = 'n'; Source = 'w'; Machine = 'All' }
+		)
+		Adds one app for every machine, leaving the committed list untouched.
+
+	.EXAMPLE
+		Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = '-Microsoft.PowerToys'; Machine = 'All' })
+		Opts this machine out of a shipped app.
+
+	.EXAMPLE
+		Save-AppCsvOverlay -DataFileKey ScoopApps -Row @() -WhatIf
+		Validates and reports what would be written without writing it.
+
+	.NOTES
+		Errors are raised as exceptions so a caller can surface them; progress goes to `Write-Verbose`.
+		This keeps the writer usable from an interactive shell and from the compiled installer alike.
+	#>
+	[CmdletBinding(SupportsShouldProcess = $true)]
+	[OutputType([psobject])]
+	param(
+		[Parameter(Mandatory = $true, Position = 0)]
+		[ValidateSet('WinGetApps', 'ScoopApps', 'ChocolateyApps')]
+		[string]$DataFileKey,
+
+		[Parameter(Mandatory = $false, Position = 1)]
+		[AllowEmptyCollection()]
+		[hashtable[]]$Row = @(),
+
+		[Parameter(Mandatory = $false)]
+		[string]$RepoRoot,
+
+		[Parameter(Mandatory = $false)]
+		[switch]$NoBackup
+	)
+
+	# A supplied-but-blank -RepoRoot is an accident, never an intention, and the fallback below is this
+	# machine's own clone - so treating blank as "use the fallback" would quietly write an overlay beside
+	# the tracked app lists when the caller meant to work in a sandbox. Omitting the parameter still uses
+	# the fallback, which is what an interactive caller wants.
+	if ($PSBoundParameters.ContainsKey('RepoRoot') -and [string]::IsNullOrWhiteSpace($RepoRoot)) {
+		throw "-RepoRoot was given but is empty. Pass a real path, or omit the parameter to use this machine's own clone."
+	}
+
+	if (-not $RepoRoot) {
+		$RepoRoot = $global:MachineSpecificPaths.Projects.Self.Root
+	}
+	if (-not $RepoRoot) {
+		throw "Cannot locate the repository - pass -RepoRoot."
+	}
+
+	$relativePath = $global:Configuration.BootstrapConfig.DataFiles.$DataFileKey
+	if ([string]::IsNullOrWhiteSpace($relativePath)) {
+		throw "BootstrapConfig.DataFiles.$DataFileKey is not configured."
+	}
+
+	$basePath = Join-Path -Path $RepoRoot -ChildPath $relativePath
+	if (-not (Test-Path -Path $basePath)) {
+		throw "App list not found => [$basePath]"
+	}
+
+	$overlayPath = [System.IO.Path]::ChangeExtension($basePath, $null) + 'local.csv'
+
+	# The committed file's header defines the column order, so the overlay can never drift into a shape
+	# the installer does not read.
+	$headerLine = @(Get-Content -Path $basePath -TotalCount 1)[0]
+	if ([string]::IsNullOrWhiteSpace($headerLine)) {
+		throw "The app list [$basePath] has no header row."
+	}
+	$columns = @($headerLine -split ',' | ForEach-Object { $_.Trim() })
+
+	$validTypes = @()
+	if ($global:Configuration.ValidMachineTypes) {
+		$validTypes = @($global:Configuration.ValidMachineTypes)
+	}
+
+	# --- validate every row before anything is written -------------------------------------------
+	$rowIndex = 0
+	foreach ($entry in $Row) {
+		$appId = "$($entry.App)".Trim()
+		if ([string]::IsNullOrWhiteSpace($appId)) {
+			throw "Row $rowIndex has no App id, so there would be nothing to install."
+		}
+
+		$machineCell = "$($entry.Machine)".Trim()
+		if ([string]::IsNullOrWhiteSpace($machineCell)) {
+			throw "Row $rowIndex ($appId) is not assigned to any PC, so it would never install. Use All, or name a machine type."
+		}
+
+		foreach ($token in ($machineCell -split '/')) {
+			$trimmed = $token.Trim()
+			if ($trimmed -eq 'All') { continue }
+			if ($validTypes -notcontains $trimmed) {
+				throw "Row $rowIndex ($appId) targets '$trimmed', which is not a known machine type, so it would never install."
+			}
+		}
+
+		$rowIndex++
+	}
+
+	# --- build the candidate ----------------------------------------------------------------------
+	# The COLUMN row comes first and the commentary after it, matching the committed files. Import-Csv
+	# takes line 1 as the header unconditionally, so a leading comment would be read as the header and
+	# every real row would parse with a bogus column name and an empty App.
+	$lines = [System.Collections.Generic.List[string]]::new()
+	$lines.Add(($columns -join ','))
+	$lines.Add('')
+	$lines.Add("# $DataFileKey.local.csv - this machine's own app choices, layered over the committed list.")
+	$lines.Add('# Written by Save-AppCsvOverlay. The committed CSV is never edited.')
+	$lines.Add('# A row replaces a matching base row; a new App is added; an App written as -<id> removes one.')
+	$lines.Add('')
+
+	foreach ($entry in $Row) {
+		$cells = foreach ($column in $columns) {
+			$value = "$($entry[$column])"
+			# Quote only when a cell would otherwise break the row apart.
+			if ($value -match '[",]') { '"' + ($value -replace '"', '""') + '"' } else { $value }
+		}
+		$lines.Add(($cells -join ','))
+	}
+
+	$content = ($lines -join "`r`n") + "`r`n"
+
+	# --- prove it parses back to the same rows ----------------------------------------------------
+	$stagedPath = Join-Path -Path (Split-Path -Path $overlayPath -Parent) -ChildPath ((Split-Path -Path $overlayPath -Leaf) + '.' + [System.IO.Path]::GetRandomFileName() + '.tmp')
+	try {
+		[System.IO.File]::WriteAllText($stagedPath, $content, (New-Object System.Text.UTF8Encoding($false)))
+
+		$parsed = @(Import-Csv -Path $stagedPath | Where-Object {
+				-not [string]::IsNullOrWhiteSpace($_.App) -and -not $_.App.TrimStart().StartsWith('#')
+			})
+
+		if ($parsed.Count -ne $Row.Count) {
+			throw "The overlay parsed back as $($parsed.Count) row(s) instead of $($Row.Count) - a value probably needs quoting."
+		}
+	}
+	catch {
+		Remove-Item -Path $stagedPath -Force -WhatIf:$false -Confirm:$false -ErrorAction SilentlyContinue
+		throw "The app overlay would not be valid, so nothing was written => $($_.Exception.Message)"
+	}
+
+	$backupPath = "$overlayPath.bak"
+	$overlayExists = Test-Path -Path $overlayPath
+
+	if (-not $PSCmdlet.ShouldProcess($overlayPath, "Write $($Row.Count) app row(s)")) {
+		Remove-Item -Path $stagedPath -Force -WhatIf:$false -Confirm:$false -ErrorAction SilentlyContinue
+		return [pscustomobject]@{
+			OverlayPath = $overlayPath
+			BackupPath  = $null
+			RowCount    = $Row.Count
+			Written     = $false
+		}
+	}
+
+	if ($overlayExists -and -not $NoBackup) {
+		Copy-Item -Path $overlayPath -Destination $backupPath -Force
+	}
+	else {
+		$backupPath = $null
+	}
+
+	try {
+		Move-Item -Path $stagedPath -Destination $overlayPath -Force
+	}
+	catch {
+		Remove-Item -Path $stagedPath -Force -WhatIf:$false -Confirm:$false -ErrorAction SilentlyContinue
+		throw "Could not write the app overlay => $($_.Exception.Message)"
+	}
+
+	Write-Verbose "Wrote $($Row.Count) app row(s) to [$overlayPath]"
+
+	return [pscustomobject]@{
+		OverlayPath = $overlayPath
+		BackupPath  = $backupPath
+		RowCount    = $Row.Count
+		Written     = $true
+	}
+}

--- a/Windows/PowerShell/Modules/System/Functions/Get-PinnedApps.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Get-PinnedApps.ps1
@@ -1,41 +1,52 @@
 function Get-PinnedApps {
 	<#
 	.SYNOPSIS
-		Reads version-pinned apps from a CSV file and returns the app names.
+		Returns the version-pinned apps of one app list, machine-local overlay included.
 
 	.DESCRIPTION
-		Imports a CSV file (e.g. WinGetApps.csv, ScoopApps.csv) and filters for entries
-		that have a Version field matching the criteria. Used to identify apps that
-		should NOT be upgraded because they are locked to a specific version.
+		Reads an app list through `Import-AppCsv` - so the machine-local `<name>.local.csv` is layered
+		over the committed one - and returns the `App` of every row whose `Version` is a real version
+		rather than the "track the latest" value. Used to identify apps that must NOT be upgraded
+		because they are locked to a specific version.
 
-	.PARAMETER CsvFileName
-		Relative path to the CSV file (e.g. "Windows/bootstrap/WinGetApps.csv").
-		Resolved relative to `MachineSpecificPaths.Projects.Self.Root`.
+		Reading through `Import-AppCsv` rather than the committed CSV directly is what makes the pin
+		honour the overlay, and it matters in both directions: a version pinned only in the overlay is
+		invisible in the base file, so a direct reader would let `Upgrade-All` upgrade straight past
+		the pin - exactly the outcome pinning exists to prevent - and an app the overlay removed would
+		still be reported as pinned and handed to `winget pin add`.
+
+	.PARAMETER DataFileKey
+		Which list to read: `WinGetApps`, `ScoopApps` or `ChocolateyApps`. Resolved through
+		`BootstrapConfig.DataFiles`, the same way the installers resolve it.
 
 	.PARAMETER VersionExcludeValue
-		Version value to exclude from the pinned results. Defaults to "Latest".
-		Apps with this version value are not considered pinned.
+		The `Version` value that means "not pinned". Defaults to "Latest" (WinGet); Scoop writes
+		"latest", and Chocolatey leaves the cell empty, so its caller passes `$null` and every row
+		carrying any version counts as pinned.
 
 	.EXAMPLE
-		Get-PinnedApps -CsvFileName "Windows/bootstrap/WinGetApps.csv"
-		Returns all apps in the CSV with a Version other than "Latest".
+		Get-PinnedApps -DataFileKey WinGetApps
+		Returns every app in the effective WinGet list with a Version other than "Latest".
 
 	.EXAMPLE
-		Get-PinnedApps -CsvFileName "Windows/bootstrap/ScoopApps.csv" -VersionExcludeValue "latest"
-		Returns all Scoop apps with a version other than "latest".
+		Get-PinnedApps -DataFileKey ScoopApps -VersionExcludeValue "latest"
+		The same for Scoop, whose lists spell the value in lower case.
 	#>
 	param (
-		[string]$CsvFileName,
+		[Parameter(Mandatory = $true, Position = 0)]
+		[ValidateSet('WinGetApps', 'ScoopApps', 'ChocolateyApps')]
+		[string]$DataFileKey,
+
 		[string]$VersionExcludeValue = "Latest"
 	)
 
-	$csvPath = Join-Path -Path $MachineSpecificPaths.Projects.Self.Root -ChildPath $CsvFileName
-
-	# Skip the CSV's documentation-header comments (rows whose App starts with '#') and blank rows.
-	# Import-Csv otherwise parses a comment line that happens to contain commas into a bogus row with a
-	# non-"Latest" Version field, which would be reported as "pinned" and fed to `winget pin add` -
-	# hanging the unattended upgrade on winget's first-run prompt. Same filter the install functions use.
-	$apps = Import-Csv $csvPath | Where-Object { -not [string]::IsNullOrWhiteSpace($_.App) -and -not $_.App.TrimStart().StartsWith('#') }
+	# Import-AppCsv already drops comment and blank rows, but the filter is kept here as well: a
+	# '#'-comment line that contains commas parses into a bogus row with a non-"Latest" Version, and
+	# that garbage is what was once fed to `winget pin add` and hung the unattended upgrade on a fresh
+	# machine. It costs nothing and the incident it guards against was silent.
+	$apps = @(Import-AppCsv -DataFileKey $DataFileKey | Where-Object {
+			-not [string]::IsNullOrWhiteSpace($_.App) -and -not $_.App.TrimStart().StartsWith('#')
+		})
 
 	if ($VersionExcludeValue) {
 		return $apps | Where-Object { $_.Version -and $_.Version -ne $VersionExcludeValue } | Select-Object -ExpandProperty App

--- a/Windows/PowerShell/Modules/System/Functions/Upgrade-All.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Upgrade-All.ps1
@@ -5,7 +5,8 @@ function Upgrade-All {
 
 	.DESCRIPTION
 		Upgrades packages in the specified package managers. Reads pinned (version-locked) apps
-		from the configured CSV files and prevents them from being upgraded.
+		from the configured app lists - via `Get-PinnedApps`, so a version pinned in a machine-local
+		`<name>.local.csv` overlay counts too - and prevents them from being upgraded.
 
 		Without `-PackageManager`, upgrades across all managers configured in `PackageManagers` in Configuration.psd1.
 		With `-PackageManager`, upgrades only the specified manager.
@@ -40,7 +41,7 @@ function Upgrade-All {
 		try {
 			switch ($PackageManager) {
 				"WinGet" {
-					$pinnedApps = Get-PinnedApps -CsvFileName $global:Configuration.BootstrapConfig.DataFiles.WinGetApps
+					$pinnedApps = Get-PinnedApps -DataFileKey WinGetApps
 
 					if ($pinnedApps.Count -gt 0) {
 						Show-PinnedAppsWarning -PinnedApps $pinnedApps -Message "Pinning version-specific packages to prevent upgrades"
@@ -55,7 +56,7 @@ function Upgrade-All {
 					$exitCode = $LASTEXITCODE
 				}
 				"Scoop" {
-					$pinnedApps = Get-PinnedApps -CsvFileName $global:Configuration.BootstrapConfig.DataFiles.ScoopApps -VersionExcludeValue "latest"
+					$pinnedApps = Get-PinnedApps -DataFileKey ScoopApps -VersionExcludeValue "latest"
 
 					if ($pinnedApps.Count -gt 0) {
 						Show-PinnedAppsWarning -PinnedApps $pinnedApps -Message "Pinning version-specific packages to prevent upgrades"
@@ -84,7 +85,7 @@ function Upgrade-All {
 					$exitCode = $LASTEXITCODE
 				}
 				"Chocolatey" {
-					$pinnedApps = Get-PinnedApps -CsvFileName $global:Configuration.BootstrapConfig.DataFiles.ChocolateyApps -VersionExcludeValue $null
+					$pinnedApps = Get-PinnedApps -DataFileKey ChocolateyApps -VersionExcludeValue $null
 
 					if ($pinnedApps.Count -gt 0) {
 						Show-PinnedAppsWarning -PinnedApps $pinnedApps -Message "Pinning version-specific packages to prevent upgrades"

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Install-ChocolateyApps.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Install-ChocolateyApps.Tests.ps1
@@ -9,6 +9,8 @@ BeforeAll {
 	# Dot-source the machine-scope gate so the Machine-column filtering resolves even in
 	# sessions whose imported Bootstrap module predates the Test-MachineTypeScope export.
 	. (Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions\Test-MachineTypeScope.ps1")
+	# Same reason for the layered CSV reader the installer now reads through.
+	. (Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions\Import-AppCsv.ps1")
 }
 
 AfterAll {

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Install-ScoopApps.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Install-ScoopApps.Tests.ps1
@@ -9,6 +9,8 @@ BeforeAll {
 	# Dot-source the machine-scope gate so the Machine-column filtering resolves even in
 	# sessions whose imported Bootstrap module predates the Test-MachineTypeScope export.
 	. (Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions\Test-MachineTypeScope.ps1")
+	# Same reason for the layered CSV reader the installer now reads through.
+	. (Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions\Import-AppCsv.ps1")
 
 	# scoop is absent on clean CI runners; a throwing stub makes 'scoop export' fail
 	# deterministically without Mock scoop (which would require scoop to pre-exist).

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Install-WingetApps.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Install-WingetApps.Tests.ps1
@@ -9,6 +9,8 @@ BeforeAll {
 	# Dot-source the machine-scope gate so the Machine-column filtering resolves even in
 	# sessions whose imported Bootstrap module predates the Test-MachineTypeScope export.
 	. (Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions\Test-MachineTypeScope.ps1")
+	# Same reason for the layered CSV reader the installer now reads through.
+	. (Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions\Import-AppCsv.ps1")
 }
 
 AfterAll {

--- a/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Import-AppCsv.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Import-AppCsv.Tests.ps1
@@ -1,0 +1,369 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$script:OriginalConfiguration = $global:Configuration
+	$script:OriginalMachineSpecificPaths = $global:MachineSpecificPaths
+
+	$BootstrapFunctionsPath = Join-Path (Get-RepositoryPath).Modules "Bootstrap\Functions"
+	. "$BootstrapFunctionsPath\Import-AppCsv.ps1"
+
+	# Import-AppCsv reports its layering counts through the Logging module. Reading a CSV has no
+	# other dependency on logging, so a no-op stub keeps these tests free of that import entirely.
+	function Write-LogDebug {
+		param(
+			[Parameter(ValueFromRemainingArguments = $true)]
+			$Arguments
+		)
+	}
+
+	# Writes a fixture the way the committed app lists are written: CRLF, UTF-8 without a byte-order
+	# mark. The COLUMN header is line 1 and any commentary follows it, because Import-Csv takes line
+	# 1 as the header unconditionally.
+	function Write-AppCsvFixture {
+		param(
+			[Parameter(Mandatory = $true)]
+			[string]$Path,
+
+			# AllowEmptyString is required: a mandatory [string[]] validates NotNullOrEmpty on every
+			# ELEMENT, so the blank separator lines the committed files use would fail to bind.
+			[Parameter(Mandatory = $true)]
+			[AllowEmptyString()]
+			[string[]]$Line
+		)
+
+		$text = ($Line -join "`r`n") + "`r`n"
+		[System.IO.File]::WriteAllText($Path, $text, (New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false))
+	}
+
+	# Row order is part of the contract - committed rows first, then overlay-only additions - so the
+	# assertions compare the whole id sequence rather than only a count.
+	function Get-AppIdSequence {
+		param(
+			[Parameter(Mandatory = $true)]
+			[AllowEmptyCollection()]
+			[psobject[]]$Row
+		)
+
+		return (($Row | ForEach-Object { "$($_.App)" }) -join ',')
+	}
+
+	# Three active rows, one commented-out row and one blank separator line. Written by hand rather
+	# than copied from the repository on purpose: a synthetic base makes every layering count obvious
+	# and keeps the assertions independent of the real app list, which grows whenever an app is added.
+	function Get-BaseWinGetLines {
+		return @(
+			'App,Version,Scope,Interactive,Source,Machine'
+			''
+			'# Synthetic base list - the header is line 1 and the comments come after it'
+			'# exactly like the committed CSVs.'
+			'Base.One,Latest,d,n,w,All'
+			'Base.Two,1.0.0,d,n,w,PC/Work'
+			'#Base.Disabled,Latest,d,n,w,All'
+			'Base.Three,Latest,m,n,w,All'
+		)
+	}
+
+	function Get-BaseScoopLines {
+		return @(
+			'App,Version,Global,Machine'
+			''
+			'scoop.one,latest,false,All'
+		)
+	}
+
+	function Get-BaseChocolateyLines {
+		return @(
+			'App,Version,Params,Force,Machine'
+			''
+			'choco.one,latest,,false,All'
+		)
+	}
+}
+
+AfterAll {
+	$global:Configuration = $script:OriginalConfiguration
+	$global:MachineSpecificPaths = $script:OriginalMachineSpecificPaths
+}
+
+Describe "Import-AppCsv" {
+	BeforeEach {
+		# A synthetic repository under TestDrive, rebuilt for every test so no overlay can leak from
+		# one case into the next. The real Data folder is never used: an overlay lives beside its base
+		# file, so a fixture written there would sit next to - and could shadow - a committed app list.
+		$script:repoRoot = Join-Path $TestDrive "repo"
+		$script:dataRoot = Join-Path $script:repoRoot "Windows\PowerShell\Modules\Bootstrap\Data"
+
+		if (Test-Path -Path $script:repoRoot) {
+			Remove-Item -Path $script:repoRoot -Recurse -Force
+		}
+
+		New-Item -ItemType Directory -Path $script:dataRoot -Force | Out-Null
+
+		$script:winGetBase = Join-Path $script:dataRoot "WinGetApps.csv"
+		$script:winGetOverlay = Join-Path $script:dataRoot "WinGetApps.local.csv"
+		$script:scoopBase = Join-Path $script:dataRoot "ScoopApps.csv"
+		$script:scoopOverlay = Join-Path $script:dataRoot "ScoopApps.local.csv"
+		$script:chocoBase = Join-Path $script:dataRoot "ChocolateyApps.csv"
+
+		Write-AppCsvFixture -Path $script:winGetBase -Line (Get-BaseWinGetLines)
+		Write-AppCsvFixture -Path $script:scoopBase -Line (Get-BaseScoopLines)
+		Write-AppCsvFixture -Path $script:chocoBase -Line (Get-BaseChocolateyLines)
+
+		# The two globals the function reads. MachineSpecificPaths is pointed at the sandbox as well,
+		# so even a call that forgot -RepoRoot could not reach the real repository.
+		$global:Configuration = @{
+			BootstrapConfig   = @{
+				DataFiles = @{
+					WinGetApps     = 'Windows\PowerShell\Modules\Bootstrap\Data\WinGetApps.csv'
+					ScoopApps      = 'Windows\PowerShell\Modules\Bootstrap\Data\ScoopApps.csv'
+					ChocolateyApps = 'Windows\PowerShell\Modules\Bootstrap\Data\ChocolateyApps.csv'
+				}
+			}
+			ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test')
+		}
+		$global:MachineSpecificPaths = @{ Projects = @{ Self = @{ Root = $script:repoRoot } } }
+	}
+
+	Context "Reading the committed list" {
+		It "returns the committed rows in file order when there is no overlay" {
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			$rows.Count | Should -Be 3
+			Get-AppIdSequence -Row $rows | Should -Be 'Base.One,Base.Two,Base.Three'
+		}
+
+		It "does not treat a missing overlay as an error" {
+			# The overlay is opt-in and most machines never write one, so its absence has to be the
+			# normal path rather than something every caller has to guard against.
+			Test-Path -Path $script:winGetOverlay | Should -BeFalse
+
+			{ Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot } | Should -Not -Throw
+		}
+
+		It "drops comment rows and blank App cells" {
+			# The callers used to do this individually; centralizing it is half the reason this
+			# function exists, so it is asserted here rather than in each installer's tests.
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			$rows.Count | Should -Be 3
+			@($rows | Where-Object { "$($_.App)".TrimStart().StartsWith('#') }).Count | Should -Be 0
+			@($rows | Where-Object { [string]::IsNullOrWhiteSpace($_.App) }).Count | Should -Be 0
+			Get-AppIdSequence -Row $rows | Should -Not -Match 'Base\.Disabled'
+		}
+	}
+
+	Context "Failure modes" {
+		It "throws when the committed list is missing" {
+			# The base file is tracked, so its absence is a broken checkout rather than a choice.
+			Remove-Item -Path $script:winGetBase -Force
+
+			{ Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot } |
+				Should -Throw -ExpectedMessage '*App list not found*'
+		}
+
+		It "throws when the DataFiles key is not configured" {
+			$global:Configuration.BootstrapConfig.DataFiles.Remove('ChocolateyApps')
+
+			{ Import-AppCsv -DataFileKey ChocolateyApps -RepoRoot $script:repoRoot } |
+				Should -Throw -ExpectedMessage '*is not configured*'
+		}
+
+		It "rejects a data file key that is not one of the three lists" {
+			# ValidateSet is the gate: a typo has to fail at bind time, not resolve to an unconfigured
+			# key and be reported as something else.
+			{ Import-AppCsv -DataFileKey 'WinGetApp' -RepoRoot $script:repoRoot } |
+				Should -Throw -ExpectedMessage '*DataFileKey*'
+		}
+	}
+
+	Context "Additions" {
+		It "appends an overlay row for a new App after the committed rows" {
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'Overlay.New,Latest,d,n,w,All'
+			)
+
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			# Base-first order keeps the shipped install sequence intact and puts this machine's own
+			# apps at the end.
+			$rows.Count | Should -Be 4
+			Get-AppIdSequence -Row $rows | Should -Be 'Base.One,Base.Two,Base.Three,Overlay.New'
+		}
+	}
+
+	Context "Replacements" {
+		It "replaces the matching committed row in place and the overlay's values win" {
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'Base.Two,2.5.0,m,y,w,All'
+			)
+
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			# Replacement rather than addition: the count is unchanged and the row keeps its position,
+			# which is what lets an overlay pin a version or re-target a machine without reordering
+			# the install.
+			$rows.Count | Should -Be 3
+			Get-AppIdSequence -Row $rows | Should -Be 'Base.One,Base.Two,Base.Three'
+			@($rows | Where-Object { $_.App -eq 'Base.Two' }).Count | Should -Be 1
+
+			$rows[1].Version | Should -Be '2.5.0'
+			$rows[1].Scope | Should -Be 'm'
+			$rows[1].Interactive | Should -Be 'y'
+			$rows[1].Machine | Should -Be 'All'
+		}
+
+		It "matches an existing App case-insensitively" {
+			# Package ids are case-insensitive, so an overlay written with different casing has to
+			# replace the shipped row instead of adding a second row for the same app.
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'base.TWO,3.0.0,d,n,w,All'
+			)
+
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			$rows.Count | Should -Be 3
+			@($rows | Where-Object { $_.App -eq 'Base.Two' }).Count | Should -Be 1
+			$rows[1].App | Should -BeExactly 'base.TWO'
+			$rows[1].Version | Should -Be '3.0.0'
+		}
+	}
+
+	Context "Removals" {
+		It "removes the committed row when the overlay marks the App with a leading dash" {
+			# Without this there would be no way to opt out of a shipped app, since a layer that can
+			# only add or replace cannot subtract.
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'-Base.Two,Latest,d,n,w,All'
+			)
+
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			$rows.Count | Should -Be 2
+			Get-AppIdSequence -Row $rows | Should -Be 'Base.One,Base.Three'
+		}
+
+		It "never returns a row whose App starts with the removal marker" {
+			# The marker is an instruction, not an app id. If one leaked through, the installer would
+			# try to install a package literally named -Base.Two.
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'-Base.Two,Latest,d,n,w,All'
+				'-Ghost.App,Latest,d,n,w,All'
+			)
+
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			@($rows | Where-Object { "$($_.App)".TrimStart().StartsWith('-') }).Count | Should -Be 0
+			Get-AppIdSequence -Row $rows | Should -Be 'Base.One,Base.Three'
+		}
+
+		It "ignores a removal for an App the committed list does not contain" {
+			# An overlay outlives the base list it was written against, so a removal for an app that
+			# upstream has since dropped has to be harmless rather than an error.
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'-Ghost.App,Latest,d,n,w,All'
+			)
+
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			$rows.Count | Should -Be 3
+			Get-AppIdSequence -Row $rows | Should -Be 'Base.One,Base.Two,Base.Three'
+		}
+	}
+
+	Context "Overlays that say nothing" {
+		It "leaves the committed list unchanged when the overlay has no data rows" {
+			# Exactly what Save-AppCsvOverlay writes for an empty selection: a header and nothing else.
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+			)
+
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			$rows.Count | Should -Be 3
+			Get-AppIdSequence -Row $rows | Should -Be 'Base.One,Base.Two,Base.Three'
+		}
+
+		It "leaves the committed list unchanged when the overlay contains only comments" {
+			# A commented-out overlay row is inert on both sides of the layering: it neither adds a
+			# row nor replaces the base row that shares its id.
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'# Nothing active on this machine yet.'
+				'#Base.One,9.9.9,d,n,w,All'
+			)
+
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			$rows.Count | Should -Be 3
+			Get-AppIdSequence -Row $rows | Should -Be 'Base.One,Base.Two,Base.Three'
+			$rows[0].Version | Should -Be 'Latest'
+		}
+	}
+
+	Context "List independence" {
+		It "applies an overlay only to the list it belongs to" {
+			# One overlay per list, resolved through the DataFiles key, so a Scoop choice can never
+			# add to or subtract from the WinGet install.
+			Write-AppCsvFixture -Path $script:scoopOverlay -Line @(
+				'App,Version,Global,Machine'
+				''
+				'scoop.two,latest,false,All'
+				'-scoop.one,latest,false,All'
+			)
+
+			$scoopRows = @(Import-AppCsv -DataFileKey ScoopApps -RepoRoot $script:repoRoot)
+			$winGetRows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			Get-AppIdSequence -Row $scoopRows | Should -Be 'scoop.two'
+			Get-AppIdSequence -Row $winGetRows | Should -Be 'Base.One,Base.Two,Base.Three'
+		}
+	}
+
+	Context "An App both replaced and removed by the same overlay" {
+		It "lets the removal win" {
+			# Asserted rather than assumed: the base pass tests the removal index before the
+			# replacement index, and the additions pass skips removed ids as well, so a removal
+			# cannot be undone by a normal row for the same App.
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'-Base.Two,Latest,d,n,w,All'
+				'Base.Two,9.9.9,d,n,w,All'
+			)
+
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			$rows.Count | Should -Be 2
+			Get-AppIdSequence -Row $rows | Should -Be 'Base.One,Base.Three'
+		}
+
+		It "lets the removal win whichever of the two rows comes first" {
+			# Both rows are indexed before either is applied, so the outcome does not depend on the
+			# order a person happened to write them in.
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'Base.Two,9.9.9,d,n,w,All'
+				'-Base.Two,Latest,d,n,w,All'
+			)
+
+			$rows = @(Import-AppCsv -DataFileKey WinGetApps -RepoRoot $script:repoRoot)
+
+			$rows.Count | Should -Be 2
+			Get-AppIdSequence -Row $rows | Should -Be 'Base.One,Base.Three'
+		}
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/Configuration/Save-AppCsvOverlay.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Configuration/Save-AppCsvOverlay.Tests.ps1
@@ -1,0 +1,417 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$script:OriginalConfiguration = $global:Configuration
+	$script:OriginalMachineSpecificPaths = $global:MachineSpecificPaths
+
+	$ConfigFunctionsPath = Join-Path (Get-RepositoryPath).Modules "Configuration\Functions"
+	. "$ConfigFunctionsPath\Save-AppCsvOverlay.ps1"
+
+	# Writes a fixture the way the committed app lists are written: CRLF, UTF-8 without a byte-order
+	# mark, COLUMN header on line 1 with any commentary after it.
+	function Write-AppCsvFixture {
+		param(
+			[Parameter(Mandatory = $true)]
+			[string]$Path,
+
+			# AllowEmptyString is required: a mandatory [string[]] validates NotNullOrEmpty on every
+			# ELEMENT, so the blank separator lines the committed files use would fail to bind.
+			[Parameter(Mandatory = $true)]
+			[AllowEmptyString()]
+			[string[]]$Line
+		)
+
+		$text = ($Line -join "`r`n") + "`r`n"
+		[System.IO.File]::WriteAllText($Path, $text, (New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false))
+	}
+
+	# Exact byte snapshot, so "the committed list was not touched" and "the backup is the pre-save
+	# content" are real assertions rather than text comparisons that could hide an encoding or
+	# line-ending change.
+	function Get-FileFingerprint {
+		param(
+			[Parameter(Mandatory = $true)]
+			[string]$Path
+		)
+
+		return [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes($Path))
+	}
+
+	# Reads a CSV the way the installers do, so a row that only the reader's filter would drop cannot
+	# be counted here as saved data. Deliberately a local copy of the filter rather than a call into
+	# Import-AppCsv: these tests assert what landed on disk, not what the reader makes of it.
+	function Get-OverlayDataRow {
+		param(
+			[Parameter(Mandatory = $true)]
+			[string]$Path
+		)
+
+		return @(Import-Csv -Path $Path | Where-Object {
+				-not [string]::IsNullOrWhiteSpace($_.App) -and -not $_.App.TrimStart().StartsWith('#')
+			})
+	}
+
+	function Get-BaseWinGetLines {
+		return @(
+			'App,Version,Scope,Interactive,Source,Machine'
+			''
+			'# Synthetic base list - the header is line 1 and the comments come after it'
+			'# exactly like the committed CSVs.'
+			'Base.One,Latest,d,n,w,All'
+			'Base.Two,1.0.0,d,n,w,PC/Work'
+			'#Base.Disabled,Latest,d,n,w,All'
+			'Base.Three,Latest,m,n,w,All'
+		)
+	}
+
+	function Get-BaseChocolateyLines {
+		return @(
+			'App,Version,Params,Force,Machine'
+			''
+			'choco.one,latest,,false,All'
+		)
+	}
+
+	# One fully populated row, used wherever the test is about the write rather than the values.
+	function Get-SampleWinGetRow {
+		return @(
+			@{ App = 'Overlay.One'; Version = 'Latest'; Scope = 'd'; Interactive = 'n'; Source = 'w'; Machine = 'All' }
+		)
+	}
+}
+
+AfterAll {
+	$global:Configuration = $script:OriginalConfiguration
+	$global:MachineSpecificPaths = $script:OriginalMachineSpecificPaths
+}
+
+Describe "Save-AppCsvOverlay" {
+	BeforeEach {
+		# A synthetic repository under TestDrive, rebuilt from scratch for every test. This function
+		# WRITES files, and the overlay it writes lands beside the base file, so pointing it at the
+		# working tree would drop overlays into the tracked Data folder where they would shadow the
+		# committed app lists. The folder is cleared first as well, so no stale overlay or .bak can
+		# make an assertion pass for the wrong reason.
+		$script:repoRoot = Join-Path $TestDrive "repo"
+		$script:dataRoot = Join-Path $script:repoRoot "Windows\PowerShell\Modules\Bootstrap\Data"
+
+		if (Test-Path -Path $script:repoRoot) {
+			Remove-Item -Path $script:repoRoot -Recurse -Force
+		}
+
+		New-Item -ItemType Directory -Path $script:dataRoot -Force | Out-Null
+
+		$script:winGetBase = Join-Path $script:dataRoot "WinGetApps.csv"
+		$script:winGetOverlay = Join-Path $script:dataRoot "WinGetApps.local.csv"
+		$script:winGetBackup = "$($script:winGetOverlay).bak"
+		$script:chocoBase = Join-Path $script:dataRoot "ChocolateyApps.csv"
+		$script:chocoOverlay = Join-Path $script:dataRoot "ChocolateyApps.local.csv"
+
+		Write-AppCsvFixture -Path $script:winGetBase -Line (Get-BaseWinGetLines)
+		Write-AppCsvFixture -Path $script:chocoBase -Line (Get-BaseChocolateyLines)
+
+		# The two globals the function reads. MachineSpecificPaths is pointed at the sandbox as well,
+		# so even a call that forgot -RepoRoot could not write into the real repository.
+		$global:Configuration = @{
+			BootstrapConfig   = @{
+				DataFiles = @{
+					WinGetApps     = 'Windows\PowerShell\Modules\Bootstrap\Data\WinGetApps.csv'
+					ScoopApps      = 'Windows\PowerShell\Modules\Bootstrap\Data\ScoopApps.csv'
+					ChocolateyApps = 'Windows\PowerShell\Modules\Bootstrap\Data\ChocolateyApps.csv'
+				}
+			}
+			ValidMachineTypes = @('PC', 'Laptop', 'Work', 'Test')
+		}
+		$global:MachineSpecificPaths = @{ Projects = @{ Self = @{ Root = $script:repoRoot } } }
+	}
+
+	Context "Writing the overlay" {
+		It "writes the overlay and reports Written, RowCount and OverlayPath" {
+			$result = Save-AppCsvOverlay -DataFileKey WinGetApps -Row (Get-SampleWinGetRow) -RepoRoot $script:repoRoot
+
+			$result.Written | Should -BeTrue
+			$result.RowCount | Should -Be 1
+			$result.OverlayPath | Should -Be $script:winGetOverlay
+			Test-Path -Path $script:winGetOverlay | Should -BeTrue
+
+			$saved = @(Get-OverlayDataRow -Path $script:winGetOverlay)
+			$saved.Count | Should -Be 1
+			$saved[0].App | Should -Be 'Overlay.One'
+			$saved[0].Machine | Should -Be 'All'
+		}
+
+		It "never modifies the committed CSV" {
+			# The single most important property of the whole overlay design. The committed list is
+			# read to take its header and validate against, and is never written, which is what keeps
+			# a fork's app choices out of a tracked file and stops an upstream pull from conflicting
+			# on one. Compared as bytes, so an encoding or line-ending change would count as a change.
+			$before = Get-FileFingerprint -Path $script:winGetBase
+
+			Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(
+				@{ App = 'Overlay.One'; Version = 'Latest'; Scope = 'd'; Interactive = 'n'; Source = 'w'; Machine = 'All' }
+				@{ App = 'Base.Two'; Version = '2.5.0'; Scope = 'm'; Interactive = 'n'; Source = 'w'; Machine = 'All' }
+				@{ App = '-Base.Three'; Version = 'Latest'; Scope = 'd'; Interactive = 'n'; Source = 'w'; Machine = 'All' }
+			) -RepoRoot $script:repoRoot | Out-Null
+
+			# A row that replaces a base row and a row that removes one are the two cases most likely
+			# to tempt an implementation into editing the base file, so both are in this save.
+			Get-FileFingerprint -Path $script:winGetBase | Should -Be $before
+		}
+
+		It "writes the column header as the very first line, matching the committed header exactly" {
+			# Import-Csv takes line 1 as the header UNCONDITIONALLY. A leading comment line would
+			# therefore be read as the header, every data row would parse under a bogus column name,
+			# every row would come back with an empty App, and the reader's blank-App filter would
+			# silently drop the entire overlay. That was a real bug, caught before release, which is
+			# why the banner goes after the header and why this is asserted on the file itself.
+			Save-AppCsvOverlay -DataFileKey WinGetApps -Row (Get-SampleWinGetRow) -RepoRoot $script:repoRoot | Out-Null
+
+			$baseHeader = @(Get-Content -Path $script:winGetBase -TotalCount 1)[0]
+			$overlayLines = @(Get-Content -Path $script:winGetOverlay)
+
+			$overlayLines[0] | Should -BeExactly $baseHeader
+			$overlayLines[0] | Should -Not -Match '^\s*#'
+		}
+
+		It "writes the managed comment banner after the header" {
+			# The banner is what tells a person reading the file who owns it and what a -<id> row
+			# means. It sits below the header, and the reader drops it as commentary.
+			Save-AppCsvOverlay -DataFileKey WinGetApps -Row (Get-SampleWinGetRow) -RepoRoot $script:repoRoot | Out-Null
+
+			$text = [System.IO.File]::ReadAllText($script:winGetOverlay)
+			$text | Should -Match '# WinGetApps\.local\.csv'
+			$text | Should -Match 'Written by Save-AppCsvOverlay'
+			$text | Should -Match 'The committed CSV is never edited'
+
+			@(Get-OverlayDataRow -Path $script:winGetOverlay).Count | Should -Be 1
+		}
+	}
+
+	Context "Backups" {
+		It "copies the previous overlay to a .bak whose content is the pre-save content" {
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'Overlay.Previous,Latest,d,n,w,All'
+			)
+
+			$before = Get-FileFingerprint -Path $script:winGetOverlay
+
+			$result = Save-AppCsvOverlay -DataFileKey WinGetApps -Row (Get-SampleWinGetRow) -RepoRoot $script:repoRoot
+
+			$result.BackupPath | Should -Be $script:winGetBackup
+			Test-Path -Path $script:winGetBackup | Should -BeTrue
+
+			# Restoring the .bak is the complete undo, so it has to be the exact pre-save bytes.
+			Get-FileFingerprint -Path $script:winGetBackup | Should -Be $before
+			@(Get-OverlayDataRow -Path $script:winGetBackup)[0].App | Should -Be 'Overlay.Previous'
+		}
+
+		It "does not create a .bak when there was no overlay to back up" {
+			$result = Save-AppCsvOverlay -DataFileKey WinGetApps -Row (Get-SampleWinGetRow) -RepoRoot $script:repoRoot
+
+			Test-Path -Path $script:winGetBackup | Should -BeFalse
+			$result.BackupPath | Should -BeNullOrEmpty
+		}
+
+		It "does not create a .bak when -NoBackup is given" {
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'Overlay.Previous,Latest,d,n,w,All'
+			)
+
+			$result = Save-AppCsvOverlay -DataFileKey WinGetApps -Row (Get-SampleWinGetRow) -RepoRoot $script:repoRoot -NoBackup
+
+			Test-Path -Path $script:winGetBackup | Should -BeFalse
+			$result.BackupPath | Should -BeNullOrEmpty
+			@(Get-OverlayDataRow -Path $script:winGetOverlay)[0].App | Should -Be 'Overlay.One'
+		}
+	}
+
+	Context "WhatIf" {
+		It "writes nothing, backs up nothing, reports Written as false and leaves no .tmp behind" {
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'Overlay.Previous,Latest,d,n,w,All'
+			)
+
+			$before = Get-FileFingerprint -Path $script:winGetOverlay
+
+			$result = Save-AppCsvOverlay -DataFileKey WinGetApps -Row (Get-SampleWinGetRow) -RepoRoot $script:repoRoot -WhatIf
+
+			$result.Written | Should -BeFalse
+			$result.RowCount | Should -Be 1
+			Get-FileFingerprint -Path $script:winGetOverlay | Should -Be $before
+			Test-Path -Path $script:winGetBackup | Should -BeFalse
+
+			# The candidate is still staged and parsed under -WhatIf, because reporting what would be
+			# written is only useful if the same validation ran, so the cleanup has to happen anyway.
+			@(Get-ChildItem -Path $script:dataRoot -Filter '*.tmp' -Force).Count | Should -Be 0
+		}
+	}
+
+	Context "Validation" {
+		BeforeEach {
+			# A refusal has to leave whatever was already on disk exactly as it was, so every case
+			# here runs against an existing overlay rather than a missing one.
+			Write-AppCsvFixture -Path $script:winGetOverlay -Line @(
+				'App,Version,Scope,Interactive,Source,Machine'
+				''
+				'Overlay.Previous,Latest,d,n,w,All'
+			)
+
+			$script:overlayBefore = Get-FileFingerprint -Path $script:winGetOverlay
+		}
+
+		It "refuses a row with no App id" {
+			{ Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = ''; Machine = 'All' }) -RepoRoot $script:repoRoot } |
+				Should -Throw -ExpectedMessage '*no App id*'
+
+			Get-FileFingerprint -Path $script:winGetOverlay | Should -Be $script:overlayBefore
+			Test-Path -Path $script:winGetBackup | Should -BeFalse
+		}
+
+		It "refuses a row that is not assigned to any machine" {
+			# A blank Machine cell matches nothing, so the row would sit in the overlay looking
+			# installed and never install - the most confusing possible outcome. It is refused where
+			# the overlay is written, not left for the installer to skip silently.
+			{ Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = 'Overlay.One'; Machine = '' }) -RepoRoot $script:repoRoot } |
+				Should -Throw -ExpectedMessage '*not assigned to any PC*'
+
+			Get-FileFingerprint -Path $script:winGetOverlay | Should -Be $script:overlayBefore
+			Test-Path -Path $script:winGetBackup | Should -BeFalse
+		}
+
+		It "refuses an unknown machine type" {
+			{ Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = 'Overlay.One'; Machine = 'Labtop' }) -RepoRoot $script:repoRoot } |
+				Should -Throw -ExpectedMessage '*not a known machine type*'
+
+			Get-FileFingerprint -Path $script:winGetOverlay | Should -Be $script:overlayBefore
+			Test-Path -Path $script:winGetBackup | Should -BeFalse
+		}
+
+		It "refuses an unknown token inside a slash-joined machine list" {
+			# Every token is checked, not just the first, because one good token would otherwise make
+			# a typo in the rest of the cell invisible.
+			{ Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = 'Overlay.One'; Machine = 'PC/Labtop' }) -RepoRoot $script:repoRoot } |
+				Should -Throw -ExpectedMessage "*targets 'Labtop'*"
+
+			Get-FileFingerprint -Path $script:winGetOverlay | Should -Be $script:overlayBefore
+			Test-Path -Path $script:winGetBackup | Should -BeFalse
+		}
+
+		It "refuses a -RepoRoot that was given but is empty" {
+			# Falling back to this machine's own clone here would write an overlay beside the TRACKED
+			# app lists when the caller plainly meant to work in a sandbox. Omitting the parameter
+			# still uses the fallback; passing it blank is always an accident.
+			{ Save-AppCsvOverlay -DataFileKey WinGetApps -Row (Get-SampleWinGetRow) -RepoRoot '' } |
+				Should -Throw -ExpectedMessage '*-RepoRoot was given but is empty*'
+
+			Get-FileFingerprint -Path $script:winGetOverlay | Should -Be $script:overlayBefore
+		}
+
+		It "accepts All" {
+			$result = Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = 'Overlay.One'; Machine = 'All' }) -RepoRoot $script:repoRoot
+
+			$result.Written | Should -BeTrue
+			@(Get-OverlayDataRow -Path $script:winGetOverlay)[0].Machine | Should -Be 'All'
+		}
+
+		It "accepts a slash-joined list of known machine types" {
+			$result = Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = 'Overlay.One'; Machine = 'PC/Work' }) -RepoRoot $script:repoRoot
+
+			$result.Written | Should -BeTrue
+			@(Get-OverlayDataRow -Path $script:winGetOverlay)[0].Machine | Should -Be 'PC/Work'
+		}
+	}
+
+	Context "An empty overlay" {
+		It "writes a header-only overlay for an empty -Row and reports RowCount 0" {
+			# "This machine adds nothing" is a real state, and it is not the same as having no overlay
+			# file at all: the file exists, so the reader layers an empty overlay and the caller knows
+			# it is managing this list.
+			$result = Save-AppCsvOverlay -DataFileKey WinGetApps -Row @() -RepoRoot $script:repoRoot
+
+			$result.Written | Should -BeTrue
+			$result.RowCount | Should -Be 0
+			Test-Path -Path $script:winGetOverlay | Should -BeTrue
+
+			$baseHeader = @(Get-Content -Path $script:winGetBase -TotalCount 1)[0]
+
+			@(Get-OverlayDataRow -Path $script:winGetOverlay).Count | Should -Be 0
+			@(Get-Content -Path $script:winGetOverlay)[0] | Should -BeExactly $baseHeader
+		}
+	}
+
+	Context "Quoting" {
+		It "quotes a value containing a comma so it round-trips through Import-Csv" {
+			# A Chocolatey Params cell is the realistic case. Unquoted, its comma would split the row
+			# into more fields than the header has, and the round-trip count check would refuse the
+			# save rather than write a file that parses into the wrong shape.
+			$chocolateyParams = '/InstallDir:C:\Tools,/NoDesktop'
+
+			$result = Save-AppCsvOverlay -DataFileKey ChocolateyApps -Row @(
+				@{ App = 'choco.two'; Version = 'latest'; Params = $chocolateyParams; Force = 'false'; Machine = 'All' }
+			) -RepoRoot $script:repoRoot
+
+			$result.Written | Should -BeTrue
+			$result.RowCount | Should -Be 1
+
+			$saved = @(Get-OverlayDataRow -Path $script:chocoOverlay)
+			$saved.Count | Should -Be 1
+			$saved[0].Params | Should -BeExactly $chocolateyParams
+			$saved[0].Machine | Should -Be 'All'
+		}
+
+		It "round-trips a value containing a double quote" {
+			$chocolateyParams = '/Args:"--silent --no-desktop"'
+
+			$result = Save-AppCsvOverlay -DataFileKey ChocolateyApps -Row @(
+				@{ App = 'choco.two'; Version = 'latest'; Params = $chocolateyParams; Force = 'false'; Machine = 'All' }
+			) -RepoRoot $script:repoRoot
+
+			$result.RowCount | Should -Be 1
+
+			$saved = @(Get-OverlayDataRow -Path $script:chocoOverlay)
+			$saved.Count | Should -Be 1
+			$saved[0].Params | Should -BeExactly $chocolateyParams
+		}
+	}
+
+	Context "Columns" {
+		It "takes the columns from the committed header, so an unknown extra key adds no column" {
+			# The overlay can never drift into a shape the installer does not read, because the header
+			# is copied from the committed file rather than derived from the rows it is handed.
+			Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(
+				@{ App = 'Overlay.One'; Version = 'Latest'; Scope = 'd'; Interactive = 'n'; Source = 'w'; Machine = 'All'; Nonsense = 'ignored' }
+			) -RepoRoot $script:repoRoot | Out-Null
+
+			$baseHeader = @(Get-Content -Path $script:winGetBase -TotalCount 1)[0]
+			@(Get-Content -Path $script:winGetOverlay)[0] | Should -BeExactly $baseHeader
+
+			$saved = @(Get-OverlayDataRow -Path $script:winGetOverlay)
+			@($saved[0].PSObject.Properties.Name).Count | Should -Be 6
+			$saved[0].PSObject.Properties.Name | Should -Not -Contain 'Nonsense'
+			[System.IO.File]::ReadAllText($script:winGetOverlay) | Should -Not -Match 'ignored'
+		}
+	}
+
+	Context "Temporary files" {
+		It "leaves no .tmp file in the data folder, whether the save succeeds, is refused or is a -WhatIf" {
+			# The candidate is staged in the destination folder so the replace is a same-volume rename
+			# a reader can never observe half-written. Every exit path has to clean that staging file
+			# up, including the ones that throw.
+			$row = Get-SampleWinGetRow
+
+			Save-AppCsvOverlay -DataFileKey WinGetApps -Row $row -RepoRoot $script:repoRoot | Out-Null
+			Save-AppCsvOverlay -DataFileKey WinGetApps -Row $row -RepoRoot $script:repoRoot -WhatIf | Out-Null
+
+			{ Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = 'Overlay.Two'; Machine = 'Labtop' }) -RepoRoot $script:repoRoot } |
+				Should -Throw
+
+			@(Get-ChildItem -Path $script:dataRoot -Filter '*.tmp' -Force).Count | Should -Be 0
+		}
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/System/Get-PinnedApps.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/System/Get-PinnedApps.Tests.ps1
@@ -1,52 +1,108 @@
 #Requires -Modules Pester
 
 BeforeAll {
+	$script:OriginalConfiguration = $global:Configuration
+	$script:OriginalMachineSpecificPaths = $global:MachineSpecificPaths
+
 	$ModuleRoot = (Get-RepositoryPath).Modules
 	$FunctionsPath = Join-Path $ModuleRoot "System\Functions"
 
 	. "$FunctionsPath\Get-PinnedApps.ps1"
+	# The layered reader Get-PinnedApps now reads through. Dot-sourced so it exists as a command the
+	# filtering tests can Mock, and so the real one is available to the overlay test.
+	. (Join-Path $ModuleRoot "Bootstrap\Functions\Import-AppCsv.ps1")
+
+	# Import-AppCsv reports its layering counts through the Logging module; a no-op stub keeps these
+	# tests free of that import.
+	function Write-LogDebug {
+		param(
+			[Parameter(ValueFromRemainingArguments = $true)]
+			$Arguments
+		)
+	}
+}
+
+AfterAll {
+	$global:Configuration = $script:OriginalConfiguration
+	$global:MachineSpecificPaths = $script:OriginalMachineSpecificPaths
 }
 
 Describe "Get-PinnedApps" {
-	BeforeEach {
-		$script:MachineSpecificPaths = [PSCustomObject]@{
-			Projects = [PSCustomObject]@{
-				Self = [PSCustomObject]@{
-					Root = "C:\\Repo"
-				}
+	Context "Selecting the pinned rows" {
+		BeforeEach {
+			Mock Import-AppCsv {
+				@(
+					[PSCustomObject]@{ App = "git"; Version = "2.44.0" },
+					[PSCustomObject]@{ App = "nodejs"; Version = "Latest" }
+				)
 			}
 		}
-		Mock Import-CSV {
-			@(
-				[PSCustomObject]@{ App = "git"; Version = "2.44.0" },
-				[PSCustomObject]@{ App = "nodejs"; Version = "Latest" }
-			)
+
+		It "returns only pinned apps when VersionExcludeValue is provided" {
+			$result = Get-PinnedApps -DataFileKey WinGetApps -VersionExcludeValue "Latest"
+
+			$result | Should -Contain "git"
+			$result | Should -Not -Contain "nodejs"
+		}
+
+		It "ignores CSV documentation-comment and blank rows" {
+			# A '#'-comment line that contains commas is parsed by Import-Csv into a bogus row with a
+			# non-"Latest" Version. It must NOT be reported as pinned - that garbage is what was fed to
+			# `winget pin add` and hung the unattended upgrade on a fresh machine.
+			Mock Import-AppCsv {
+				@(
+					[PSCustomObject]@{ App = "git"; Version = "2.44.0" },
+					[PSCustomObject]@{ App = "#   Scope       d (default)"; Version = " m (machine-wide)" },
+					[PSCustomObject]@{ App = "   #   Machine     where to install: `"All`""; Version = " `"Test`"" },
+					[PSCustomObject]@{ App = ""; Version = "" }
+				)
+			}
+
+			$result = Get-PinnedApps -DataFileKey WinGetApps -VersionExcludeValue "Latest"
+
+			$result | Should -Contain "git"
+			$result | Where-Object { $_ -like "*#*" } | Should -BeNullOrEmpty
 		}
 	}
 
-	It "returns only pinned apps when VersionExcludeValue is provided" {
-		$result = Get-PinnedApps -CsvFileName "Windows/bootstrap/WinGetApps.csv" -VersionExcludeValue "Latest"
+	Context "Reading through the overlay" {
+		# No mock here: the layering is exactly what is under test, so this Context runs the real
+		# Import-AppCsv over a synthetic repository.
+		BeforeEach {
+			$script:repoRoot = Join-Path $TestDrive "repo"
+			$dataRoot = Join-Path $script:repoRoot "Windows\PowerShell\Modules\Bootstrap\Data"
 
-		$result | Should -Contain "git"
-		$result | Should -Not -Contain "nodejs"
-	}
+			if (Test-Path -Path $script:repoRoot) {
+				Remove-Item -Path $script:repoRoot -Recurse -Force
+			}
+			New-Item -ItemType Directory -Path $dataRoot -Force | Out-Null
 
-	It "ignores CSV documentation-comment and blank rows" {
-		# A '#'-comment line that contains commas is parsed by Import-Csv into a bogus row with a
-		# non-"Latest" Version. It must NOT be reported as pinned - that garbage is what was fed to
-		# `winget pin add` and hung the unattended upgrade on a fresh machine.
-		Mock Import-CSV {
-			@(
-				[PSCustomObject]@{ App = "git"; Version = "2.44.0" },
-				[PSCustomObject]@{ App = "#   Scope       d (default)"; Version = " m (machine-wide)" },
-				[PSCustomObject]@{ App = "   #   Machine     where to install: `"All`""; Version = " `"Test`"" },
-				[PSCustomObject]@{ App = ""; Version = "" }
-			)
+			$encoding = New-Object -TypeName System.Text.UTF8Encoding -ArgumentList $false
+			[System.IO.File]::WriteAllText(
+				(Join-Path $dataRoot "WinGetApps.csv"),
+				"App,Version,Scope,Interactive,Source,Machine`r`nBase.Pinned,1.0.0,d,n,w,All`r`nBase.Latest,Latest,d,n,w,All`r`n",
+				$encoding)
+			[System.IO.File]::WriteAllText(
+				(Join-Path $dataRoot "WinGetApps.local.csv"),
+				"App,Version,Scope,Interactive,Source,Machine`r`nBase.Latest,7.4.6,d,n,w,All`r`n-Base.Pinned,1.0.0,d,n,w,All`r`n",
+				$encoding)
+
+			$global:Configuration = @{
+				BootstrapConfig = @{ DataFiles = @{ WinGetApps = 'Windows\PowerShell\Modules\Bootstrap\Data\WinGetApps.csv' } }
+			}
+			$global:MachineSpecificPaths = @{ Projects = @{ Self = @{ Root = $script:repoRoot } } }
 		}
 
-		$result = Get-PinnedApps -CsvFileName "Windows/bootstrap/WinGetApps.csv" -VersionExcludeValue "Latest"
+		It "counts a version pinned only in the overlay, and drops one the overlay removed" {
+			# The whole reason this function no longer parses the committed CSV itself. A pin that
+			# lives in the machine-local overlay is invisible in the base file, and missing it would
+			# let Upgrade-All upgrade straight past the pin - the exact outcome pinning prevents.
+			$result = @(Get-PinnedApps -DataFileKey WinGetApps -VersionExcludeValue "Latest")
 
-		$result | Should -Contain "git"
-		$result | Where-Object { $_ -like "*#*" } | Should -BeNullOrEmpty
+			# The overlay pinned an app the base tracked at Latest...
+			$result | Should -Contain "Base.Latest"
+			# ...and removed the one the base had pinned, so it is not reported as pinned any more.
+			$result | Should -Not -Contain "Base.Pinned"
+		}
 	}
 }

--- a/docs/configuration/repository-structure.md
+++ b/docs/configuration/repository-structure.md
@@ -39,9 +39,10 @@ WinuX/
     │       ├── Application/                        # App launchers & installers
     │       ├── Bootstrap/                          # System initialization
     │       │   └── Data/
-    │       │       ├── WinGetApps.csv              # WinGet applications
-    │       │       ├── ScoopApps.csv               # Scoop applications
-    │       │       └── ChocolateyApps.csv          # Chocolatey applications
+    │       │       ├── WinGetApps.csv              # WinGet applications (upstream baseline)
+    │       │       ├── WinGetApps.local.csv        # your own apps, layered over it (gitignored)
+    │       │       ├── ScoopApps.csv               # Scoop applications (+ ScoopApps.local.csv)
+    │       │       └── ChocolateyApps.csv          # Chocolatey applications (+ .local.csv)
     │       ├── Configuration/                      # Programmatic config modifications
     │       ├── Custom/                             # Fork-owned functions & modules (see Fork Model)
     │       ├── Git/                                # Repository management

--- a/docs/contributing/fork-model.md
+++ b/docs/contributing/fork-model.md
@@ -61,20 +61,55 @@ Windows/PowerShell/Configuration.local.psd1`) and commit. Upstream never tracks 
 it in your fork never conflicts on a pull; it simply syncs across your machines like any other file. Keep
 machine-specific values keyed by machine type / hostname so the one committed file serves every machine.
 
-## Keeping your own app lists and payloads (the `merge=ours` protection)
+## Keeping your own app lists (the `.local.csv` overlay)
 
-`Configuration.local.psd1` covers your **settings**. A few other tracked files are also yours but have no
-"base + override" split - your curated package lists and your payload configs. WinuX ships example/blank
-versions; your fork edits them in place. So that an upstream pull never overwrites your versions, WinuX's
-`.gitattributes` marks them with the **`ours` merge driver**:
+`Configuration.local.psd1` covers your **settings**. Your **app lists** work the same way, for the same
+reason. WinuX ships three committed CSVs under `Windows/PowerShell/Modules/Bootstrap/Data/` holding only
+the software WinuX itself needs; everything you add for yourself goes in a sibling overlay:
 
 ```
-Windows/PowerShell/Modules/Bootstrap/Data/WinGetApps.csv       merge=ours
-Windows/PowerShell/Modules/Bootstrap/Data/ScoopApps.csv        merge=ours
-Windows/PowerShell/Modules/Bootstrap/Data/ChocolateyApps.csv   merge=ours
+WinuX (upstream)                      your fork
+─────────────────                     ─────────────────────────────────────────
+WinGetApps.csv          ──pull──►      WinGetApps.csv           (tracks upstream, unchanged)
+                                       WinGetApps.local.csv     (yours; gitignored by default)
+                                                 │
+                                       layered at read time
+                                                 ▼
+                                        effective app list
+```
+
+[`Import-AppCsv`](../modules/bootstrap.md#import-appcsv) does the layering, and every reader goes through
+it - all three `Install-*Apps` functions and `Get-PinnedApps` - so what the overlay says is what gets
+installed. An overlay row **adds** a new app, **replaces** a committed row with the same `App` (to pin a
+version, change the scope, or re-target the machine), or - written as `-<id>` - **removes** one you don't
+want. [`Save-AppCsvOverlay`](../modules/configuration.md#save-appcsvoverlay) writes it with validation and
+a `.bak`; you can also just edit the file. The full reference is in
+[Software List: Machine-Local Overlay](../reference/software-list.md#machine-local-overlay).
+
+**Never edit the committed CSVs in your fork.** They are ordinary upstream-tracked files now, exactly like
+`Configuration.psd1`: leave them alone and every pull applies cleanly while you keep receiving upstream's
+baseline changes.
+
+> [!IMPORTANT]
+> **Migrating an older fork.** Before this, the three CSVs were marked `merge=ours` and forks curated them
+> in place. That attribute has been removed, so a fork that still keeps its apps in the committed CSVs will
+> have them overwritten by the next `git merge upstream/master`. Move them first - it is a one-time copy:
+> take your added rows out of `WinGetApps.csv` into a new `WinGetApps.local.csv` (same header on line 1),
+> write `-<id>` rows for any shipped app you had deleted, restore the committed file to upstream's version
+> (`git checkout upstream/master -- Windows/PowerShell/Modules/Bootstrap/Data/`), and repeat for Scoop and
+> Chocolatey if you use them. Then pull as usual.
+
+## Keeping your own payloads (the `merge=ours` protection)
+
+A few other tracked files are yours but have no "base + override" split - your payload configs. WinuX ships
+generic/blank versions; your fork edits them in place. So that an upstream pull never overwrites your
+versions, WinuX's `.gitattributes` marks them with the **`ours` merge driver**:
+
+```
 Git/.gitconfig                                                 merge=ours
 NuGet/nuget.config                                             merge=ours
 Firefox/user.js                                                merge=ours
+docs/custom/README.md                                          merge=ours
 ```
 
 `merge=ours` means: when `git merge upstream/master` touches one of these files, Git keeps **your** copy
@@ -88,14 +123,15 @@ security boundary - so this can never be fully automatic; the bootstrap (or that
 it gets. Until it is registered, Git just does a normal merge for those files, so nothing breaks - you only
 lose the "keep mine" behavior.
 
-**Trade-off.** A `merge=ours` file never receives upstream changes; that is the intent for lists and
-payloads that are wholly yours. If WinuX later restructures one and you want the new shape, diff it against
-upstream and port what you want by hand.
+**Trade-off.** A `merge=ours` file never receives upstream changes; that is the intent for payloads that
+are wholly yours. If WinuX later restructures one and you want the new shape, diff it against upstream and
+port what you want by hand. That trade-off is exactly why the app lists moved off `merge=ours` and onto an
+overlay: there, the base can keep improving upstream while your choices stay yours.
 
 ## The Custom area - your code, upstream's layout
 
-`Configuration.local.psd1` covers your **settings** and `merge=ours` covers your **data files**; the
-**Custom area** covers your **code and docs** - everything you build that WinuX does not (yet) ship. It is
+`Configuration.local.psd1` covers your **settings**, `*.local.csv` covers your **app lists** and
+`merge=ours` covers your **payload configs**; the **Custom area** covers your **code and docs** - everything you build that WinuX does not (yet) ship. It is
 a fork-owned subtree that mirrors the module tree, so upstream pulls never touch it and promoting something
 into WinuX later is a mechanical move:
 
@@ -140,7 +176,10 @@ locations and open a PR. The step-by-step checklist lives in
    one-liner), which writes your `Configuration.local.psd1`. It is gitignored by default, so it
    never travels to GitHub; if you run several machines, commit it in your fork instead - see
    "One machine vs. several" above.
-4. **Install** as usual - see [Installation](../getting-started/installation.md).
+4. **Add your apps** to `Windows/PowerShell/Modules/Bootstrap/Data/WinGetApps.local.csv` (and the Scoop /
+   Chocolatey overlays if you use them), never to the committed CSVs - see
+   [Keeping your own app lists](#keeping-your-own-app-lists-the-localcsv-overlay).
+5. **Install** as usual - see [Installation](../getting-started/installation.md).
 
 ## Pulling upstream updates
 
@@ -149,12 +188,14 @@ git fetch upstream
 git merge upstream/master      # or: git rebase upstream/master
 ```
 
-Because your personal settings live in the override (not the tracked base config), and your app lists +
-payload configs are protected by `merge=ours` (see above - just make sure the driver is registered once),
-these updates apply cleanly: neither your configuration nor your owned files are a source of conflicts.
-Custom-area code and docs live in fork-owned paths upstream never touches, so they never conflict either.
-If you have edited _other_ tracked files (engine, docs), resolve those as you normally would.
+Because your personal settings live in the override (not the tracked base config), your apps live in the
+`.local.csv` overlays (not the tracked lists), and your payload configs are protected by `merge=ours` (see
+above - just make sure the driver is registered once), these updates apply cleanly: neither your
+configuration nor your owned files are a source of conflicts. Custom-area code and docs live in fork-owned
+paths upstream never touches, so they never conflict either. If you have edited _other_ tracked files
+(engine, docs), resolve those as you normally would.
 
 > [!NOTE]
 > Keeping personal values out of tracked files is what makes this work. Avoid editing
-> `Configuration.psd1` with machine-specific values; put them in `Configuration.local.psd1` instead.
+> `Configuration.psd1` with machine-specific values or the `Data/*.csv` app lists with your own apps; put
+> them in `Configuration.local.psd1` and the `*.local.csv` overlays instead.

--- a/docs/docs_overview.md
+++ b/docs/docs_overview.md
@@ -206,7 +206,7 @@ docs/
 │   └── agent-system.md                     # Custom agents, prompts, instructions
 │
 ├── contributing/
-│   └── fork-model.md                       # Fork model, merge=ours, config override
+│   └── fork-model.md                       # Fork model, config + app-list overrides, merge=ours
 │
 └── reference/
     ├── software-list.md                    # Packages installed from the CSV files

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -126,6 +126,11 @@ Applications are defined in CSV files and **filtered by machine type**:
 | `ScoopApps.csv`      | Scoop      | `App,Version,Global,Machine`                   |
 | `ChocolateyApps.csv` | Chocolatey | `App,Version,Params,Force,Machine`             |
 
+The committed CSVs hold only the software WinuX itself needs. **Your own apps go in a sibling
+`<name>.local.csv`**, which is layered over the committed list at read time and is gitignored - so
+you never edit a tracked file and upstream pulls never conflict on an app choice. See
+[Software List: Machine-Local Overlay](../reference/software-list.md#machine-local-overlay).
+
 **Machine column values:**
 
 The values are not a fixed set - each row is matched against the machine types you define in

--- a/docs/modules/application.md
+++ b/docs/modules/application.md
@@ -30,17 +30,17 @@ Get-VSCodeWorkspaceNames
 
 ## [Install-ChocolateyApps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Install-ChocolateyApps.ps1)
 
-- **Description:** Installs Chocolatey-managed apps from the WinuX CSV, filtered by machine type. Reads the app list from `ChocolateyApps.csv`, installs entries matching the current machine type (plus any "All" entries), and skips the rest. `Machine`-column tokens are validated via `Test-MachineTypeScope` - unknown machine types are reported and never match. Requires administrator privileges and is called automatically by Bootstrap.
+- **Description:** Installs Chocolatey-managed apps from the WinuX CSV, filtered by machine type. Reads the app list through `Import-AppCsv`, which layers the machine-local `ChocolateyApps.local.csv` over the committed `ChocolateyApps.csv`, then installs entries matching the current machine type (plus any "All" entries) and skips the rest. `Machine`-column tokens are validated via `Test-MachineTypeScope` - unknown machine types are reported and never match. Requires administrator privileges and is called automatically by Bootstrap.
 - **Usage:** `Install-ChocolateyApps`
 
-Reads the app list from the CSV at `BootstrapConfig.DataFiles.ChocolateyApps` in `Configuration.psd1`. Each row specifies an app ID and the machine types it applies to ("All", "PC", "Laptop", etc.), and may also carry optional `Version`, `Params`, and `Force` columns that are passed through to `choco install`. Apps for the current machine type and All-type apps are installed; others are skipped. Administrator privileges are verified up front via `Test-AdminPrivileges`.
+Reads the app list with `Import-AppCsv -DataFileKey ChocolateyApps`, which resolves the committed CSV through `BootstrapConfig.DataFiles.ChocolateyApps` in `Configuration.psd1` and layers the sibling `ChocolateyApps.local.csv` over it when one exists, so this machine's own choices apply without the tracked CSV ever being edited. Each row specifies an app ID and the machine types it applies to ("All", "PC", "Laptop", etc.), and may also carry optional `Version`, `Params`, and `Force` columns that are passed through to `choco install`. Apps for the current machine type and All-type apps are installed; others are skipped. Administrator privileges are verified up front via `Test-AdminPrivileges`.
 
 ```powershell
 # Install all Chocolatey apps applicable to the current machine type
 Install-ChocolateyApps
 ```
 
-**See also:** [Modules: Workflow](workflow.md)
+**See also:** [Import-AppCsv](bootstrap.md#import-appcsv), [Modules: Workflow](workflow.md)
 
 ## [Install-ChocolateyPackageManager](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Install-ChocolateyPackageManager.ps1)
 
@@ -123,17 +123,17 @@ Install-PowerShellModules
 
 ## [Install-ScoopApps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Install-ScoopApps.ps1)
 
-- **Description:** Installs Scoop-managed apps from the WinuX CSV, filtered by the current machine type. Apps matching the current machine type (or marked `All`) are installed; others are skipped. `Machine`-column tokens are validated via `Test-MachineTypeScope` - unknown machine types are reported and never match. Requires administrator privileges and is called automatically by Bootstrap.
+- **Description:** Installs Scoop-managed apps from the WinuX CSV, filtered by the current machine type. Reads the app list through `Import-AppCsv`, which layers the machine-local `ScoopApps.local.csv` over the committed `ScoopApps.csv`. Apps matching the current machine type (or marked `All`) are installed; others are skipped. `Machine`-column tokens are validated via `Test-MachineTypeScope` - unknown machine types are reported and never match. Requires administrator privileges and is called automatically by Bootstrap.
 - **Usage:** `Install-ScoopApps`
 
-Reads the app list from the CSV at `BootstrapConfig.DataFiles.ScoopApps` in `Configuration.psd1`. Each row specifies an app name, optional bucket, version, global flag, and the machine types it applies to. The function determines the current machine type, queries `scoop export` for already-installed apps, and for each applicable row either installs the app, updates it (when already installed and not version-pinned), or skips it (when already installed with a pinned version).
+Reads the app list with `Import-AppCsv -DataFileKey ScoopApps`, which resolves the committed CSV through `BootstrapConfig.DataFiles.ScoopApps` in `Configuration.psd1` and layers the sibling `ScoopApps.local.csv` over it when one exists, so this machine's own choices apply without the tracked CSV ever being edited. Each row specifies an app name, optional bucket, version, global flag, and the machine types it applies to. The function determines the current machine type, queries `scoop export` for already-installed apps, and for each applicable row either installs the app, updates it (when already installed and not version-pinned), or skips it (when already installed with a pinned version).
 
 ```powershell
 # Install all Scoop apps applicable to the current machine type
 Install-ScoopApps
 ```
 
-**See also:** [Modules: Workflow](workflow.md)
+**See also:** [Import-AppCsv](bootstrap.md#import-appcsv), [Modules: Workflow](workflow.md)
 
 ## [Install-ScoopPackageManager](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Install-ScoopPackageManager.ps1)
 
@@ -147,8 +147,10 @@ Install-ScoopPackageManager
 
 ## [Install-WingetApps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Install-WingetApps.ps1)
 
-- **Description:** Installs WinGet-managed apps from the WinuX CSV, filtered by machine type. Reads the app list from `BootstrapConfig.DataFiles.WinGetApps` in `Configuration.psd1`; apps matching the current machine type (or marked `All`) are installed, others are skipped. `Machine`-column tokens are validated via `Test-MachineTypeScope` - unknown machine types are reported and never match. Requires administrator privileges and is called automatically by Bootstrap.
+- **Description:** Installs WinGet-managed apps from the WinuX CSV, filtered by machine type. Reads the app list through `Import-AppCsv`, which layers the machine-local `WinGetApps.local.csv` over the committed CSV named by `BootstrapConfig.DataFiles.WinGetApps` in `Configuration.psd1`; apps matching the current machine type (or marked `All`) are installed, others are skipped. `Machine`-column tokens are validated via `Test-MachineTypeScope` - unknown machine types are reported and never match. Requires administrator privileges and is called automatically by Bootstrap.
 - **Usage:** `Install-WingetApps`
+
+The list is read with `Import-AppCsv -DataFileKey WinGetApps`, so the sibling `WinGetApps.local.csv` is layered over the committed list and this machine's own choices apply without the tracked CSV ever being edited.
 
 Each CSV row specifies an app ID, version, installation scope (`d` default / `m` machine / `u` user), interactive flag, source (`w` winget / `s` msstore), and the machine types it applies to. The machine type is resolved at runtime and rows whose `Machine` column does not include the current type or `All` are skipped. For apps pinned at `Latest`, an existing WinGet pin is removed first so the latest version can install cleanly.
 
@@ -156,7 +158,7 @@ The function is fully unattended. Before touching any app it queries each source
 
 Every install is verified: a nonzero winget exit code triggers a `winget list --id` ground-truth check (nonzero codes are not uniformly failures - "already installed" variants are benign), and genuinely failed installs are collected and printed as an explicit summary at the end (app id, exit code, and how to retry) instead of scrolling by invisibly in the bootstrap output.
 
-**Data Source:** `WinGetApps.csv`
+**Data Source:** `WinGetApps.csv`, plus the machine-local `WinGetApps.local.csv` overlay when present
 
 ```csv
 App,Version,Scope,Interactive,Source,Machine
@@ -170,7 +172,7 @@ Valve.Steam,Latest,d,n,w,PC
 Install-WingetApps
 ```
 
-**See also:** [Modules: Bootstrap](bootstrap.md)
+**See also:** [Import-AppCsv](bootstrap.md#import-appcsv), [Modules: Bootstrap](bootstrap.md)
 
 ## [Invoke-Browser](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Invoke-Browser.ps1)
 
@@ -357,10 +359,11 @@ Runs a multi-step privacy workflow:
 
 Requires the Window module to be loaded (for Win32 `ShowWindow` access).
 
-> **Requires Tor Browser** - the base bootstrap does not install it. Enable the commented
-> `TorProject.TorBrowser` row in `WinGetApps.csv` (WinGet installs the portable build onto the
-> Desktop; move the "Tor Browser" folder to `{User}\Tor Browser`, where the default
-> `Universal.Browsers.Tor` entry points), install it manually, or provision it in a fork via
+> **Requires Tor Browser** - the base bootstrap does not install it. Add a
+> `TorProject.TorBrowser,Latest,d,n,w,All` row to your machine-local
+> [`WinGetApps.local.csv`](../reference/software-list.md#machine-local-overlay) (WinGet installs the
+> portable build onto the Desktop; move the "Tor Browser" folder to `{User}\Tor Browser`, where the
+> default `Universal.Browsers.Tor` entry points), install it manually, or provision it in a fork via
 > `BootstrapConfig.PersonalSteps`.
 
 ```powershell

--- a/docs/modules/bootstrap.md
+++ b/docs/modules/bootstrap.md
@@ -118,6 +118,47 @@ Recurses into nested hashtables and `IList` collections, expanding every string 
 $expanded = Expand-Hashtable -Source $config -DevPath "<DevRoot>" -UserPath "C:\Users\<User>" -MachineTypeName "MyMachine"
 ```
 
+## [Import-AppCsv](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Bootstrap/Functions/Import-AppCsv.ps1)
+
+- **Description:** The single read path for the three app lists. Parses the committed CSV named by `BootstrapConfig.DataFiles`, layers the sibling machine-local `<name>.local.csv` over it when one exists, and returns the combined active rows. It is for app lists exactly what `Configuration.local.psd1` is for settings: the committed CSV stays the shipped baseline upstream can keep improving, everything a person chose for this machine lives in the overlay beside it, so a fork never has to edit a tracked CSV and pulling upstream never conflicts on one.
+- **Parameters:** -DataFileKey, -RepoRoot
+- **Usage:** `Import-AppCsv -DataFileKey WinGetApps`, `Import-AppCsv -DataFileKey ScoopApps | Where-Object { $_.Global -eq 'true' }`
+
+Called by `Install-WinGetApps`, `Install-ScoopApps`, `Install-ChocolateyApps` and `Get-PinnedApps` in place of a plain `Import-Csv`, so every reader sees the same effective list and the comment-and-blank-row filtering each of them used to do individually now lives in one place.
+
+Layering rules:
+
+| Overlay row                        | Effect                                                                                                                                                        |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `App` matches a base row           | **Replaces** that row in place, which is what lets the overlay pin a version, change the install scope, or re-target a machine without touching the base.      |
+| `App` is new                       | **Added**, after the committed rows.                                                                                                                          |
+| `App` is `-<id>`                   | **Removes** the matching base row. Without this there would be no way to opt out of a shipped app, since a layer that can only add or replace cannot subtract. |
+| `App` starts with `#`, or is blank | Dropped, in the committed file and the overlay alike.                                                                                                          |
+
+Matching is **case-insensitive**, because package ids are. Row order is base-first, then overlay-only additions, so the shipped install order is preserved and this machine's own apps follow it. A row whose `App` still carries the `-` marker is never returned - the marker is an instruction, not a package id. When an overlay both removes and replaces the same `App`, the **removal wins**, whichever order the two rows appear in.
+
+A missing overlay is the normal case and is **not** an error; most machines never write one. A missing **base** file is an error, since it is a tracked file the repository is supposed to ship.
+
+| Parameter      | Type   | Required | Description                                                                                                                                                                                                       |
+| -------------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-DataFileKey` | String | Yes      | Which list to read: `WinGetApps`, `ScoopApps` or `ChocolateyApps`. Resolved through `BootstrapConfig.DataFiles`, so the location stays configuration-driven. Anything outside that set is rejected by `ValidateSet`. |
+| `-RepoRoot`    | String | No       | Repository root the relative data-file path is resolved against. Defaults to `$global:MachineSpecificPaths.Projects.Self.Root`.                                                                                     |
+
+```powershell
+# The active WinGet rows, with any machine-local overlay applied
+Import-AppCsv -DataFileKey WinGetApps
+
+# Filter the combined list exactly as a plain Import-Csv result would be filtered
+Import-AppCsv -DataFileKey ScoopApps | Where-Object { $_.Global -eq 'true' }
+```
+
+> [!IMPORTANT]
+> The column header must be **line 1** of the committed file and of the overlay, with any commentary after it. `Import-Csv` takes line 1 as the header unconditionally, so a leading comment line becomes the header and every real row then parses under a bogus column name with an empty `App` - which this function's own blank-`App` filter would then silently discard.
+
+This function only reads. [Save-AppCsvOverlay](configuration.md#save-appcsvoverlay) writes the overlay, and the committed CSV is never modified by either.
+
+**See also:** [Save-AppCsvOverlay](configuration.md#save-appcsvoverlay), [Software List: Machine-Local Overlay](../reference/software-list.md#machine-local-overlay), [Test-MachineTypeScope](#test-machinetypescope), [Fork Model](../contributing/fork-model.md)
+
 ## [Initialize-Configuration](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Bootstrap/Functions/Initialize-Configuration.ps1)
 
 - **Description:** First-run writer that captures your personal identity and paths into a sibling `Configuration.local.psd1` override - never into the committed `Configuration.psd1`. WinuX ships a generic base config (blank Git identity, placeholder paths) and commits no personal data; this function writes only the keys that differ - `GitConfig.UserName`/`UserEmail`, the `BasePaths.<MachineType>` `{Dev}`/`{User}` roots, and this machine's `HostnameToMachineType` entry - which `Load-PathConfiguration` deep-merges over the base at load time. Because the base file is never edited, pulling upstream updates into a fork never conflicts on configuration. Validates that the generated override parses before writing, and does nothing if the override already has a Git identity unless `-Force` is given.
@@ -410,6 +451,8 @@ Bootstrap uses CSV files for package definitions:
 | `WinGetApps.csv`     | `Modules/Bootstrap/Data/` | WinGet packages     |
 | `ScoopApps.csv`      | `Modules/Bootstrap/Data/` | Scoop packages      |
 | `ChocolateyApps.csv` | `Modules/Bootstrap/Data/` | Chocolatey packages |
+
+Each of the three may have a machine-local `<name>.local.csv` beside it, which [Import-AppCsv](#import-appcsv) layers over the committed list and [Save-AppCsvOverlay](configuration.md#save-appcsvoverlay) writes. Nothing ever edits the committed CSV, so a fork's own app choices never touch a tracked file and upstream can keep improving the baseline. WinuX gitignores the overlays, exactly as it gitignores `Configuration.local.psd1`. See [Software List: Machine-Local Overlay](../reference/software-list.md#machine-local-overlay).
 
 ### WinGetApps.csv Format
 

--- a/docs/modules/configuration.md
+++ b/docs/modules/configuration.md
@@ -2,6 +2,8 @@
 
 The Configuration module provides **reliable programmatic modification** of `Configuration.psd1` - adding browser groups, workspaces, projects, symbolic links, and window layouts without manual text editing.
 
+`Save-AppCsvOverlay` extends the same base-plus-override discipline that `Configuration.local.psd1` gives settings to the three app list CSVs: it writes only `<name>.local.csv`, never the committed list, and [`Import-AppCsv`](bootstrap.md#import-appcsv) layers the two at read time.
+
 ## [Add-BrowserGroup](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Configuration/Functions/Add-BrowserGroup.ps1)
 
 - **Description:** Adds a new browser URL group to the `BrowserGroups` array in `Configuration.psd1`. Supports named URLs with labels (recommended, via `-Urls`) and simple URL lists (via `-SimpleUrls`).
@@ -193,6 +195,60 @@ $section = Find-ConfigurationSection -Lines $lines -SectionName "BrowserGroups"
 
 **See also:** [Add Browser Group](../configuration/guides/add-browser-group.md)
 
+## [Save-AppCsvOverlay](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Configuration/Functions/Save-AppCsvOverlay.ps1)
+
+- **Description:** Writes the machine-local app list overlay, validating before it replaces anything. The only function that writes an overlay: it replaces `<name>.local.csv` wholesale from the rows it is given, having first proved the result parses and that every row is something the installers can actually act on.
+- **Parameters:** -DataFileKey, -Row, -RepoRoot, -NoBackup
+- **Usage:** `Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = "Obsidian.Obsidian"; Machine = "All" })`, `Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = "-Microsoft.PowerToys"; Machine = "All" })`, `Save-AppCsvOverlay -DataFileKey ScoopApps -Row @() -WhatIf`
+
+**Only the overlay is ever written.** The committed CSV is read to take its column header and to validate against, and is never modified - which is what keeps a fork's app choices out of a tracked file and stops an upstream pull from conflicting on one. [`Import-AppCsv`](bootstrap.md#import-appcsv) then layers what is written here over the shipped list, exactly as the shell layers `Configuration.local.psd1` over `Configuration.psd1`.
+
+Validation runs in order against a candidate held in memory, so a refusal leaves the live overlay byte-identical:
+
+1. **Every row needs a non-empty `App`** - there would otherwise be nothing to install.
+2. **Every `Machine` cell must be `All`, or known machine types joined with `/`.** A blank or unknown token silently matches nothing, so the row would sit in the overlay looking installed and never install, which is the most confusing possible outcome. Tokens are checked against `ValidMachineTypes`, and **every** token of a `/` list is checked rather than only the first, since one good token would otherwise hide a typo in the rest of the cell.
+3. **The candidate must round-trip through `Import-Csv`** and come back with the same row count. Values containing a comma or a double quote are quoted (and embedded quotes doubled), and this is the gate that proves it worked rather than assuming it.
+
+Only then is the existing overlay copied to `<name>.local.csv.bak` and the candidate moved over it. The candidate is staged in the destination folder so the replace is a same-volume rename a reader can never observe half-written, and restoring the `.bak` is a complete undo. `-WhatIf` runs the whole validation and reports what would be written without writing it, without backing anything up and without leaving a staged file behind.
+
+The **column header is line 1** of what it writes, and the comment banner goes after it. That order is not cosmetic: `Import-Csv` takes line 1 as the header unconditionally, so a leading comment would be read as the header, every real row would parse under a bogus column name with an empty `App`, and the reader's blank-`App` filter would then discard the whole overlay in silence. The columns themselves are taken from the committed file's header, so a row carrying an unknown extra key adds no column and the overlay's shape can never drift from what the installer reads.
+
+A **removal** is expressed as a row whose `App` is `-<id>`, which is how the overlay opts out of an app the committed list ships. `Import-AppCsv` applies that; nothing here needs to know the base file's contents beyond validating machine tokens. Passing **no rows** writes an empty overlay (header and banner only), which is the correct way to say "this machine adds nothing" and is different from having no overlay file at all.
+
+| Parameter      | Description                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `-DataFileKey` | Which list to write: `WinGetApps`, `ScoopApps` or `ChocolateyApps`. Mandatory, positional; resolved through `BootstrapConfig.DataFiles`.                                                                                                                                                        |
+| `-Row`         | The overlay rows, as hashtables. Each must have an `App` and a `Machine`; the remaining columns are taken from the committed file's header, so a key it does not name is ignored and a column it does name but the row omits is written empty. An empty collection writes a header-only overlay. |
+| `-RepoRoot`    | Repository root the data-file path is resolved against. Defaults to the running repository. Passing it **blank** is refused rather than silently falling back, since that would write beside the tracked lists when the caller meant a sandbox.                                                  |
+| `-NoBackup`    | Do not write a `.bak` copy. Not recommended; it removes the one-click undo.                                                                                                                                                                                                                     |
+
+The returned object reports `OverlayPath`, `BackupPath`, `RowCount` and `Written`.
+
+```powershell
+# Add one app for every machine, leaving the committed list untouched
+Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(
+    @{ App = "Obsidian.Obsidian"; Version = "Latest"; Scope = "d"; Interactive = "n"; Source = "w"; Machine = "All" }
+)
+
+# Pin a version for an app the committed list already ships (the matching row is replaced)
+Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(
+    @{ App = "Microsoft.PowerShell"; Version = "7.4.6"; Scope = "d"; Interactive = "n"; Source = "w"; Machine = "PC/Work" }
+)
+
+# Opt this machine out of a shipped app
+Save-AppCsvOverlay -DataFileKey WinGetApps -Row @(@{ App = "-Microsoft.PowerToys"; Machine = "All" })
+
+# Validate and report what would be written, without writing it
+Save-AppCsvOverlay -DataFileKey ScoopApps -Row @() -WhatIf
+```
+
+> [!IMPORTANT]
+> The overlay is replaced **wholesale**, not edited row by row. A caller that wants to add one app has to pass the rows it wants to keep as well - read the current set with `Import-AppCsv` first. This is the one place the app overlay differs from `Configuration.local.psd1`, which is edited by hand or by the `Add-*` builders.
+
+Errors are raised as exceptions and progress goes to `Write-Verbose` rather than the logging module, so this writer is usable from an interactive shell and from the compiled installer alike. Callers render their own messages.
+
+**See also:** [Import-AppCsv](bootstrap.md#import-appcsv), [Software List: Machine-Local Overlay](../reference/software-list.md#machine-local-overlay), [Fork Model](../contributing/fork-model.md)
+
 ## [Test-ConfigurationKeyPath](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Configuration/Functions/Test-ConfigurationKeyPath.ps1)
 
 - **Description:** Tests whether an ordered configuration key path resolves to a non-empty value. Walks a hashtable using the provided key path and returns `$true` only when every segment exists and the final resolved value is not `$null` or an empty string. Used internally by `Test-ConfigurationSchema` to validate required top-level and nested settings.
@@ -264,6 +320,10 @@ All functions are covered by Pester tests in `Modules/Tests/Modules/Configuratio
 | `Add-Project.Tests.ps1`               | 8     | Basic, defaults, custom actions, TerminalTabs, ProjectTerminals, RunnableProjects, PathMappings, full |
 | `Add-SymbolicLink.Tests.ps1`          | 4     | Simple link, preserve existing, nested links, valid format                                            |
 | `Add-WindowLayout.Tests.ps1`          | 8     | File creation, multiple machines, no overwrite, valid data, SimpleLayoutWorkspaces                    |
+| `Save-AppCsvOverlay.Tests.ps1`        | 20    | Overlay written and reported, the committed CSV byte-identical, header on line 1, comment banner, backups, `-WhatIf`, every machine-token refusal, blank `-RepoRoot`, comma and quote round-trips, header-only overlay, columns from the base header, temp-file hygiene |
+
+> [!IMPORTANT]
+> `Save-AppCsvOverlay` writes files, and the overlay it writes lands beside the committed CSV in `Modules/Bootstrap/Data/`. Its tests therefore build a synthetic app list in a sandbox repository under `$TestDrive` and pass it as `-RepoRoot`; a test pointed at the working tree would drop overlays into the tracked data folder, where they would shadow the real committed app lists. The folder is rebuilt for every test, so no stale overlay or `.bak` can make an assertion pass for the wrong reason, and "the committed list is never modified" is asserted as an exact byte comparison rather than a text one.
 
 Run tests with:
 

--- a/docs/modules/system.md
+++ b/docs/modules/system.md
@@ -234,24 +234,28 @@ Get-InstalledApps
 
 ## [Get-PinnedApps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Get-PinnedApps.ps1)
 
-- **Description:** Reads version-pinned apps from a package-manager CSV file (e.g. WinGetApps.csv, ScoopApps.csv) and returns their app names. Used to identify apps that should NOT be upgraded because they are locked to a specific version. Helper function for `Upgrade-All`.
-- **Parameters:** -CsvFileName, -VersionExcludeValue
-- **Usage:** `Get-PinnedApps -CsvFileName "Windows/bootstrap/WinGetApps.csv"`, `Get-PinnedApps -CsvFileName "Windows/bootstrap/ScoopApps.csv" -VersionExcludeValue "latest"`
+- **Description:** Returns the version-pinned apps of one app list, machine-local overlay included. Reads the list through [`Import-AppCsv`](bootstrap.md#import-appcsv) and returns the `App` of every row whose `Version` is a real version rather than the "track the latest" value. Used to identify apps that should NOT be upgraded because they are locked to a specific version. Helper function for `Upgrade-All`.
+- **Parameters:** -DataFileKey, -VersionExcludeValue
+- **Usage:** `Get-PinnedApps -DataFileKey WinGetApps`, `Get-PinnedApps -DataFileKey ScoopApps -VersionExcludeValue "latest"`
 
-Imports the given CSV and returns the `App` values of every row whose `Version` field is set and does not match the exclude value. The CSV path is resolved relative to `MachineSpecificPaths.Projects.Self.Root`. Apps whose version equals the exclude value (default `"Latest"`) are treated as unpinned and are omitted from the results.
+Apps whose version equals the exclude value (default `"Latest"`) are treated as unpinned and are omitted from the results. Comment and blank rows are dropped: a `#` line containing commas parses into a bogus row with a non-`"Latest"` Version, and feeding that to `winget pin add` once hung an unattended upgrade.
 
-| Parameter              | Description                                                                                                                            |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `-CsvFileName`         | Relative path to the CSV file (e.g. `"Windows/bootstrap/WinGetApps.csv"`). Resolved against `MachineSpecificPaths.Projects.Self.Root`. |
-| `-VersionExcludeValue` | Version value treated as "not pinned" and excluded from results. Defaults to `"Latest"`.                                               |
+Reading through `Import-AppCsv` rather than the committed CSV directly is what makes the pin honour the [machine-local overlay](../reference/software-list.md#machine-local-overlay), and it matters in both directions: a version pinned only in the overlay is invisible in the base file, so a direct reader would let `Upgrade-All` upgrade straight past the pin - the exact outcome pinning exists to prevent - and an app the overlay removed would still be reported as pinned.
+
+| Parameter              | Description                                                                                                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-DataFileKey`         | Which list to read: `WinGetApps`, `ScoopApps` or `ChocolateyApps`. Mandatory, positional; resolved through `BootstrapConfig.DataFiles`, the same way the installers resolve it. |
+| `-VersionExcludeValue` | The `Version` value that means "not pinned". Defaults to `"Latest"` (WinGet); Scoop writes `"latest"`, and Chocolatey leaves the cell empty, so its caller passes `$null`.  |
 
 ```powershell
 # Return WinGet apps locked to a specific version (Version other than "Latest")
-Get-PinnedApps -CsvFileName "Windows/bootstrap/WinGetApps.csv"
+Get-PinnedApps -DataFileKey WinGetApps
 
 # Same for Scoop, excluding the lowercase "latest" sentinel
-Get-PinnedApps -CsvFileName "Windows/bootstrap/ScoopApps.csv" -VersionExcludeValue "latest"
+Get-PinnedApps -DataFileKey ScoopApps -VersionExcludeValue "latest"
 ```
+
+**See also:** [Import-AppCsv](bootstrap.md#import-appcsv), [Upgrade-All](#upgrade-all)
 
 ## [Initialize-OhMyPosh](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Initialize-OhMyPosh.ps1)
 
@@ -1225,11 +1229,11 @@ Update-DirectoryNames -Path "C:\My Folders" -WhatIf
 
 ## [Upgrade-All](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Upgrade-All.ps1)
 
-- **Description:** Upgrades all packages across WinGet, Scoop, and/or Chocolatey. Reads pinned (version-locked) apps from the configured CSV files and prevents them from being upgraded. Without `-PackageManager` it upgrades across all managers listed in `PackageManagers` in `Configuration.psd1`; with `-PackageManager` it upgrades only the specified manager. Requires administrator privileges.
+- **Description:** Upgrades all packages across WinGet, Scoop, and/or Chocolatey. Reads pinned (version-locked) apps from the configured app lists - via `Get-PinnedApps`, so a version pinned in a machine-local `<name>.local.csv` overlay counts too - and prevents them from being upgraded. Without `-PackageManager` it upgrades across all managers listed in `PackageManagers` in `Configuration.psd1`; with `-PackageManager` it upgrades only the specified manager. Requires administrator privileges.
 - **Parameters:** -PackageManager
 - **Usage:** `Upgrade-All`, `Upgrade-All -PackageManager "WinGet"`
 
-For each targeted manager the function first loads its version-pinned apps from the manager's CSV data file, warns about them, and pins them so they are excluded from the upgrade, then runs the manager's bulk upgrade (`winget upgrade --all`, `scoop update *`, or `choco upgrade all -y`) and reports success or the failing exit code per manager.
+For each targeted manager the function first loads its version-pinned apps through [`Get-PinnedApps`](#get-pinnedapps) (which reads the effective list, overlay included), warns about them, and pins them so they are excluded from the upgrade, then runs the manager's bulk upgrade (`winget upgrade --all`, `scoop update *`, or `choco upgrade all -y`) and reports success or the failing exit code per manager.
 
 | Parameter         | Description                                                                                                                   |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/reference/software-list.md
+++ b/docs/reference/software-list.md
@@ -1,9 +1,9 @@
 # Software List
 
 Everything the base WinuX bootstrap installs, and where it comes from. The CSV files under
-`Windows\PowerShell\Modules\Bootstrap\Data\` are the source of truth - each fork curates its
-own lists (the CSVs are `merge=ours` fork-owned, so upstream pulls never overwrite them). This
-page documents the shipped template.
+`Windows\PowerShell\Modules\Bootstrap\Data\` are the source of truth. WinuX ships only the
+software its own features need; everything you add for yourself goes in a machine-local
+`<name>.local.csv` beside it - see [Machine-Local Overlay](#machine-local-overlay).
 
 ## How installs are driven
 
@@ -19,7 +19,71 @@ page documents the shipped template.
   Tokens are validated against `ValidMachineTypes` via `Test-MachineTypeScope` - unknown machine
   types are reported via `Write-LogError` and never match.
 - All three package managers are installed by Bootstrap even when their CSV is empty - add rows
-  and re-run to install more.
+  to the matching overlay and re-run to install more.
+
+## Machine-Local Overlay
+
+Each committed list may have a machine-local overlay beside it in `Modules/Bootstrap/Data/`:
+
+| Committed list       | Machine-local overlay      |
+| -------------------- | -------------------------- |
+| `WinGetApps.csv`     | `WinGetApps.local.csv`     |
+| `ScoopApps.csv`      | `ScoopApps.local.csv`      |
+| `ChocolateyApps.csv` | `ChocolateyApps.local.csv` |
+
+[`Import-AppCsv`](../modules/bootstrap.md#import-appcsv) layers the overlay over the committed list
+at read time, and every reader goes through it - all three installers and `Get-PinnedApps` - so what
+the overlay says is what gets installed and what stays pinned.
+[`Save-AppCsvOverlay`](../modules/configuration.md#save-appcsvoverlay) is the only thing that writes
+an overlay, and **neither ever modifies a committed CSV**.
+
+This is for app lists what `Configuration.local.psd1` is for settings: the tracked list stays the
+shipped baseline upstream can keep improving, everything chosen for this machine lives beside it, so
+a fork never edits a tracked CSV and pulling upstream never conflicts on an app choice. WinuX
+gitignores the overlays for the same reason it gitignores `Configuration.local.psd1`.
+
+An overlay uses the same columns as the list it sits beside, and the same rule that the **header is
+line 1** with any comments after it - `Import-Csv` reads line 1 as the header unconditionally, so a
+leading comment would be taken as the column names and every row below it would be discarded.
+
+### Adding, overriding and removing an app
+
+```csv
+App,Version,Scope,Interactive,Source,Machine
+
+# WinGetApps.local.csv - this machine's own app choices.
+# Added: an App the committed list does not have
+Obsidian.Obsidian,Latest,d,n,w,All
+# Override: the same App as a committed row, so it replaces it (here to pin a version)
+Microsoft.PowerShell,7.4.6,d,n,w,All
+# Removed: a leading - opts this machine out of a shipped app
+-Microsoft.PowerToys,Latest,d,n,w,All
+```
+
+- **Add** - a new `App` is appended after the shipped rows, so the committed install order is kept
+  and your own apps follow it.
+- **Override** - an `App` matching a committed row replaces that row in place, which is how you pin
+  a version, change the `Scope`, or re-target the `Machine` column without touching the base list.
+  Matching is case-insensitive, because package ids are.
+- **Remove** - an `App` written as `-<id>` drops the committed row. This is the only way to opt out
+  of a shipped app; commenting the row out in the committed CSV would edit a tracked file.
+- A row whose `App` starts with `#` or is blank is ignored, in the overlay exactly as in the
+  committed list. A header-only overlay is valid and changes nothing.
+- If one overlay both removes and overrides the same `App`, the **removal wins**, whichever order
+  the two rows are written in.
+
+You can write an overlay by hand, or through `Save-AppCsvOverlay`, which validates every row before
+it replaces anything (an empty `App`, a blank `Machine` cell, or an unknown machine token is refused,
+because such a row would look installed and never install), keeps a `.bak` of the previous overlay,
+and swaps the new one in atomically.
+
+### Committing your overlays in a fork
+
+WinuX gitignores `*.local.csv`, exactly as it gitignores `Configuration.local.psd1`: both are
+personal, and upstream ships only the generic baseline. If you run several machines and want your
+app choices to travel between them, **commit the overlays in your fork** - remove the ignore line
+(or `git add -f` them). Upstream never tracks those paths, so committing them downstream never
+conflicts on a pull. Ignore the writers' `.bak` files either way; they are noise.
 
 ## Shipped WinGet apps
 
@@ -57,12 +121,26 @@ Installed via `Install-PowerShellModules`:
 | `ps2exe`         | Convert scripts to .exe            |
 | `Pester`         | Testing framework                  |
 
-## Commented examples
+## Adding your own software
 
-`WinGetApps.csv` ships a block of commented example rows you can uncomment or use as patterns:
-editors and dev toolchains (Neovim, Visual Studio Community, .NET SDK, Node.js, Python, Docker
-Desktop, VirtualBox), CLI utilities (7zip, ripgrep, fzf, zoxide, fd, jq, lazygit), and apps
-(Obsidian, Notepad++, VLC). It also carries a commented `TorProject.TorBrowser` row for
-[`Open-SecureBrowser`](../modules/application.md#open-securebrowser) - WinGet installs Tor
-Browser as a portable build onto the Desktop; move the "Tor Browser" folder to
-`{User}\Tor Browser`, where the default `Universal.Browsers.Tor` entry points.
+Put it in the [machine-local overlay](#machine-local-overlay), never in the committed CSV. Some
+common starting points, all `Machine = All`:
+
+| Category                | Rows for `WinGetApps.local.csv`                                                                                                                                                       |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Editors / dev toolchains | `Neovim.Neovim`, `Microsoft.VisualStudio.Community`, `Microsoft.DotNet.SDK.9`, `OpenJS.NodeJS.LTS`, `Python.Python.3.13`, `Docker.DockerDesktop`, `Oracle.VirtualBox`                 |
+| CLI utilities            | `7zip.7zip`, `BurntSushi.ripgrep.MSVC`, `junegunn.fzf`, `ajeetdsouza.zoxide`, `sharkdp.fd`, `jqlang.jq`, `JesseDuffield.lazygit`                                                      |
+| Apps                     | `Obsidian.Obsidian`, `Notepad++.Notepad++`, `VideoLAN.VLC`                                                                                                                            |
+
+```csv
+App,Version,Scope,Interactive,Source,Machine
+
+Obsidian.Obsidian,Latest,d,n,w,All
+BurntSushi.ripgrep.MSVC,Latest,d,n,w,All
+```
+
+`TorProject.TorBrowser` is the one worth calling out: it is what
+[`Open-SecureBrowser`](../modules/application.md#open-securebrowser) needs, and the base bootstrap
+does not install it. WinGet installs Tor Browser as a portable build onto the Desktop; move the
+"Tor Browser" folder to `{User}\Tor Browser`, where the default `Universal.Browsers.Tor` entry
+points.


### PR DESCRIPTION
## Description

The three app list CSVs get the same base-plus-override split that `Configuration.local.psd1` gives settings, and for the same reason.

Until now a fork's own apps could only live in the tracked CSVs, so every fork edited a file upstream also owns. The `merge=ours` attribute those three files carried made that survivable but not good: it pinned the fork's copy permanently, which meant the fork never received an upstream base-list change either. That is the same trade-off we deliberately avoided for configuration by giving it an override file instead of a merge driver.

So the CSVs now work the way `Configuration.psd1` does:

- **`Import-AppCsv`** (Bootstrap) is the single read path. It parses the committed CSV named by `BootstrapConfig.DataFiles`, layers a sibling `<name>.local.csv` over it when one exists, and returns the combined active rows. An overlay row whose `App` matches a base row **replaces** it (pin a version, change the scope, re-target the `Machine` column), a new `App` is **added** after the shipped rows so the committed install order is preserved, and an `App` written as `-<id>` **removes** a shipped row - without which there would be no way to opt out of an app the base ships, since a layer that can only add or replace cannot subtract. Matching is case-insensitive because package ids are; a removal beats a replacement of the same `App` whichever order the rows appear in; comment and blank rows are dropped from both files, which is the filtering all three installers previously each did for themselves. A missing overlay is the normal case and not an error; a missing base file is, since it is tracked.
- **`Save-AppCsvOverlay`** (Configuration) is the only writer. It replaces `<name>.local.csv` wholesale, having first proved - against a candidate held in memory, so a refusal leaves the live file byte-identical - that every row carries an `App`, that every `Machine` cell is `All` or known machine types joined with `/`, and that the result round-trips through `Import-Csv` with the same row count. Only then is the previous overlay copied to `.bak` and the candidate moved over it, staged in the destination folder so the replace is a same-volume rename no reader can observe half-written.
- **Every reader goes through `Import-AppCsv`** - all three `Install-*Apps` functions and `Get-PinnedApps`.

`Get-PinnedApps` is the part worth a second look. `Upgrade-All` uses it to block upgrades of version-pinned apps, and it parsed the committed CSV directly. Once overlays exist that is wrong in both directions: a version pinned only in the overlay is invisible in the base file, so `Upgrade-All` would upgrade straight past the pin - the exact outcome pinning exists to prevent - and an app the overlay removed would still be reported as pinned and handed to `winget pin add`. It now reads the effective list and takes `-DataFileKey` in place of `-CsvFileName`.

The committed lists are trimmed to just what WinuX itself needs, and their commented example rows are replaced by a pointer to the overlay - the examples were an invitation to edit a tracked file, which is precisely what the overlay removes the need for. The catalogue of suggested package ids moved to `docs/reference/software-list.md`.

**One gotcha the implementation is shaped around:** the column header must be line 1 of both files, with any commentary after it. `Import-Csv` takes line 1 as the header unconditionally, so a leading comment becomes the column names, every real row parses under a bogus column with an empty `App`, and the reader's blank-`App` filter then discards the whole file in silence. That is asserted directly on the written file in the tests.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [x] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

### What breaks, and how to migrate

**1. `merge=ours` is removed from the three app CSVs.** They are now ordinary upstream-tracked files, which is what lets a fork keep receiving base-list improvements instead of pinning its own copy forever. A fork that still keeps its apps in the committed CSVs will have them overwritten by its next `git merge upstream/master`. Migrating is a one-time copy:

```powershell
# 1. Move your added rows into a new overlay (same header on line 1), and write
#    -<id> rows for any shipped app you had deleted from the committed list.
# 2. Restore the committed lists to upstream's version:
git checkout upstream/master -- Windows/PowerShell/Modules/Bootstrap/Data/
```

The step-by-step note lives in [the fork model](docs/contributing/fork-model.md#keeping-your-own-app-lists-the-localcsv-overlay). The payload configs (`Git/.gitconfig`, `NuGet/nuget.config`, `Firefox/user.js`, `docs/custom/README.md`) keep `merge=ours`; they have no base-plus-override split and are wholly the fork's.

**2. `Get-PinnedApps` takes `-DataFileKey` instead of `-CsvFileName`.** Its only caller in-tree is `Upgrade-All`, which is updated. A fork calling it directly changes `Get-PinnedApps -CsvFileName $config.BootstrapConfig.DataFiles.WinGetApps` to `Get-PinnedApps -DataFileKey WinGetApps`.

## Quality bar

- [x] The change is **minimal and focused** (one logical change; reuses existing helpers, no duplication / DRY).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` using placeholder paths (`{Dev}`, `{User}`, `{MachineType}`, `{RepoRoot}`, `{AppData}`).

## Tests

```powershell
Run-Tests -TestName "Import-AppCsv"          # Passed: 17, Failed: 0
Run-Tests -TestName "Save-AppCsvOverlay"     # Passed: 20, Failed: 0
Run-Tests -TestName "Get-PinnedApps"         # Passed:  3, Failed: 0
Run-Tests -TestName "Install-WingetApps"     # Passed:  2, Failed: 0
Run-Tests -TestName "Install-ScoopApps"      # Passed:  1, Failed: 0
Run-Tests -TestName "Install-ChocolateyApps" # Passed:  1, Failed: 0
Run-Tests -TestName "Upgrade-All"            # Passed:  1, Failed: 0
```

Full suite: 1310 tests, with the failure set compared against a pristine `master` worktree run under identical conditions - **identical before and after**, so this change introduces no regression.

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/`.
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text.
- [ ] N/A - no testable behavior changed (docs/chore only).

Both new test files build a synthetic app list in a sandbox repository under `$TestDrive` and pass it as `-RepoRoot`. That is deliberate: an overlay lives *beside* its base file, so a test pointed at the working tree would drop fixtures into the tracked `Data/` folder where they would shadow the real committed lists. "The committed list is never modified" is asserted as an exact byte comparison rather than a text one, so an encoding or line-ending change would also count as a change.

## Documentation & manifests

- [x] I updated `docs/modules/<Module>.md` for any added/renamed/removed/changed function.
- [x] I updated the module `.psd1` `FunctionsToExport`.
- [x] I updated `docs/docs_overview.md` (and `docs/_sidebar.md` if a page was added/removed).
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds.
- [ ] N/A - no exported function changed.

Docs touched: `modules/bootstrap.md` (new `Import-AppCsv` entry + Data Files), `modules/configuration.md` (new `Save-AppCsvOverlay` entry + testing table), `modules/application.md` (three installers), `modules/system.md` (`Get-PinnedApps`, `Upgrade-All`), `reference/software-list.md` (new **Machine-Local Overlay** section), `contributing/fork-model.md` (app lists moved from `merge=ours` to the overlay, with the migration note), `getting-started/first-run.md`, `configuration/repository-structure.md`, `docs_overview.md`.

## Tested on

- Windows version: Windows 11 Pro 25H2
- PowerShell version: 7.6.4
- Machine type(s): PC via a private fork

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] This PR contains no secrets or personal data (tokens, real paths/hostnames/emails).