### PR TITLE
Add automatic idle-time log maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.24] - 2026-08-04
+
+### Added
+
+- `Invoke-LogMaintenance` (Logging module): the periodic, silent housekeeping sweep over every log the repository generates, and the piece that makes retention actually happen on machines that only ever open shells. `Clear-OldLogs` has always enforced the session-log limits, but nothing called it in an ordinary session - it runs from `Stop-Logging`, which only bootstrap flows reach - so a machine that never bootstraps accumulated session logs without bound (nearly 400 of them on the machine that prompted this, against a configured cap of 20). The sweep calls `Clear-OldLogs` with the configured limits, then prunes `Tests\Results` with the same rules `Invoke-TestSuite` applies at run start - run logs beyond the newest ten, worker XMLs whose owning run log is gone, abandoned `Work\` directories - so `Results/` stays bounded even on a machine that stopped running the suite. Everything on the Results side is age-gated to one day, because a live test run's artifacts exist before its run log does (the log is merged at the end of the run): without the gate a sweep landing mid-run could delete the XMLs of a run still in flight, and with it nothing younger than a day is eligible while runs last minutes. `timings.json`, `.gitkeep` files and `Logs/Pinned` are never touched. Throttled through a stamp file (`Logs\.last-maintenance`, gitignored), written before the sweep so concurrent shells and a sweep that fails midway cannot re-run it back to back; when the stamp is younger than the configured interval the call returns in about a millisecond. No console output, per-file errors swallowed - the same contract as `Clear-OldLogs`.
+- `Logging.Maintenance` (configuration): `Enabled` (default `$true`) and `IntervalHours` (default `24`), consumed by `Invoke-LogMaintenance` with the same hardcoded fallbacks as the rest of the module. Ships enabled so nobody has to configure anything to get bounded logs; set `Enabled = $false` to opt out and prune manually.
+
+### Changed
+
+- The profile registers a one-shot `PowerShell.OnIdle` engine event that calls `Invoke-LogMaintenance`, which is how the sweep is triggered without shell launch paying anything: registering the subscription costs well under a millisecond, and the action fires only after the prompt has rendered and the shell has been idle ~300ms. The action is silent by construction - an engine-event action's output goes to the eventing system, never the console - and unregisters itself on first fire, so it runs at most once per session. It is registered with `-SupportEvent`, which keeps the subscription and its event job out of `Get-Job` and `Get-EventSubscriber` (a plain registration leaves a completed `PSEventJob` visible in `Get-Job` for the rest of the session; measured and rejected), and is why the self-unregister passes `-Force`. The alternatives were rejected on their own terms: a synchronous profile call is exactly the 50-150ms startup regression this must not cause, and a Windows scheduled task is zero-cost at startup but silently mutates machine state outside the repository and needs per-machine registration and cleanup. On days the sweep already ran, the fired action hits the stamp check and returns in ~1ms.
+- `Stop-Logging` is unchanged and still enforces retention on every bootstrap stop; `Clear-OldLogs`'s help and docs now name both callers.
+
 ## [0.1.23] - 2026-08-03
 
 ### Added
@@ -360,7 +372,8 @@ The first public release of WinuX.
 - Governance and licensing: MIT license, contributor guide, code of conduct, security policy, and third-party notices.
 - CI: the full Pester suite on every pull request, and a release workflow that builds `WinuX.exe` from every version tag and attaches it - with a SHA-256 checksum - to the GitHub release.
 
-[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.23...HEAD
+[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.24...HEAD
+[0.1.24]: https://github.com/IvanPavlak/WinuX/compare/v0.1.23...v0.1.24
 [0.1.23]: https://github.com/IvanPavlak/WinuX/compare/v0.1.22...v0.1.23
 [0.1.22]: https://github.com/IvanPavlak/WinuX/compare/v0.1.21...v0.1.22
 [0.1.21]: https://github.com/IvanPavlak/WinuX/compare/v0.1.20...v0.1.21

--- a/Windows/PowerShell/Configuration.psd1
+++ b/Windows/PowerShell/Configuration.psd1
@@ -2092,14 +2092,17 @@
 	# Set-LogLevel, Start-Logging / Stop-Logging). Console colors default to the documented
 	# house style; structured logs are written to the module's own Logs/ folder and pruned by
 	# the retention limits below so they stay detailed but small. Pinned logs (Logs/Pinned,
-	# created via Protect-Log) are never pruned.
-	# → Consumer: Initialize-LoggingState, Write-Log, Clear-OldLogs
+	# created via Protect-Log) are never pruned. Maintenance controls the automatic background
+	# sweep (Invoke-LogMaintenance, fired from the profile once the shell is idle) that enforces
+	# retention and clears stale test-run artifacts without adding startup time.
+	# → Consumer: Initialize-LoggingState, Write-Log, Clear-OldLogs, Invoke-LogMaintenance
 	#
 	# Example:
 	#   Logging = @{
 	#       DefaultLevel = "Normal"   # Quiet | Normal | Verbose
 	#       Colors       = @{ Success = "Green"; Error = "Red" }
 	#       FileLogging  = @{ Enabled = $true; Retention = @{ MaxSessionFiles = 20 } }
+	#       Maintenance  = @{ Enabled = $true; IntervalHours = 24 }
 	#   }
 	# ==========================================================================
 	Logging                       = @{
@@ -2129,6 +2132,15 @@
 				MaxTotalSizeMB     = 50  # Cap combined session-log size (oldest removed first)
 				MaxErrorFileSizeMB = 5   # Trim the error log to its most recent content past this size
 			}
+		}
+
+		# Automatic background housekeeping (Invoke-LogMaintenance). Enforces the retention above
+		# and prunes stale Tests\Results artifacts, at most once per interval, fired from the
+		# profile only after the shell is idle - never during startup. No setup required; set
+		# Enabled = $false to opt out and prune manually instead.
+		Maintenance  = @{
+			Enabled       = $true # Set $false to disable the automatic idle-time sweep
+			IntervalHours = 24    # Minimum hours between sweeps (stamp file: Logs\.last-maintenance)
 		}
 	}
 

--- a/Windows/PowerShell/Microsoft.PowerShell_profile.ps1
+++ b/Windows/PowerShell/Microsoft.PowerShell_profile.ps1
@@ -169,6 +169,19 @@ New-Alias -Name translate -Value Invoke-GoogleTranslate -Force
 . (Join-Path $ModulesPath "System\Functions\Test-PowerPlan.ps1")
 Test-PowerPlan
 
+# Background log maintenance - prunes session logs and stale test-run artifacts at most once per
+# Configuration.Logging.Maintenance.IntervalHours. Registering the engine event costs well under a
+# millisecond, and the action fires only AFTER the prompt is rendered and the shell has been idle
+# ~300ms - so shell launch pays nothing. The action is silent by construction (its output goes to
+# the event system, never the console) and unregisters itself so it fires at most once per session;
+# -SupportEvent keeps the subscription and its event job out of Get-Job / Get-EventSubscriber
+# (which is also why unregistering needs -Force). On already-swept days the fired action hits the
+# stamp-file check inside Invoke-LogMaintenance and returns in ~1ms.
+Register-EngineEvent -SourceIdentifier PowerShell.OnIdle -SupportEvent -Action {
+	try { Invoke-LogMaintenance } catch { }
+	Unregister-Event -SourceIdentifier PowerShell.OnIdle -Force -ErrorAction SilentlyContinue
+}
+
 # Integrity checks are intentionally NOT run at startup (they add ~200ms+ and shell launch
 # must stay fast). Run them on-demand instead:
 #   List-Functions -ListDiscrepancies   - functions loaded vs documented in docs/modules

--- a/Windows/PowerShell/Modules/Logging/Functions/Clear-OldLogs.ps1
+++ b/Windows/PowerShell/Modules/Logging/Functions/Clear-OldLogs.ps1
@@ -10,8 +10,9 @@ function Clear-OldLogs {
 		its own size cap (the most recent lines are kept).
 
 		Logs in the Logs/Pinned subfolder are NEVER touched - use Protect-Log to move a log there
-		when you want to keep it through ongoing development. Called automatically by Stop-Logging;
-		safe to run manually at any time. Limits default from $Configuration.Logging.FileLogging.Retention.
+		when you want to keep it through ongoing development. Called automatically by Stop-Logging
+		and by the idle-time Invoke-LogMaintenance sweep; safe to run manually at any time. Limits
+		default from $Configuration.Logging.FileLogging.Retention.
 
 	.PARAMETER MaxAgeDays
 		Delete session logs older than this many days. Default from config (fallback 7).

--- a/Windows/PowerShell/Modules/Logging/Functions/Invoke-LogMaintenance.ps1
+++ b/Windows/PowerShell/Modules/Logging/Functions/Invoke-LogMaintenance.ps1
@@ -1,0 +1,121 @@
+function Invoke-LogMaintenance {
+	<#
+	.SYNOPSIS
+		Runs the periodic, silent housekeeping sweep over every log the repository generates.
+
+	.DESCRIPTION
+		Single entry point for background log hygiene. Enforces session-log retention via
+		Clear-OldLogs (limits from $Configuration.Logging.FileLogging.Retention), then prunes the
+		Tests\Results folder with the same rules Invoke-TestSuite applies at run start: the ten
+		newest TestRun_*.log files are kept, orphaned pester-results-*.xml files (whose owning run
+		log is gone) are removed, and abandoned Work\ directories are swept. Results artifacts are
+		only touched when older than one day, so a test run in flight can never lose its files.
+		timings.json, .gitkeep files, and Logs/Pinned are never touched.
+
+		Produces no console output and swallows per-file errors, so it is safe to call from the
+		profile's idle-time hook. Throttled by a stamp file (Logs\.last-maintenance): when the last
+		sweep is younger than Maintenance.IntervalHours the call returns immediately (~1 ms), so
+		opening many shells per day costs nothing. Behavior defaults from
+		$Configuration.Logging.Maintenance (Enabled $true, IntervalHours 24) - runs out of the box,
+		set Enabled = $false to opt out. Called automatically once per interval from the profile's
+		PowerShell.OnIdle hook; safe to run manually at any time.
+
+	.PARAMETER Force
+		Run the sweep now, ignoring the Enabled flag and the stamp-file throttle.
+
+	.PARAMETER ResultsDirectory
+		Override the Tests\Results directory to prune (default: resolved via Get-RepositoryPath).
+		Intended for tests.
+
+	.EXAMPLE
+		Invoke-LogMaintenance
+		Runs the sweep if the maintenance interval has elapsed; otherwise returns immediately.
+
+	.EXAMPLE
+		Invoke-LogMaintenance -Force
+		Runs the full sweep right now, regardless of the stamp file.
+	#>
+	[CmdletBinding()]
+	param(
+		[Parameter(Mandatory = $false)]
+		[switch]$Force,
+
+		[Parameter(Mandatory = $false)]
+		[string]$ResultsDirectory
+	)
+
+	$maintenance = $null
+	if ($global:Configuration -and $global:Configuration.Logging -and $global:Configuration.Logging.Maintenance) {
+		$maintenance = $global:Configuration.Logging.Maintenance
+	}
+
+	$enabled = if ($maintenance -and $null -ne $maintenance.Enabled) { [bool]$maintenance.Enabled } else { $true }
+	$intervalHours = if ($maintenance -and $null -ne $maintenance.IntervalHours) { [int]$maintenance.IntervalHours } else { 24 }
+
+	if (-not $enabled -and -not $Force) { return }
+
+	if (-not $global:LoggingState) {
+		Initialize-LoggingState | Out-Null
+	}
+	$state = $global:LoggingState
+	if (-not (Test-Path $state.LogsDir)) { return }
+
+	# Stamp throttle: skip when the last sweep is younger than the interval. The stamp is written
+	# up front so concurrent shells (and a sweep that fails midway) don't re-run it back to back.
+	$stampFile = Join-Path $state.LogsDir ".last-maintenance"
+	if (-not $Force -and (Test-Path $stampFile)) {
+		$stampAge = (Get-Date) - (Get-Item -Path $stampFile -Force).LastWriteTime
+		if ($stampAge.TotalHours -lt $intervalHours) { return }
+	}
+	try { Set-Content -Path $stampFile -Value (Get-Date -Format 'o') -Encoding UTF8 -Force -ErrorAction Stop } catch { }
+
+	# Session logs + error log: existing retention, limits from configuration.
+	try { Clear-OldLogs } catch { }
+
+	# Tests\Results: same shape Invoke-TestSuite enforces at run start, so the folder stays
+	# bounded even on machines that stopped running the suite. Everything here is age-gated to
+	# one day - a live run's artifacts (its run log appears only at the end of the run) are
+	# never eligible.
+	$resultsDir = $ResultsDirectory
+	if (-not $resultsDir) {
+		try { $resultsDir = Join-Path (Get-RepositoryPath -StartPath $PSScriptRoot).Modules "Tests\Results" } catch { return }
+	}
+	if (-not (Test-Path $resultsDir)) { return }
+
+	$ageCutoff = (Get-Date).AddDays(-1)
+	$retainedLogs = 10
+
+	# 1) Keep the ten newest completed run logs (mirrors Invoke-TestSuite's own retention).
+	$runLogs = @(Get-ChildItem -Path $resultsDir -Filter "TestRun_*.log" -File -ErrorAction SilentlyContinue |
+			Sort-Object LastWriteTime -Descending)
+	if ($runLogs.Count -gt $retainedLogs) {
+		foreach ($stale in ($runLogs | Select-Object -Skip $retainedLogs)) {
+			if ($stale.LastWriteTime -lt $ageCutoff) {
+				try { Remove-Item -LiteralPath $stale.FullName -Force -ErrorAction Stop } catch { }
+			}
+		}
+	}
+
+	# 2) An XML whose run log is gone is an orphan; the age gate protects a run still in flight
+	# (its XMLs exist before its run log does).
+	$liveRunIds = [System.Collections.Generic.HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+	foreach ($log in (Get-ChildItem -Path $resultsDir -Filter "TestRun_*.log" -File -ErrorAction SilentlyContinue)) {
+		[void]$liveRunIds.Add(($log.BaseName -replace '^TestRun_', ''))
+	}
+	foreach ($xml in (Get-ChildItem -Path $resultsDir -Filter "pester-results-*.xml" -File -ErrorAction SilentlyContinue)) {
+		$owner = ($xml.BaseName -replace '^pester-results-', '') -replace '-worker\d+$', ''
+		if (-not $liveRunIds.Contains($owner) -and $xml.LastWriteTime -lt $ageCutoff) {
+			try { Remove-Item -LiteralPath $xml.FullName -Force -ErrorAction Stop } catch { }
+		}
+	}
+
+	# 3) Work directories are removed by the run that owns them; a killed run leaves one behind.
+	$workRoot = Join-Path $resultsDir "Work"
+	if (Test-Path $workRoot) {
+		foreach ($abandoned in (Get-ChildItem -Path $workRoot -Directory -ErrorAction SilentlyContinue)) {
+			if ($abandoned.LastWriteTime -lt $ageCutoff) {
+				try { Remove-Item -LiteralPath $abandoned.FullName -Recurse -Force -ErrorAction Stop } catch { }
+			}
+		}
+	}
+}

--- a/Windows/PowerShell/Modules/Logging/Logging.psd1
+++ b/Windows/PowerShell/Modules/Logging/Logging.psd1
@@ -7,6 +7,7 @@
 		'Clear-OldLogs',
 		'Get-LogPath',
 		'Initialize-LoggingState',
+		'Invoke-LogMaintenance',
 		'Protect-Log',
 		'Set-LogLevel',
 		'Start-Logging',

--- a/Windows/PowerShell/Modules/Tests/Modules/Logging/Invoke-LogMaintenance.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Logging/Invoke-LogMaintenance.Tests.ps1
@@ -1,0 +1,183 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModulePath = Join-Path (Get-RepositoryPath).Modules "Logging\Logging.psd1"
+	Import-Module $ModulePath -Force
+
+	$script:PrevConfig = $global:Configuration
+}
+
+AfterAll {
+	$global:Configuration = $script:PrevConfig
+	Remove-Variable -Name LoggingState -Scope Global -ErrorAction SilentlyContinue
+	Remove-Module Logging -Force -ErrorAction SilentlyContinue
+}
+
+Describe "Invoke-LogMaintenance" {
+	BeforeEach {
+		$script:LogsDir = Join-Path $TestDrive ([System.IO.Path]::GetRandomFileName())
+		$script:ResultsDir = Join-Path $TestDrive ([System.IO.Path]::GetRandomFileName())
+		New-Item -ItemType Directory -Path $script:LogsDir -Force | Out-Null
+		New-Item -ItemType Directory -Path $script:ResultsDir -Force | Out-Null
+
+		$global:Configuration = @{
+			Logging = @{
+				FileLogging = @{
+					Enabled   = $true
+					Retention = @{ MaxAgeDays = 0; MaxSessionFiles = 2; MaxTotalSizeMB = 0; MaxErrorFileSizeMB = 0 }
+				}
+				Maintenance = @{ Enabled = $true; IntervalHours = 24 }
+			}
+		}
+
+		$global:LoggingState = @{
+			Level       = 'Normal'
+			Colors      = @{}
+			FileLogging = $true
+			LogsDir     = $script:LogsDir
+			PinnedDir   = (Join-Path $script:LogsDir 'Pinned')
+			SessionFile = (Join-Path $script:LogsDir 'Session_current.log')
+			ErrorFile   = (Join-Path $script:LogsDir 'Errors.log')
+			Config      = $global:Configuration.Logging
+		}
+
+		$script:StampFile = Join-Path $script:LogsDir '.last-maintenance'
+	}
+
+	Context "throttling and configuration" {
+		BeforeEach {
+			Mock -ModuleName Logging Clear-OldLogs { }
+		}
+
+		It "skips the sweep when the stamp is younger than the interval" {
+			Set-Content -Path $script:StampFile -Value 'stamp'
+			Invoke-LogMaintenance -ResultsDirectory $script:ResultsDir
+			Should -Invoke -ModuleName Logging Clear-OldLogs -Times 0 -Exactly
+		}
+
+		It "runs the sweep when the stamp is older than the interval" {
+			Set-Content -Path $script:StampFile -Value 'stamp'
+			(Get-Item -Path $script:StampFile -Force).LastWriteTime = (Get-Date).AddHours(-25)
+			Invoke-LogMaintenance -ResultsDirectory $script:ResultsDir
+			Should -Invoke -ModuleName Logging Clear-OldLogs -Times 1 -Exactly
+		}
+
+		It "honors a custom IntervalHours from configuration" {
+			$global:Configuration.Logging.Maintenance.IntervalHours = 1
+			Set-Content -Path $script:StampFile -Value 'stamp'
+			(Get-Item -Path $script:StampFile -Force).LastWriteTime = (Get-Date).AddHours(-2)
+			Invoke-LogMaintenance -ResultsDirectory $script:ResultsDir
+			Should -Invoke -ModuleName Logging Clear-OldLogs -Times 1 -Exactly
+		}
+
+		It "-Force bypasses a fresh stamp" {
+			Set-Content -Path $script:StampFile -Value 'stamp'
+			Invoke-LogMaintenance -Force -ResultsDirectory $script:ResultsDir
+			Should -Invoke -ModuleName Logging Clear-OldLogs -Times 1 -Exactly
+		}
+
+		It "does nothing when Maintenance.Enabled is false" {
+			$global:Configuration.Logging.Maintenance.Enabled = $false
+			Invoke-LogMaintenance -ResultsDirectory $script:ResultsDir
+			Should -Invoke -ModuleName Logging Clear-OldLogs -Times 0 -Exactly
+		}
+
+		It "-Force overrides Maintenance.Enabled = false" {
+			$global:Configuration.Logging.Maintenance.Enabled = $false
+			Invoke-LogMaintenance -Force -ResultsDirectory $script:ResultsDir
+			Should -Invoke -ModuleName Logging Clear-OldLogs -Times 1 -Exactly
+		}
+
+		It "defaults to enabled when the Maintenance block is absent" {
+			$global:Configuration.Logging.Remove('Maintenance')
+			Invoke-LogMaintenance -ResultsDirectory $script:ResultsDir
+			Should -Invoke -ModuleName Logging Clear-OldLogs -Times 1 -Exactly
+		}
+
+		It "writes the stamp file when it runs" {
+			Invoke-LogMaintenance -ResultsDirectory $script:ResultsDir
+			Test-Path $script:StampFile | Should -BeTrue
+		}
+	}
+
+	Context "session-log retention" {
+		It "prunes session logs through Clear-OldLogs using configured retention" {
+			1..5 | ForEach-Object {
+				$f = Join-Path $script:LogsDir ("Session_2026-01-{0:D2}_00-00-00_{1}.log" -f $_, $_)
+				Set-Content -Path $f -Value 'x'
+				(Get-Item $f).LastWriteTime = (Get-Date).AddHours( - $_)
+			}
+			Invoke-LogMaintenance -Force -ResultsDirectory $script:ResultsDir
+			(Get-ChildItem $script:LogsDir -Filter 'Session_*.log' -File).Count | Should -Be 2
+		}
+	}
+
+	Context "test-results pruning" {
+		BeforeEach {
+			Mock -ModuleName Logging Clear-OldLogs { }
+
+			# Helper: create a file with a given age in days.
+			$script:NewAgedFile = {
+				param([string]$Name, [double]$AgeDays)
+				$path = Join-Path $script:ResultsDir $Name
+				Set-Content -Path $path -Value 'x'
+				(Get-Item $path).LastWriteTime = (Get-Date).AddDays( - $AgeDays)
+				$path
+			}
+		}
+
+		It "keeps only the ten newest day-old run logs" {
+			1..12 | ForEach-Object { & $script:NewAgedFile ("TestRun_2026-01-{0:D2}_00-00-00_{0}.log" -f $_) ($_ + 1) }
+			Invoke-LogMaintenance -Force -ResultsDirectory $script:ResultsDir
+			(Get-ChildItem $script:ResultsDir -Filter 'TestRun_*.log' -File).Count | Should -Be 10
+		}
+
+		It "never removes run logs younger than a day, even beyond the retained count" {
+			1..12 | ForEach-Object { & $script:NewAgedFile ("TestRun_2026-01-{0:D2}_00-00-00_{0}.log" -f $_) 0.01 }
+			Invoke-LogMaintenance -Force -ResultsDirectory $script:ResultsDir
+			(Get-ChildItem $script:ResultsDir -Filter 'TestRun_*.log' -File).Count | Should -Be 12
+		}
+
+		It "removes day-old orphaned worker XMLs" {
+			& $script:NewAgedFile 'pester-results-2026-01-01_00-00-00_111-worker0.xml' 2
+			Invoke-LogMaintenance -Force -ResultsDirectory $script:ResultsDir
+			(Get-ChildItem $script:ResultsDir -Filter 'pester-results-*.xml' -File).Count | Should -Be 0
+		}
+
+		It "keeps orphaned XMLs younger than a day (a run may still be in flight)" {
+			& $script:NewAgedFile 'pester-results-2026-01-01_00-00-00_111-worker0.xml' 0.01
+			Invoke-LogMaintenance -Force -ResultsDirectory $script:ResultsDir
+			(Get-ChildItem $script:ResultsDir -Filter 'pester-results-*.xml' -File).Count | Should -Be 1
+		}
+
+		It "keeps XMLs whose run log still exists, regardless of age" {
+			& $script:NewAgedFile 'TestRun_2026-01-01_00-00-00_111.log' 5
+			& $script:NewAgedFile 'pester-results-2026-01-01_00-00-00_111-worker0.xml' 5
+			Invoke-LogMaintenance -Force -ResultsDirectory $script:ResultsDir
+			(Get-ChildItem $script:ResultsDir -Filter 'pester-results-*.xml' -File).Count | Should -Be 1
+		}
+
+		It "sweeps abandoned Work directories older than a day and keeps young ones" {
+			$workRoot = Join-Path $script:ResultsDir 'Work'
+			$old = Join-Path $workRoot 'run-old'
+			$young = Join-Path $workRoot 'run-young'
+			New-Item -ItemType Directory -Path $old, $young -Force | Out-Null
+			(Get-Item $old).LastWriteTime = (Get-Date).AddDays(-2)
+			Invoke-LogMaintenance -Force -ResultsDirectory $script:ResultsDir
+			Test-Path $old | Should -BeFalse
+			Test-Path $young | Should -BeTrue
+		}
+
+		It "never touches timings.json" {
+			$timings = Join-Path $script:ResultsDir 'timings.json'
+			Set-Content -Path $timings -Value '{}'
+			(Get-Item $timings).LastWriteTime = (Get-Date).AddDays(-30)
+			Invoke-LogMaintenance -Force -ResultsDirectory $script:ResultsDir
+			Test-Path $timings | Should -BeTrue
+		}
+
+		It "returns quietly when the results directory does not exist" {
+			{ Invoke-LogMaintenance -Force -ResultsDirectory (Join-Path $TestDrive 'missing') } | Should -Not -Throw
+		}
+	}
+}

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -823,7 +823,7 @@ Sections not detailed above, with their real shapes and consumers:
 | `ExplorerOptions` | array of registry entries (ships fully commented - Win11Debloat covers the defaults) | File Explorer tweaks applied via the registry | `Set-ExplorerOptions` |
 | `AutoEnvironmentVariables` | name → path (placeholders allowed) | User environment variables written by `Set-EnvironmentVariables -Auto` | `Set-EnvironmentVariables` |
 | `AutoPathAdditions` | array of directories | Directories persisted onto the User `PATH` (e.g. Oh My Posh install locations) | `Set-EnvironmentVariables` |
-| `Logging` | `@{ DefaultLevel; Colors; ... }` | Console verbosity at session start (`Quiet`/`Normal`/`Verbose`), per-level console colors, and file-logging settings | Logging module (`Write-Log*`, `Set-LogLevel`) |
+| `Logging` | `@{ DefaultLevel; Colors; ... }` | Console verbosity at session start (`Quiet`/`Normal`/`Verbose`), per-level console colors, file-logging settings, and automatic idle-time log maintenance | Logging module (`Write-Log*`, `Set-LogLevel`, `Invoke-LogMaintenance`) |
 | `BrowserGroupMatching` | `@{ BrowserProcessNames; KeywordExtraction; ... }` | Maps browser labels to process names and tunes URL-keyword extraction for detecting already-open browser groups | `Test-BrowserGroupAlreadyOpen`, `Collect-BrowserUrls` |
 
 ---

--- a/docs/modules/logging.md
+++ b/docs/modules/logging.md
@@ -22,9 +22,14 @@ Verbosity is controlled globally with `Set-LogLevel` (cross-module reliable; a g
 `$VerbosePreference = 'Continue'` is also honored). File logging records every level regardless of
 console verbosity, so the on-disk record is always complete.
 
+Housekeeping is automatic: the profile registers a one-shot idle-time hook that calls
+`Invoke-LogMaintenance` after the prompt is rendered - never during startup, so shell launch pays
+nothing - and the sweep itself runs at most once per `Configuration.Logging.Maintenance.IntervalHours`
+(default 24). No setup is required; set `Maintenance.Enabled = $false` to opt out.
+
 ## [Clear-OldLogs](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Logging/Functions/Clear-OldLogs.ps1)
 
-- **Description:** Enforces log retention so the `Logs/` folder stays small but complete. Prunes session logs (`Session_*.log`) by age, then count, then total size (oldest removed first), and trims the error log past its size cap. Logs in `Logs/Pinned` are never touched. Called automatically by `Stop-Logging`; limits default from `Configuration.Logging.FileLogging.Retention`.
+- **Description:** Enforces log retention so the `Logs/` folder stays small but complete. Prunes session logs (`Session_*.log`) by age, then count, then total size (oldest removed first), and trims the error log past its size cap. Logs in `Logs/Pinned` are never touched. Called automatically by `Stop-Logging` and by the idle-time `Invoke-LogMaintenance` sweep; limits default from `Configuration.Logging.FileLogging.Retention`.
 - **Parameters:** `[-MaxAgeDays]` `[-MaxSessionFiles]` `[-MaxTotalSizeMB]` `[-MaxErrorFileSizeMB]`
 - **Usage:** `Clear-OldLogs`, `Clear-OldLogs -MaxSessionFiles 5`
 
@@ -39,6 +44,12 @@ console verbosity, so the on-disk record is always complete.
 - **Description:** Initializes (or, with `-Force`, resets) the shared `$global:LoggingState` that the engine reads on every call: active verbosity level, color palette, file-logging toggle, and resolved session/error log paths. Reads `Configuration.Logging` when present, falling back to documented defaults. Called lazily by `Write-Log` on first use.
 - **Parameters:** `[-Force]`
 - **Usage:** `Initialize-LoggingState`, `Initialize-LoggingState -Force`
+
+## [Invoke-LogMaintenance](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Logging/Functions/Invoke-LogMaintenance.ps1)
+
+- **Description:** Periodic, silent housekeeping sweep over every log the repository generates. Enforces session-log retention via `Clear-OldLogs`, then prunes stale `Tests\Results` artifacts with the same rules `Invoke-TestSuite` applies at run start: run logs beyond the newest ten, orphaned worker XMLs, and abandoned `Work\` directories - each only when older than a day, so a test run in flight is never touched (`timings.json` and pinned logs are always exempt). Throttled by a stamp file (`Logs\.last-maintenance`) to one sweep per `Configuration.Logging.Maintenance.IntervalHours`; fired automatically from the profile's `PowerShell.OnIdle` hook after the prompt is rendered, so it adds zero startup time. Safe to run manually at any time.
+- **Parameters:** `[-Force]` `[-ResultsDirectory]`
+- **Usage:** `Invoke-LogMaintenance`, `Invoke-LogMaintenance -Force`
 
 ## [Protect-Log](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Logging/Functions/Protect-Log.ps1)
 

--- a/docs/modules/tests.md
+++ b/docs/modules/tests.md
@@ -66,7 +66,7 @@ Everything a detailed serial run would have printed - every per-test line, and e
 
 `<run>` is `<timestamp>_<PID>`, the same shape the Logging module uses for its session logs. Naming every artifact after its run is what makes concurrent runs safe - a scoped `Run-Tests` in one terminal while a full sweep finishes in another used to have the second run wipe the first's in-flight files and then report results it never produced.
 
-The ten most recent run logs are kept, the same way `Clear-OldLogs` keeps session logs; each run's XMLs are pruned with its log.
+The ten most recent run logs are kept, the same way `Clear-OldLogs` keeps session logs; each run's XMLs are pruned with its log. Retention is enforced twice: at the start of every run by the harness itself, and once a day by the Logging module's idle-time `Invoke-LogMaintenance` sweep - so `Results/` stays bounded even on machines that stopped running the suite.
 
 ### Exit codes
 


### PR DESCRIPTION
## Description

Session-log retention existed but nothing invoked it in an ordinary session: `Clear-OldLogs` runs from `Stop-Logging`, which only bootstrap flows reach, so a machine that only ever opens shells accumulated session logs without bound - the motivating machine had nearly 400 (~6 MB) against a configured cap of 20. `Tests\Results` had the sibling problem: the harness prunes at run start, so a machine that stops running the suite keeps its last batch forever.

This PR adds `Invoke-LogMaintenance` (Logging module), a silent housekeeping sweep that:

- enforces session-log retention via `Clear-OldLogs` (existing `FileLogging.Retention` limits, unchanged);
- prunes `Tests\Results` with the same rules `Invoke-TestSuite` applies at run start (ten newest `TestRun_*.log` kept, orphaned worker XMLs and abandoned `Work\` directories removed) - every Results deletion is age-gated to one day, because a live run's XMLs exist before its run log does, so a sweep landing mid-run can never delete an in-flight run's artifacts;
- never touches `timings.json`, `.gitkeep` files, or `Logs/Pinned`;
- throttles itself through a stamp file (`Logs\.last-maintenance`, gitignored) to once per `Logging.Maintenance.IntervalHours` (default 24); a throttled call returns in ~1 ms (measured 4 ms end-to-end).

The trigger is the part with the design constraint - **zero startup-time regression**. The profile registers a one-shot `PowerShell.OnIdle` engine event: registration costs well under a millisecond, and the action fires only after the prompt is rendered and the shell has been idle ~300 ms. The action is silent by construction (engine-event action output goes to the eventing system, never the console) and unregisters itself on first fire. It is registered with `-SupportEvent` because a plain registration leaves a completed `PSEventJob` visible in `Get-Job` for the rest of the session (verified empirically); with `-SupportEvent` the subscription and job are invisible and the self-unregister (`-Force`) leaves nothing behind (also verified).

Alternatives rejected: a synchronous profile call (50-150 ms - exactly the regression this must avoid) and a Windows scheduled task (zero startup cost, but silently mutates machine state outside the repo and needs per-machine registration/cleanup).

New configuration: `Logging.Maintenance = @{ Enabled = $true; IntervalHours = 24 }` - ships enabled so users get bounded logs with no setup; `Enabled = $false` opts out.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [ ] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

## Quality bar

- [x] The change is **minimal and focused** (one logical change; reuses existing helpers, no duplication / DRY).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` using placeholder paths (`{Dev}`, `{User}`, `{MachineType}`, `{RepoRoot}`, `{AppData}`). *(New `Logging.Maintenance` keys are plain values; all paths are resolved at runtime via `Get-RepositoryPath` / `LoggingState`.)*

## Tests

```powershell
Run-Tests -TestName "Invoke-LogMaintenance"
Run-Tests
```

All tests pass

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/`. *(New `Invoke-LogMaintenance.Tests.ps1`: 17 cases - stamp throttling, `IntervalHours` override, `Enabled` toggle + `-Force` override, default-on when the config block is absent, stamp written, retention via `Clear-OldLogs`, run-log count + age gating, orphaned vs owned XMLs, `Work\` sweep, `timings.json` exemption, missing-directory no-throw.)*
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text.
- [ ] N/A - no testable behavior changed (docs/chore only).

## Documentation & manifests

- [x] I updated `docs/modules/<Module>.md` for any added/renamed/removed/changed function. *(`logging.md`: new `Invoke-LogMaintenance` entry, maintenance paragraph in the intro, `Clear-OldLogs` callers; `tests.md`: Results retention now enforced twice.)*
- [x] I updated the module `.psd1` `FunctionsToExport`. *(`Logging.psd1` exports `Invoke-LogMaintenance`.)*
- [x] I updated `docs/docs_overview.md` (and `docs/_sidebar.md` if a page was added/removed). *(No change needed - no page added; the overview does not enumerate individual functions. `configuration-reference.md` Logging row updated instead.)*
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds.
- [ ] N/A - no exported function changed.

## Tested on

- Windows version: Windows 11 Pro (10.0.26200)
- PowerShell version: 7.6.4
- Machine type(s): PC via a private fork

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] This PR contains no secrets or personal data (tokens, real paths/hostnames/emails).
