### PR TITLE
Fix Edge windows surviving Kill-All and browser instance launches being dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.27] - 2026-08-05
+
+### Added
+
+- `Get-BrowserTitlePattern` (System module): the browser-name → window-title-regex map that used to live inline in `Terminate-AllBrowserProcesses`, promoted to an exported function so `Open-Browser`'s `-Instances` counting can use the same identification. It is the single source of truth for "which windows belong to this browser": Firefox and Tor Browser share the `firefox.exe` process name, so any process-level count or close must be narrowed by title to act on the right browser.
+- `Wait-BrowserWindowReady` (Application module): polls until a process (optionally narrowed by a title regex) has at least one visible window, or a timeout expires. Used by `Open-Browser`'s `-Instances` mode as a cold-start gate - launches fired while the first browser instance is still bootstrapping are silently dropped because Chromium's process singleton is not accepting hand-offs yet, which is how a cold `-Instances 33` burst used to yield one or two windows.
+
 ### Fixed
 
+- `Terminate-AllBrowserProcesses` (System module) now actually closes Microsoft Edge windows. Edge's real window title embeds a zero-width space (U+200B) before the regular space in "Microsoft Edge", so two characters sit between the words and the old `Microsoft.?Edge` pattern (at most one) never matched - `Kill-All` reported success while every Edge window stayed open. The pattern is now `Microsoft.{0,2}Edge` (via `Get-BrowserTitlePattern`). The same U+200B also defeats `\s`-based matching (it is a format character, not whitespace), so the `BrowserTitleSuffixPatterns` Edge entry in `Configuration.psd1` moved from `Microsoft\s+Edge` to `Microsoft\W{1,2}Edge`.
+- `Initialize-Win32BrowserHelperType` (System module): `GetWindowText`/`GetWindowTextLength` now marshal as Unicode (`CharSet.Unicode`). The ANSI default mangled every non-ANSI title character to `?` - Edge's U+200B included - so title-pattern matching ran against corrupted strings.
+- `Open-Browser -NoMenu -Instances` (Application module) now opens the requested number of windows on every configured browser, not just Chrome and Firefox. Each instance launch passes the browser's configured `NewWindowArg`: a bare launch only opens a window on some browsers, while Brave routes it into the existing session as a tab ("Opening in existing browser session."), which is why `-Instances 33` produced two Brave windows. Cold starts are gated through `Wait-BrowserWindowReady` before the remaining launches are burst (both in `-NoMenu` mode and in group `-Instances` mode), and the existing-window count is filtered by the browser's title pattern so Firefox and Tor Browser no longer count each other's windows as their own.
 - `Open-ClaudeDesktop` (Application module): dropped the `--processStart claude.exe` argument. The install-root `claude.exe` is a Squirrel stub that resolves the newest `app-*` directory on its own and forwards any arguments it receives straight through to the Electron binary, which parsed the trailing `claude.exe` as a file path and prompted to attach it to the session on every launch.
 
 ## [0.1.26] - 2026-08-04
@@ -411,7 +421,8 @@ The first public release of WinuX.
 - Governance and licensing: MIT license, contributor guide, code of conduct, security policy, and third-party notices.
 - CI: the full Pester suite on every pull request, and a release workflow that builds `WinuX.exe` from every version tag and attaches it - with a SHA-256 checksum - to the GitHub release.
 
-[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.26...HEAD
+[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.27...HEAD
+[0.1.27]: https://github.com/IvanPavlak/WinuX/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/IvanPavlak/WinuX/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/IvanPavlak/WinuX/compare/v0.1.24...v0.1.25
 [0.1.24]: https://github.com/IvanPavlak/WinuX/compare/v0.1.23...v0.1.24

--- a/Windows/PowerShell/Configuration.psd1
+++ b/Windows/PowerShell/Configuration.psd1
@@ -1782,7 +1782,9 @@
 			BrowserTitleSuffixPatterns  = @(
 				'\s*[-—]\s*(Mozilla\s+)?Firefox\s*$',
 				'\s*[-—]\s*Google\s+Chrome\s*$',
-				'\s*[-—]\s*Microsoft\s+Edge\s*$',
+				# Edge embeds a zero-width space (U+200B) before the regular space in
+				# "Microsoft Edge" - U+200B is not \s, so \W{1,2} covers both variants.
+				'\s*[-—]\s*Microsoft\W{1,2}Edge\s*$',
 				'\s*[-—]\s*Opera.*$',
 				'\s*[-—]\s*Brave\s*$'
 			)

--- a/Windows/PowerShell/Modules/Application/Application.psd1
+++ b/Windows/PowerShell/Modules/Application/Application.psd1
@@ -44,6 +44,7 @@
 		'Start-MicrosoftActivationScripts',
 		'Start-Win11Debloat',
 		'Update-Win11DebloatVendor',
+		'Wait-BrowserWindowReady',
 		'Test-BrowserGroupAlreadyOpen',
 		'Test-ProjectAlreadyOpen'
 	)

--- a/Windows/PowerShell/Modules/Application/Functions/Open-Browser.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Open-Browser.ps1
@@ -133,10 +133,17 @@ function Open-Browser {
 				default { $Browser.ToLower() }
 			}
 
+			$browserTitlePattern = Get-BrowserTitlePattern -BrowserName $Browser
+
 			$existingWindows = @()
 			if ($Instances -gt 0) {
 				$existingWindows = @(Get-WindowHandle -ProcessName $browserProcessName -ErrorAction SilentlyContinue)
-				Write-LogDebug " [Open-Browser] Found $($existingWindows.Count) existing [$browserProcessName] window(s) before Instances launch"
+				# Firefox and Tor Browser share the firefox.exe process name - keep only
+				# THIS browser's windows or each would count the other's as its own.
+				if ($browserTitlePattern) {
+					$existingWindows = @($existingWindows | Where-Object { $_.Title -match $browserTitlePattern })
+				}
+				Write-LogDebug " [Open-Browser] Found $($existingWindows.Count) existing [$Browser] window(s) before Instances launch"
 			}
 
 			$targetInstances = if ($Instances -gt 0) { $Instances } else { 1 }
@@ -154,8 +161,21 @@ function Open-Browser {
 				elseif ($Private) {
 					Start-Process $browserPath -ArgumentList $privateArg -NoNewWindow -ErrorAction Stop
 				}
+				elseif ($newWindowArg) {
+					# A bare launch only opens a window on some browsers: Chrome does,
+					# but Brave routes it into the existing session as a TAB ("Opening
+					# in existing browser session."), so N launches yielded one window.
+					Start-Process $browserPath -ArgumentList $newWindowArg -NoNewWindow -ErrorAction Stop
+				}
 				else {
 					Start-Process $browserPath -NoNewWindow -ErrorAction Stop
+				}
+
+				# Cold-start gate: launches fired while the FIRST instance is still
+				# bootstrapping are dropped (Chromium's process singleton is not
+				# accepting hand-offs yet) or pile up on the profile lock (Tor).
+				if ($inst -eq 0 -and $toOpen -gt 1 -and $existingWindows.Count -eq 0) {
+					[void](Wait-BrowserWindowReady -ProcessName $browserProcessName -TitlePattern $browserTitlePattern)
 				}
 			}
 
@@ -201,6 +221,8 @@ function Open-Browser {
 
 			# Cache browser windows once for all duplicate checks (avoids re-enumerating per group)
 			$cachedWindows = $null
+			$browserWarm = $true
+			$groupTitlePattern = $null
 			if (-not $Override -or $Instances -gt 0) {
 				$browserProcessName = switch ($Browser) {
 					"Chrome" { "chrome" }
@@ -211,6 +233,13 @@ function Open-Browser {
 				}
 				$cachedWindows = @(Get-WindowHandle -ProcessName $browserProcessName -ErrorAction SilentlyContinue)
 				Write-LogDebug " [Open-Browser] Cached $($cachedWindows.Count) [$browserProcessName] window(s) for $($resolvedGroups.Count) group check(s)"
+
+				# Cold-start detection for the Instances burst below. Filtered by title
+				# because Firefox and Tor Browser share the firefox.exe process name.
+				$groupTitlePattern = Get-BrowserTitlePattern -BrowserName $Browser
+				$browserWarm = @($cachedWindows | Where-Object {
+						-not $groupTitlePattern -or $_.Title -match $groupTitlePattern
+					}).Count -gt 0
 			}
 
 			foreach ($selection in $resolvedGroups) {
@@ -324,6 +353,14 @@ function Open-Browser {
 							else {
 								Start-Process $browserPath -ArgumentList $newWindowArg, $urlString -NoNewWindow -ErrorAction Stop
 							}
+						}
+
+						# Cold-start gate: launches fired while the FIRST instance is still
+						# bootstrapping are dropped (Chromium's process singleton is not
+						# accepting hand-offs yet) or pile up on the profile lock (Tor).
+						if (-not $browserWarm) {
+							[void](Wait-BrowserWindowReady -ProcessName $browserProcessName -TitlePattern $groupTitlePattern)
+							$browserWarm = $true
 						}
 					}
 

--- a/Windows/PowerShell/Modules/Application/Functions/Wait-BrowserWindowReady.ps1
+++ b/Windows/PowerShell/Modules/Application/Functions/Wait-BrowserWindowReady.ps1
@@ -1,0 +1,67 @@
+function Wait-BrowserWindowReady {
+	<#
+	.SYNOPSIS
+		Waits until a browser has at least one visible window.
+
+	.DESCRIPTION
+		Polls the window list until at least one window of the given process
+		(optionally narrowed by a title regex) is present, or the timeout
+		expires. Returns `$true` when a window appeared, `$false` on timeout.
+
+		Used by `Open-Browser`'s `-Instances` mode as a cold-start gate: when
+		the browser is not running yet, launches fired while the first instance
+		is still bootstrapping are silently dropped (Chromium's process
+		singleton is not accepting hand-offs yet). Waiting for the first window
+		before bursting the remaining launches makes the requested instance
+		count reliable.
+
+	.PARAMETER ProcessName
+		Process name (without .exe) whose windows to wait for, e.g. "msedge".
+
+	.PARAMETER TitlePattern
+		Optional title regex a window must also match - used to tell apart
+		browsers that share a process name (Firefox vs. Tor Browser).
+
+	.PARAMETER TimeoutSeconds
+		Maximum time to wait. Defaults to 30 seconds; fast browsers exit the
+		poll in well under a second per 250ms tick.
+
+	.EXAMPLE
+		Wait-BrowserWindowReady -ProcessName "brave"
+		Waits until a Brave window exists (or 30s pass).
+
+	.EXAMPLE
+		Wait-BrowserWindowReady -ProcessName "msedge" -TitlePattern "Microsoft.{0,2}Edge" -TimeoutSeconds 10
+		Waits up to 10s for an Edge window.
+	#>
+	[CmdletBinding()]
+	[OutputType([bool])]
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$ProcessName,
+
+		[Parameter()]
+		[string]$TitlePattern,
+
+		[Parameter()]
+		[int]$TimeoutSeconds = 30
+	)
+
+	$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+
+	do {
+		$browserWindows = @(Get-WindowHandle -ProcessName $ProcessName -ErrorAction SilentlyContinue)
+		if ($TitlePattern) {
+			$browserWindows = @($browserWindows | Where-Object { $_.Title -match $TitlePattern })
+		}
+
+		if ($browserWindows.Count -gt 0) {
+			return $true
+		}
+
+		Start-Sleep -Milliseconds 250
+	} while ([DateTime]::UtcNow -lt $deadline)
+
+	Write-LogDebug " [Wait-BrowserWindowReady] No [$ProcessName] window appeared within [$TimeoutSeconds]s - continuing anyway" -Style Warning
+	return $false
+}

--- a/Windows/PowerShell/Modules/System/Functions/Get-BrowserTitlePattern.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Get-BrowserTitlePattern.ps1
@@ -1,0 +1,52 @@
+function Get-BrowserTitlePattern {
+	<#
+	.SYNOPSIS
+		Returns the window title regex that identifies a browser's main windows.
+
+	.DESCRIPTION
+		Maps a browser name (a key of `Configuration.Universal.Browsers`) to the
+		regular expression that identifies that browser's visible top-level
+		windows by title. Returns `$null` for unknown browser names.
+
+		This is the single source of truth for browser window identification,
+		shared by `Terminate-AllBrowserProcesses` (to find the windows to close)
+		and `Open-Browser`'s `-Instances` mode (to count only the target
+		browser's existing windows - Firefox and Tor Browser share the
+		firefox.exe process name, so a process-level count cannot tell them
+		apart).
+
+		The Edge pattern allows up to two arbitrary characters between
+		"Microsoft" and "Edge" because Edge's real window title embeds a
+		zero-width space (U+200B) before the regular space: "Microsoft​ Edge".
+		U+200B is a format character, not whitespace, so neither a literal space
+		nor `\s` matches it.
+
+	.PARAMETER BrowserName
+		Browser name as configured in `Configuration.Universal.Browsers`
+		(e.g. "Firefox", "Tor", "Chrome", "Edge", "Brave").
+
+	.EXAMPLE
+		Get-BrowserTitlePattern -BrowserName "Edge"
+		Returns the regex matching Microsoft Edge window titles.
+
+	.EXAMPLE
+		Get-BrowserTitlePattern -BrowserName "Tor"
+		Returns "Tor Browser", distinguishing Tor windows from Firefox ones.
+	#>
+	[CmdletBinding()]
+	[OutputType([string])]
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$BrowserName
+	)
+
+	$browserTitlePatterns = @{
+		Firefox = "Mozilla Firefox|Firefox Developer Edition|Firefox Nightly"
+		Tor     = "Tor Browser"
+		Chrome  = "Google Chrome"
+		Edge    = "Microsoft.{0,2}Edge"
+		Brave   = "Brave"
+	}
+
+	return $browserTitlePatterns[$BrowserName]
+}

--- a/Windows/PowerShell/Modules/System/Functions/Initialize-Win32BrowserHelperType.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Initialize-Win32BrowserHelperType.ps1
@@ -7,6 +7,10 @@ function Initialize-Win32BrowserHelperType {
 		Adds the `Win32BrowserHelper` C# type used by browser window discovery and
 		graceful window closure. The type is added only once per session.
 
+		The text APIs marshal as Unicode: without an explicit CharSet the default
+		is ANSI, which mangles non-ANSI title characters to `?` - including the
+		zero-width space (U+200B) Edge embeds in "Microsoft Edge" window titles.
+
 	.EXAMPLE
 		Initialize-Win32BrowserHelperType
 		Loads the Win32 browser helper type if it has not already been added.
@@ -29,10 +33,10 @@ function Initialize-Win32BrowserHelperType {
 				[DllImport("user32.dll")]
 				public static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
 
-				[DllImport("user32.dll")]
+				[DllImport("user32.dll", CharSet = CharSet.Unicode)]
 				public static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
 
-				[DllImport("user32.dll")]
+				[DllImport("user32.dll", CharSet = CharSet.Unicode)]
 				public static extern int GetWindowTextLength(IntPtr hWnd);
 
 				[DllImport("user32.dll")]

--- a/Windows/PowerShell/Modules/System/Functions/Terminate-AllBrowserProcesses.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Terminate-AllBrowserProcesses.ps1
@@ -60,17 +60,9 @@ function Terminate-AllBrowserProcesses {
 		return
 	}
 
-	# Title regex used to identify each browser's main top-level windows.
-	# Keys must match browser names in Configuration.Universal.Browsers.
-	$browserTitlePatterns = @{
-		Firefox = "Mozilla Firefox|Firefox Developer Edition|Firefox Nightly"
-		Tor     = "Tor Browser"
-		Chrome  = "Google Chrome"
-		Edge    = "Microsoft.?Edge"
-		Brave   = "Brave"
-	}
-
-	# Build the list of running browsers to act on.
+	# Build the list of running browsers to act on. Title regexes come from
+	# Get-BrowserTitlePattern - the shared map also used by Open-Browser's
+	# -Instances counting.
 	$browserTargets = @()
 	foreach ($browserName in $browsersConfig.Keys) {
 		$browserDef = $browsersConfig[$browserName]
@@ -78,7 +70,7 @@ function Terminate-AllBrowserProcesses {
 			continue
 		}
 
-		$titlePattern = $browserTitlePatterns[$browserName]
+		$titlePattern = Get-BrowserTitlePattern -BrowserName $browserName
 		if (-not $titlePattern) {
 			Write-LogDebug " No window title pattern known for browser [$browserName] - skipping" -Style Warning
 			continue

--- a/Windows/PowerShell/Modules/System/System.psd1
+++ b/Windows/PowerShell/Modules/System/System.psd1
@@ -17,6 +17,7 @@
 		'Determine-DotnetDependencies',
 		'Display-SystemLanguageSettings',
 		'Enable-DeveloperMode',
+		'Get-BrowserTitlePattern',
 		'Get-BrowserWindowsByTarget',
 		'Get-InstalledApps',
 		'Get-PinnedApps',

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Open-Browser.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Open-Browser.Tests.ps1
@@ -11,6 +11,10 @@ BeforeAll {
 	. "$ModuleRoot\Helper\Functions\Test-ConfigValue.ps1"
 	. "$ModuleRoot\Helper\Functions\Confirm-ConfigValue.ps1"
 
+	# Instance counting and the cold-start gate lean on these two.
+	. "$ModuleRoot\System\Functions\Get-BrowserTitlePattern.ps1"
+	. "$AppFunctionsPath\Wait-BrowserWindowReady.ps1"
+
 	. "$AppFunctionsPath\Open-Browser.ps1"
 }
 
@@ -52,6 +56,7 @@ Describe "Open-Browser" {
 		Mock Get-WindowHandle { @() }
 		Mock Test-BrowserGroupAlreadyOpen { $false }
 		Mock Start-Process { }
+		Mock Wait-BrowserWindowReady { $true }
 	}
 
 	It "resolves configured group and opens URL with browser new-window argument" {
@@ -96,6 +101,64 @@ Describe "Open-Browser" {
 
 		Should -Invoke Test-BrowserGroupAlreadyOpen -Times 0
 		Should -Invoke Start-Process -Times 1 -Exactly
+	}
+
+	Context "NoMenu Instances mode" {
+		It "opens each missing instance with the browser new-window argument" {
+			# A bare launch only opens a window on some browsers (Brave routes it
+			# into the existing session as a tab), so every instance launch must
+			# carry NewWindowArg.
+			Mock Get-WindowHandle {
+				@([PSCustomObject]@{ Handle = [IntPtr]11; Title = 'New Tab - Google Chrome' })
+			}
+
+			Open-Browser -NoMenu -Browser Chrome -Instances 3
+
+			Should -Invoke Start-Process -Times 2 -Exactly -ParameterFilter {
+				$ArgumentList -contains '--new-window'
+			}
+		}
+
+		It "waits for the first window before bursting the rest on a cold start" {
+			Mock Get-WindowHandle { @() }
+
+			Open-Browser -NoMenu -Browser Chrome -Instances 3
+
+			Should -Invoke Start-Process -Times 3 -Exactly
+			Should -Invoke Wait-BrowserWindowReady -Times 1 -Exactly
+		}
+
+		It "does not count another browser's windows that share the process name" {
+			$global:Configuration.Universal.Browsers['Firefox'] = @{
+				Exe          = 'C:\\Tools\\firefox.exe'
+				PrivateArg   = '-private-window'
+				NewWindowArg = '-new-window'
+			}
+
+			# Tor Browser runs as firefox.exe - its windows must not count as
+			# existing Firefox instances.
+			Mock Get-WindowHandle {
+				@([PSCustomObject]@{ Handle = [IntPtr]11; Title = 'Connect to Tor - Tor Browser' })
+			}
+
+			Open-Browser -NoMenu -Browser Firefox -Instances 2
+
+			Should -Invoke Start-Process -Times 2 -Exactly
+		}
+
+		It "opens nothing when the instance target is already met" {
+			Mock Get-WindowHandle {
+				@(
+					[PSCustomObject]@{ Handle = [IntPtr]11; Title = 'New Tab - Google Chrome' },
+					[PSCustomObject]@{ Handle = [IntPtr]22; Title = 'Docs - Google Chrome' }
+				)
+			}
+			Mock Write-LogWarning { }
+
+			Open-Browser -NoMenu -Browser Chrome -Instances 2
+
+			Should -Invoke Start-Process -Times 0
+		}
 	}
 
 	It "warns and launches nothing when no browser is given and DefaultBrowser is blank (empty base)" {

--- a/Windows/PowerShell/Modules/Tests/Modules/Application/Wait-BrowserWindowReady.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Application/Wait-BrowserWindowReady.Tests.ps1
@@ -1,0 +1,59 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$AppFunctionsPath = Join-Path $ModuleRoot "Application\Functions"
+
+	. "$AppFunctionsPath\Wait-BrowserWindowReady.ps1"
+}
+
+Describe "Wait-BrowserWindowReady" {
+	BeforeEach {
+		Mock Write-LogDebug { }
+		Mock Start-Sleep { }
+	}
+
+	It "returns true immediately when a window already exists" {
+		Mock Get-WindowHandle {
+			@([PSCustomObject]@{ Handle = [IntPtr]11; Title = 'New Tab - Brave' })
+		}
+
+		Wait-BrowserWindowReady -ProcessName "brave" | Should -BeTrue
+
+		Should -Invoke Start-Sleep -Times 0
+	}
+
+	It "filters candidate windows by title pattern" {
+		# A regular Firefox window must not satisfy a wait for Tor Browser.
+		Mock Get-WindowHandle {
+			@([PSCustomObject]@{ Handle = [IntPtr]11; Title = 'WinuX - Mozilla Firefox' })
+		}
+
+		Wait-BrowserWindowReady -ProcessName "firefox" -TitlePattern "Tor Browser" -TimeoutSeconds 1 | Should -BeFalse
+	}
+
+	It "returns false and logs when no window appears before the timeout" {
+		Mock Get-WindowHandle { @() }
+
+		Wait-BrowserWindowReady -ProcessName "brave" -TimeoutSeconds 1 | Should -BeFalse
+
+		Should -Invoke Write-LogDebug -Times 1
+	}
+
+	It "keeps polling until a window appears" {
+		$script:pollCount = 0
+		Mock Get-WindowHandle {
+			$script:pollCount++
+			if ($script:pollCount -ge 3) {
+				@([PSCustomObject]@{ Handle = [IntPtr]11; Title = 'New Tab - Brave' })
+			}
+			else {
+				@()
+			}
+		}
+
+		Wait-BrowserWindowReady -ProcessName "brave" -TimeoutSeconds 5 | Should -BeTrue
+
+		$script:pollCount | Should -Be 3
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/System/Get-BrowserTitlePattern.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/System/Get-BrowserTitlePattern.Tests.ps1
@@ -1,0 +1,43 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$FunctionsPath = Join-Path $ModuleRoot "System\Functions"
+
+	. "$FunctionsPath\Get-BrowserTitlePattern.ps1"
+}
+
+Describe "Get-BrowserTitlePattern" {
+	It "returns a pattern for every configured browser name" {
+		foreach ($browser in @("Firefox", "Tor", "Chrome", "Edge", "Brave")) {
+			Get-BrowserTitlePattern -BrowserName $browser | Should -Not -BeNullOrEmpty
+		}
+	}
+
+	It "returns null for unknown browser names" {
+		Get-BrowserTitlePattern -BrowserName "CustomBrowser" | Should -BeNullOrEmpty
+	}
+
+	It "matches the real Edge title, which embeds a zero-width space before ' Edge'" {
+		# Regression test: Edge titles are "... - Microsoft<U+200B> Edge". The old
+		# pattern "Microsoft.?Edge" allowed at most one character between the words
+		# and never matched, so Kill-All left every Edge window open.
+		$realEdgeTitle = "New tab - Personal - Microsoft$([char]0x200B) Edge"
+
+		$realEdgeTitle -match (Get-BrowserTitlePattern -BrowserName "Edge") | Should -BeTrue
+	}
+
+	It "matches an Edge title with a plain space (ANSI-degraded or older titles)" {
+		"New tab - Microsoft Edge" -match (Get-BrowserTitlePattern -BrowserName "Edge") | Should -BeTrue
+	}
+
+	It "distinguishes Tor Browser windows from Firefox windows" {
+		$firefoxPattern = Get-BrowserTitlePattern -BrowserName "Firefox"
+		$torPattern = Get-BrowserTitlePattern -BrowserName "Tor"
+
+		"WinuX - Mozilla Firefox" -match $firefoxPattern | Should -BeTrue
+		"WinuX - Mozilla Firefox" -match $torPattern | Should -BeFalse
+		"Connect to Tor - Tor Browser" -match $torPattern | Should -BeTrue
+		"Connect to Tor - Tor Browser" -match $firefoxPattern | Should -BeFalse
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/System/Terminate-AllBrowserProcesses.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/System/Terminate-AllBrowserProcesses.Tests.ps1
@@ -5,6 +5,7 @@ BeforeAll {
 	$FunctionsPath = Join-Path $ModuleRoot "System\Functions"
 
 	. "$FunctionsPath\Initialize-Win32BrowserHelperType.ps1"
+	. "$FunctionsPath\Get-BrowserTitlePattern.ps1"
 	. "$FunctionsPath\Get-BrowserWindowsByTarget.ps1"
 	. "$FunctionsPath\Close-BrowserWindows.ps1"
 	. "$FunctionsPath\Terminate-AllBrowserProcesses.ps1"

--- a/docs/modules/application.md
+++ b/docs/modules/application.md
@@ -229,7 +229,7 @@ Open-Acrobat -Pdf "MyDocs","OtherDocs"
 - **Parameters:** -Groups, -Private, -NoMenu, -Search, -Browser, -Override, -Instances
 - **Usage:** `Open-Browser`, `Open-Browser GroupName`, `Open-Browser Parent.ChildGroup`, `Open-Browser GroupA,GroupB`, `Open-Browser -Search "search terms"`, `Open-Browser -Private GroupName`, `Open-Browser GroupName -Override`, `Open-Browser -NoMenu -Browser PreferredBrowser -Instances 2`
 
-The default browser is read from `Configuration.Universal.DefaultBrowser`; the base ships it empty, so the function warns and returns until one is set in `Configuration.local.psd1`. Browser definitions (executable path, private/incognito argument, new-window argument) come from `Configuration.Universal.Browsers`, so any browser key defined there (e.g. Firefox, Chrome, Edge, Brave, Tor) can be passed to `-Browser`. Groups support unlimited hierarchical nesting and are addressed with dot-notation. Private mode cannot be combined with group opening (it falls back to normal mode for groups) but does support `-Search`. `-Instances N` is rerun-safe: it counts how many matching windows already exist and opens only the deficit.
+The default browser is read from `Configuration.Universal.DefaultBrowser`; the base ships it empty, so the function warns and returns until one is set in `Configuration.local.psd1`. Browser definitions (executable path, private/incognito argument, new-window argument) come from `Configuration.Universal.Browsers`, so any browser key defined there (e.g. Firefox, Chrome, Edge, Brave, Tor) can be passed to `-Browser`. Groups support unlimited hierarchical nesting and are addressed with dot-notation. Private mode cannot be combined with group opening (it falls back to normal mode for groups) but does support `-Search`. `-Instances N` is rerun-safe: it counts how many matching windows already exist and opens only the deficit. The count filters windows by the browser's title pattern ([`Get-BrowserTitlePattern`](system.md#get-browsertitlepattern)), so Firefox and Tor Browser - which share the `firefox.exe` process name - never count each other's windows. Every instance launch passes the browser's configured `NewWindowArg`: a bare launch only opens a window on some browsers (Chrome does; Brave routes it into the existing session as a tab). When the browser is not running yet, the first launch is gated through [`Wait-BrowserWindowReady`](#wait-browserwindowready) before the rest are fired, because launches that arrive while the first instance is still bootstrapping are silently dropped by Chromium's process singleton.
 
 | Parameter    | Description                                                                                                                        |
 | ------------ | ---------------------------------------------------------------------------------------------------------------------------------- |
@@ -754,6 +754,28 @@ Update-Win11DebloatVendor
 # Pin and vendor a specific release tag
 Update-Win11DebloatVendor -ReleaseTag "2026.05.11"
 ```
+
+## [Wait-BrowserWindowReady](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Application/Functions/Wait-BrowserWindowReady.ps1)
+
+- **Description:** Polls the window list until at least one window of the given process (optionally narrowed by a title regex) is present, or the timeout expires. Returns `$true` when a window appeared, `$false` on timeout. `Open-Browser`'s `-Instances` mode uses it as a cold-start gate: launches fired while the first browser instance is still bootstrapping are silently dropped (Chromium's process singleton is not accepting hand-offs yet), so waiting for the first window before bursting the remaining launches makes the requested instance count reliable.
+- **Parameters:** -ProcessName, -TitlePattern, -TimeoutSeconds
+- **Usage:** `Wait-BrowserWindowReady -ProcessName "brave"`, `Wait-BrowserWindowReady -ProcessName "msedge" -TitlePattern "Microsoft.{0,2}Edge" -TimeoutSeconds 10`
+
+| Parameter         | Description                                                                                                                    |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `-ProcessName`    | Process name (without `.exe`) whose windows to wait for, e.g. `"msedge"`.                                                       |
+| `-TitlePattern`   | Optional title regex a window must also match - used to tell apart browsers that share a process name (Firefox vs. Tor Browser). |
+| `-TimeoutSeconds` | Maximum time to wait; defaults to 30 seconds. Fast browsers exit the poll in well under a second (250ms ticks).                  |
+
+```powershell
+# Wait until a Brave window exists (or 30s pass)
+Wait-BrowserWindowReady -ProcessName "brave"
+
+# Wait up to 10s for an Edge window
+Wait-BrowserWindowReady -ProcessName "msedge" -TitlePattern "Microsoft.{0,2}Edge" -TimeoutSeconds 10
+```
+
+**See also:** [Open-Browser](#open-browser), [Get-BrowserTitlePattern](system.md#get-browsertitlepattern)
 
 ## Configuration Reference
 

--- a/docs/modules/system.md
+++ b/docs/modules/system.md
@@ -200,6 +200,28 @@ The function first calls `Test-AdminPrivileges`, then checks whether `AllowDevel
 Enable-DeveloperMode
 ```
 
+## [Get-BrowserTitlePattern](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Get-BrowserTitlePattern.ps1)
+
+- **Description:** Returns the window title regex that identifies a browser's main windows, keyed by browser name from `Configuration.Universal.Browsers` (Firefox, Tor, Chrome, Edge, Brave); unknown names return `$null`. The single source of truth for browser window identification, shared by `Terminate-AllBrowserProcesses` (to find the windows to close) and `Open-Browser`'s `-Instances` mode (to count only the target browser's existing windows - Firefox and Tor Browser share the `firefox.exe` process name, so a process-level count cannot tell them apart).
+- **Parameters:** -BrowserName
+- **Usage:** `Get-BrowserTitlePattern -BrowserName "Edge"`
+
+The Edge pattern (`Microsoft.{0,2}Edge`) deliberately allows up to two arbitrary characters between "Microsoft" and "Edge": real Edge window titles embed a zero-width space (U+200B) before the regular space, and U+200B is a format character rather than whitespace, so neither a literal space nor `\s` matches it.
+
+| Parameter      | Type     | Description                                                                                 |
+| -------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `-BrowserName` | `string` | Browser name as configured in `Configuration.Universal.Browsers` (e.g. `"Firefox"`, `"Edge"`). |
+
+```powershell
+# Regex matching Microsoft Edge window titles (zero-width-space tolerant)
+Get-BrowserTitlePattern -BrowserName "Edge"
+
+# Regex distinguishing Tor Browser windows from regular Firefox ones
+Get-BrowserTitlePattern -BrowserName "Tor"
+```
+
+**See also:** [Get-BrowserWindowsByTarget](#get-browserwindowsbytarget), [Terminate-AllBrowserProcesses](#terminate-allbrowserprocesses)
+
 ## [Get-BrowserWindowsByTarget](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Get-BrowserWindowsByTarget.ps1)
 
 - **Description:** Enumerates visible top-level windows (via the native `Win32BrowserHelper` type) for the supplied browser process IDs and returns only the ones whose titles match the provided regex. Used to distinguish browser main windows from child/helper processes (GPU / renderer / utility) that do not own a top-level window.
@@ -274,7 +296,7 @@ Called by the PowerShell profile on every shell start. **Must be dot-invoked** (
 - **Description:** Ensures the `Win32BrowserHelper` C# interop type is available. Adds the type used by browser window discovery and graceful window closure, enumerating visible browser windows and posting WM_CLOSE messages. The type is added only once per PowerShell session.
 - **Usage:** `Initialize-Win32BrowserHelperType`
 
-Adds the Win32 interop type only once per session, exposing the native `user32.dll` calls (`EnumWindows`, `GetWindowThreadProcessId`, `GetWindowText`, `GetWindowTextLength`, `IsWindowVisible`, and `PostMessage`) used by `Get-BrowserWindowsByTarget` and `Close-BrowserWindows`.
+Adds the Win32 interop type only once per session, exposing the native `user32.dll` calls (`EnumWindows`, `GetWindowThreadProcessId`, `GetWindowText`, `GetWindowTextLength`, `IsWindowVisible`, and `PostMessage`) used by `Get-BrowserWindowsByTarget` and `Close-BrowserWindows`. The text APIs marshal as Unicode (`CharSet.Unicode`): the ANSI default mangles non-ANSI title characters to `?` - including the zero-width space (U+200B) Edge embeds in "Microsoft Edge" window titles - which would break title-pattern matching against those windows.
 
 ```powershell
 # Load the Win32 browser helper type if it has not already been added
@@ -1012,7 +1034,7 @@ SymbolicLinkMaker
 - **Parameters:** -Exclude
 - **Usage:** `Terminate-AllBrowserProcesses`, `Terminate-AllBrowserProcesses -Exclude "*YouTube*"`, `Terminate-AllBrowserProcesses -Exclude "*YouTube*", "*Gmail*"`
 
-Browser identification is two-staged: the process name is resolved from each browser's configured executable (`firefox.exe` -> `firefox`, `chrome.exe` -> `chrome`), and a brand-specific title regex selects only the real top-level windows. `WM_CLOSE` is posted directly to each non-excluded window handle (per handle, not via `SendKeys`), so it does not touch the foreground and excluded windows are never accidentally closed by a misfired keystroke.
+Browser identification is two-staged: the process name is resolved from each browser's configured executable (`firefox.exe` -> `firefox`, `chrome.exe` -> `chrome`), and a brand-specific title regex from [`Get-BrowserTitlePattern`](#get-browsertitlepattern) selects only the real top-level windows. `WM_CLOSE` is posted directly to each non-excluded window handle (per handle, not via `SendKeys`), so it does not touch the foreground and excluded windows are never accidentally closed by a misfired keystroke.
 
 | Parameter  | Description                                                                                                                                                                                                                                                                 |
 | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Description

Three related browser bugs, all reproduced and fixed on a real machine.

**1. `Kill-All` never closed Microsoft Edge.** Edge's real window title is `… - Microsoft​ Edge` with a **zero-width space (U+200B)** before the regular space, so two characters sit between "Microsoft" and "Edge". The title regex in `Terminate-AllBrowserProcesses` was `Microsoft.?Edge`, which allows at most one - it never matched a single Edge window. The function found the Edge processes, matched zero windows, posted zero `WM_CLOSE`, and reported success. Nothing else caught them either: Edge is excluded from `Terminate-AllProcessesWithVisibleWindows` by process name precisely because the browser step is supposed to have handled it gracefully.

Two more places had the same blind spot:

- `Initialize-Win32BrowserHelperType` imported `GetWindowText`/`GetWindowTextLength` without a `CharSet`, so they marshalled as **ANSI** and mangled every non-ANSI title character to `?`. Pattern matching was running against corrupted strings.
- The `BrowserTitleSuffixPatterns` Edge entry used `Microsoft\s+Edge`. U+200B is a _format_ character, not whitespace, so `\s` does not match it either.

**2. `Open-Browser -Instances N` only ever produced one or two Brave windows.** The instance loop launched the executable bare. A bare launch happens to open a window on Chrome, but Brave routes it into the existing session as a **tab** (`Opening in existing browser session.`) - the configured `NewWindowArg` was never passed on this path. Measured: 5 bare launches → 1 window.

**3. Cold-start bursts lost launches.** Firing every instance instantly while the first one is still bootstrapping gets the rest silently dropped by Chromium's process singleton. Separately, the "how many windows already exist" count was taken per **process name**, and Firefox and Tor Browser are both `firefox.exe` - so each counted the other's windows as its own and opened too few.

### Changes

| Change                                          | Why                                                                                                                                                                                                                                                                |
| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| **New** `Get-BrowserTitlePattern` (System)      | The browser→title-regex map, promoted out of `Terminate-AllBrowserProcesses` so window identification has one source of truth shared with `Open-Browser`. Edge is now `Microsoft.{0,2}Edge`, matching the real ZWSP title, a plain space, and an ANSI-mangled `?`. |
| **New** `Wait-BrowserWindowReady` (Application) | Cold-start gate: waits for the first window before the remaining instance launches are fired.                                                                                                                                                                      |
| `Initialize-Win32BrowserHelperType`             | `GetWindowText`/`GetWindowTextLength` now marshal as `CharSet.Unicode`.                                                                                                                                                                                            |
| `Terminate-AllBrowserProcesses`                 | Uses `Get-BrowserTitlePattern` instead of its inline map.                                                                                                                                                                                                          |
| `Open-Browser`                                  | Every instance launch passes `NewWindowArg`; instance counts are filtered by title pattern; cold starts gate through `Wait-BrowserWindowReady` in both `-NoMenu` and group `-Instances` modes.                                                                     |
| `Configuration.psd1`                            | `BrowserTitleSuffixPatterns` Edge entry: `Microsoft\s+Edge` → `Microsoft\W{1,2}Edge`.                                                                                                                                                                              |

Tor is deliberately left as-is beyond the shared title-pattern fix - it does not support many concurrent windows, so it is not a target for reliable multi-instance launching.

This release also carries the already-committed `Open-ClaudeDesktop` fix that was sitting under `[Unreleased]`; both are folded into **0.1.27**.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [ ] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

## Quality bar

- [x] The change is **minimal and focused** (one logical change; reuses existing helpers, no duplication / DRY).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` using placeholder paths (`{Dev}`, `{User}`, `{MachineType}`, `{RepoRoot}`, `{AppData}`).

## Tests

```powershell
Run-Tests -TestName "Get-BrowserTitlePattern"
Run-Tests -TestName "Wait-BrowserWindowReady"
Run-Tests -TestName "Terminate-AllBrowserProcesses"
Run-Tests -TestName "Open-Browser"
Run-Tests -TestName "Initialize-Win32BrowserHelperType"
```

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/`.
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text.
- [ ] N/A - no testable behavior changed (docs/chore only).

New/updated test files:

- `Tests/Modules/System/Get-BrowserTitlePattern.Tests.ps1` **(new)** - includes the U+200B regression case and the Firefox/Tor disambiguation.
- `Tests/Modules/Application/Wait-BrowserWindowReady.Tests.ps1` **(new)** - immediate hit, title filtering, timeout, and keep-polling paths.
- `Tests/Modules/Application/Open-Browser.Tests.ps1` - new `NoMenu Instances mode` context: `NewWindowArg` on every launch, the cold-start gate, the shared-process-name count, and the already-satisfied case.
- `Tests/Modules/System/Terminate-AllBrowserProcesses.Tests.ps1` - dot-sources the new helper.

### Manual verification (real machine, before/after)

| Scenario                                                  | Before      | After                                              |
| --------------------------------------------------------- | ----------- | -------------------------------------------------- |
| `Terminate-AllBrowserProcesses` with 3 Edge windows open  | 3 remained  | 0 remain                                           |
| `Open-Browser -NoMenu -Browser Brave -Instances 3` (cold) | 1-2 windows | exactly 3                                          |
| `Open-Browser -NoMenu -Browser Edge -Instances 2` (cold)  | -           | exactly 2, then all closed by the kill step        |
| Re-run of a satisfied `-Instances` target                 | -           | `already has 3/3 instance(s) open!`, opens nothing |
| A separate Firefox session running throughout             | -           | untouched by every Edge/Brave run                  |

## Documentation & manifests

- [x] I updated `docs/modules/<Module>.md` for any added/renamed/removed/changed function.
- [x] I updated the module `.psd1` `FunctionsToExport`.
- [ ] I updated `docs/docs_overview.md` (and `docs/_sidebar.md` if a page was added/removed) - **N/A**, neither indexes individual functions and no page was added.
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds.
- [ ] N/A - no exported function changed.

## Tested on

- Windows version: Windows 11 Pro 25H2 (10.0.26200)
- PowerShell version: 7.6.4
- Machine type(s): PC via a private fork

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] This PR contains no secrets or personal data (tokens, real paths/hostnames/emails).
