### PR TITLE
Stop installing package managers WinuX has no apps for and reconcile version pins uniformly on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.28] - 2026-08-05
+
+### Added
+
+- `Resolve-PackageManagers` (Bootstrap module): the single gate deciding which of WinGet, Scoop and Chocolatey WinuX installs and upgrades, consumed by both `Bootstrap` and `Upgrade-All`. A manager is in play only when it is listed in `PackageManagers` **and** its effective app list holds at least one row for this machine type (read through `Import-AppCsv`, so the `<name>.local.csv` overlay counts, with each row's `Machine` column checked via `Test-MachineTypeScope`). Returns canonical spelling in Bootstrap's install order, and reports an unknown entry like `"Chocolatley"` through `Write-LogError` instead of silently dropping a manager.
+- `Sync-AppPins` (System module): reconciles a package manager's own version pins with the effective app list in both directions before an upgrade - pinning every version-locked row, and clearing pins left behind by rows that are back to tracking the latest. All three managers go through their native mechanism (`winget pin`, `scoop hold`, `choco pin`), so the treatment is uniform and the lock is recorded in the manager rather than only in WinuX.
+
+### Changed
+
+- **A package manager is no longer installed when WinuX has no apps for it.** `Bootstrap`'s three `*Apps` steps now run only for managers in play, so the step toggles can only turn a manager off - enabling `ScoopApps` does not install Scoop if `PackageManagers` omits it or its app list is empty. A vanilla bootstrap used to download and PATH-register two package managers that then managed nothing, because `ScoopApps.csv` and `ChocolateyApps.csv` ship empty.
+- `PackageManagers` went from a near-dead key that only `Upgrade-All` read to the opt-in list gating installation as well.
+- `Bootstrap` resolves the managers once and hands the set to `Upgrade-All` rather than letting it resolve again - one set of skip warnings per run, and the upgrade provably covers exactly what was just installed.
+- `Upgrade-All` now upgrades only the managers in play rather than every manager the configuration listed, `-PackageManager` accepts more than one manager (`Upgrade-All WinGet, Scoop`), and an explicit request is honoured as given without consulting the config. It also skips a manager whose CLI is absent instead of running it anyway: with Chocolatey listed but never installed, `choco upgrade all` used to fail and log an error for a manager the machine deliberately did not have.
+- All three `Upgrade-All` branches are now the same two steps - reconcile pins, then run the manager's bulk upgrade. Scoop's special case is gone: it no longer enumerates installed apps via `scoop export` to build a filtered `scoop update <list>`, because a held app is skipped by `scoop update *` on its own.
+
+### Breaking
+
+- **`PackageManagers` in the base configuration is now `@("WinGet")` instead of all three managers**, and it gates installation rather than only upgrades. A fork that relied on the base list to get Scoop or Chocolatey installed will stop getting them.
+
+  **Migration.** If your `<name>.local.csv` overlay gives Scoop or Chocolatey any apps, name those managers in `Configuration.local.psd1`:
+
+  ```powershell
+  PackageManagers = @("WinGet", "Scoop")
+  ```
+
+  Arrays replace wholesale on merge, so list every manager you want, not just the additions. No action is needed if your Scoop and Chocolatey lists are empty - that is the case this release exists to fix, and those managers were installing for zero apps. `Resolve-PackageManagers` reports every manager it drops and why, so a bootstrap log tells you immediately whether a manager you expected is missing.
+
+### Fixed
+
+- A version pin no longer outlives the decision behind it. Unpinning an app in the CSV left `winget pin` / `choco pin` in place, so the app stayed frozen forever with nothing in WinuX left to explain why it had stopped updating - and nothing anywhere ever removed a stale Chocolatey pin. `Upgrade-All` now reconciles every manager's pins through `Sync-AppPins`, which only ever touches apps WinuX manages, leaving hand-made pins for other apps alone.
+- **A version-pinned Scoop app is now actually held in Scoop.** Scoop supports `hold`/`unhold`, but WinuX never used it: the Scoop branch merely left pinned apps out of the app list it passed to `scoop update`, so the lock existed only inside `Upgrade-All`. A hand-run `scoop update *` upgraded straight past the pin. Pinned rows are now held through `scoop hold` (with `-g` when the app is installed globally, following the installed scope read from `scoop export` rather than the CSV's `Global` column), which makes Scoop behave exactly like WinGet and Chocolatey and makes the pin hold outside WinuX too. A version-locked row that is not installed yet is reported and left to `Install-ScoopApps`, since a hold only exists on an installed app.
+- `Upgrade-All` no longer reports a failure for a manager whose CLI sets no exit code. The per-manager exit code is reset each iteration, so it cannot inherit the previous manager's `$LASTEXITCODE`.
+
 ## [0.1.27] - 2026-08-05
 
 ### Added
@@ -421,7 +454,8 @@ The first public release of WinuX.
 - Governance and licensing: MIT license, contributor guide, code of conduct, security policy, and third-party notices.
 - CI: the full Pester suite on every pull request, and a release workflow that builds `WinuX.exe` from every version tag and attaches it - with a SHA-256 checksum - to the GitHub release.
 
-[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.27...HEAD
+[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.28...HEAD
+[0.1.28]: https://github.com/IvanPavlak/WinuX/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/IvanPavlak/WinuX/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/IvanPavlak/WinuX/compare/v0.1.25...v0.1.26
 [0.1.25]: https://github.com/IvanPavlak/WinuX/compare/v0.1.24...v0.1.25

--- a/Windows/PowerShell/Configuration.psd1
+++ b/Windows/PowerShell/Configuration.psd1
@@ -22,7 +22,10 @@
 # (Process scope), the framework apps in WinGetApps.csv (PowerShell, Windows
 # Terminal, PowerToys), PowerShell modules, and the framework symlinks (the
 # PowerShell profile that persists WinuX into new shells, plus the FancyZones
-# files backing the window machinery). Individual bootstrap steps are toggleable
+# files backing the window machinery). WinGet is the only package manager
+# installed, because it is the only one the base has apps for - Scoop and
+# Chocolatey ship empty lists and are skipped entirely (see PackageManagers).
+# Individual bootstrap steps are toggleable
 # via BootstrapConfig.Steps (see that section); invasive steps such as
 # MicrosoftActivationScripts, Win11Debloat, DeveloperMode, NuGetConfig and
 # LockedStartLayout are OFF until you opt in.
@@ -98,7 +101,7 @@
 # → Universal executable paths      : Open-* functions (DBeaver, VirtualBox, etc.)
 #
 # Bootstrap Process:
-# → PackageManagers              : Bootstrap
+# → PackageManagers              : Resolve-PackageManagers → Bootstrap, Upgrade-All
 # → BootstrapConfig              : Bootstrap, Install-Bootstrap
 #
 # Machine Type Detection:
@@ -645,10 +648,25 @@
 	# ==========================================================================
 	# Package Managers Configuration
 	# ==========================================================================
+	# → Consumers: Resolve-PackageManagers (and through it Bootstrap and Upgrade-All)
+	#
+	# The opt-in list of package managers WinuX uses. A manager absent from this list is
+	# never installed by Bootstrap and never touched by Upgrade-All.
+	#
+	# Being listed is necessary but not sufficient: Resolve-PackageManagers also drops a
+	# listed manager whose effective app list has no entries for the current machine type
+	# (overlay included), because installing a package manager that then manages nothing is
+	# a download, a PATH entry and a shim directory bought for no apps. So the list and the
+	# CSVs cannot drift into that state - emptying an overlay is enough to stop installing
+	# its manager.
+	#
+	# The base ships WinGet alone: it carries the framework apps (PowerShell, Windows
+	# Terminal, PowerToys), while ScoopApps.csv and ChocolateyApps.csv ship empty. Add a
+	# manager here in Configuration.local.psd1 when your overlay gives it apps, e.g.
+	#   PackageManagers = @("WinGet", "Scoop")
+	# Valid values: "WinGet", "Scoop", "Chocolatey" (anything else is reported as unknown).
 	PackageManagers               = @(
-		"WinGet",
-		"Scoop",
-		"Chocolatey"
+		"WinGet"
 	)
 
 	# ==========================================================================
@@ -734,6 +752,11 @@
 		# - ScoopApps                  : Install-ScoopPackageManager + Install-ScoopApps
 		# - ChocolateyApps             : Install-ChocolateyPackageManager + Install-ChocolateyApps
 		# - UpgradeAll                 : Upgrade-All
+		#
+		# The three *Apps steps and UpgradeAll are additionally gated by which managers are
+		# in play (PackageManagers plus a non-empty app list - see Resolve-PackageManagers).
+		# The step toggle can only turn a manager OFF: enabling ScoopApps does not install
+		# Scoop if PackageManagers omits it or its app list is empty for this machine.
 		# - DotnetEf                   : Install-DotnetEf
 		# - EnvironmentVariables       : Set-EnvironmentVariables -Auto
 		# - CondaEnvironments          : Create-CondaEnvironments

--- a/Windows/PowerShell/Modules/Bootstrap/Bootstrap.psd1
+++ b/Windows/PowerShell/Modules/Bootstrap/Bootstrap.psd1
@@ -15,6 +15,7 @@
 		'Load-PathConfiguration',
 		'Merge-Hashtable',
 		'Resolve-BootstrapSteps',
+		'Resolve-PackageManagers',
 		'Test-MachineTypeScope'
 	)
 }

--- a/Windows/PowerShell/Modules/Bootstrap/Functions/Bootstrap.ps1
+++ b/Windows/PowerShell/Modules/Bootstrap/Functions/Bootstrap.ps1
@@ -191,31 +191,45 @@ function Bootstrap {
 			Write-LogWarning "WSL setup disabled for machine type [$global:MachineType] (BootstrapConfig.Steps.WSL) - skipping Configure-WSL, Initialize-WSLEnvironment, Configure-WSLSSH"
 		}
 
-		if ($steps.WinGetApps) {
+		# Which package managers this machine actually uses: listed in PackageManagers AND holding at
+		# least one app for this machine type (see Resolve-PackageManagers, which reports the ones it
+		# drops). A manager with nothing to install is never installed just to sit there managing
+		# nothing - the base Scoop and Chocolatey lists ship empty, so a vanilla bootstrap installs
+		# WinGet alone. The step toggles remain the per-invocation override on top of that.
+		$managers = @(Resolve-PackageManagers)
+
+		if ($steps.WinGetApps -and $managers -contains "WinGet") {
 			Install-WinGetPackageManager
 			Install-WinGetApps
 		}
-		else {
+		elseif (-not $steps.WinGetApps) {
 			Write-LogWarning "WinGet apps skipped (BootstrapConfig.Steps.WinGetApps)"
 		}
 
-		if ($steps.ScoopApps) {
+		if ($steps.ScoopApps -and $managers -contains "Scoop") {
 			Install-ScoopPackageManager
 			Install-ScoopApps
 		}
-		else {
+		elseif (-not $steps.ScoopApps) {
 			Write-LogWarning "Scoop apps skipped (BootstrapConfig.Steps.ScoopApps)"
 		}
 
-		if ($steps.ChocolateyApps) {
+		if ($steps.ChocolateyApps -and $managers -contains "Chocolatey") {
 			Install-ChocolateyPackageManager
 			Install-ChocolateyApps
 		}
-		else {
+		elseif (-not $steps.ChocolateyApps) {
 			Write-LogWarning "Chocolatey apps skipped (BootstrapConfig.Steps.ChocolateyApps)"
 		}
 
-		if ($steps.UpgradeAll) { Upgrade-All } else { Write-LogWarning "Package upgrade skipped (BootstrapConfig.Steps.UpgradeAll)" }
+		# The managers resolved above are handed over rather than resolved a second time: same answer,
+		# one set of skip warnings per run, and the upgrade provably covers exactly what was installed.
+		if ($steps.UpgradeAll -and $managers.Count -gt 0) {
+			Upgrade-All -PackageManager $managers
+		}
+		elseif (-not $steps.UpgradeAll) {
+			Write-LogWarning "Package upgrade skipped (BootstrapConfig.Steps.UpgradeAll)"
+		}
 
 		# Fork-defined optional install steps (BootstrapConfig.PersonalSteps) - the base config
 		# ships an empty list, so a vanilla WinuX bootstrap runs nothing here. Entries are plain

--- a/Windows/PowerShell/Modules/Bootstrap/Functions/Resolve-PackageManagers.ps1
+++ b/Windows/PowerShell/Modules/Bootstrap/Functions/Resolve-PackageManagers.ps1
@@ -1,0 +1,114 @@
+function Resolve-PackageManagers {
+	<#
+	.SYNOPSIS
+		Returns the package managers actually in play on this machine, in canonical order.
+
+	.DESCRIPTION
+		The single gate deciding which of WinGet, Scoop and Chocolatey WinuX installs and upgrades.
+		A manager is in play when BOTH of these hold:
+
+		- It is listed in `PackageManagers` in Configuration.psd1. That list is the opt-in: a manager
+		  absent from it is never installed and never upgraded.
+		- Its effective app list holds at least one row applicable to this machine type. The list is
+		  read through `Import-AppCsv`, so the machine-local `<name>.local.csv` overlay counts, and
+		  each row's `Machine` column is checked with `Test-MachineTypeScope`, so a manager whose
+		  only apps target other machines counts as empty here.
+
+		The second condition is what keeps a package manager off a machine that has no use for it.
+		Installing one is not free - it is a download, a PATH entry and a shim directory that then
+		sit there managing nothing - and the base WinuX Scoop and Chocolatey lists ship empty, so a
+		vanilla bootstrap used to install two managers for zero apps. Deriving it from the data
+		rather than from the list alone also means the two cannot drift: a fork that empties its
+		Scoop overlay stops installing Scoop without having to remember to also edit
+		`PackageManagers`.
+
+		Names are matched case-insensitively and returned in canonical spelling and canonical order
+		(WinGet, Scoop, Chocolatey - the order Bootstrap installs them in), so callers can switch on
+		the returned strings directly. Unknown entries are reported through `Write-LogError` with the
+		valid values, the same way `Test-MachineTypeScope` reports a misspelled machine scope, so a
+		typo like "Chocolatley" is surfaced instead of silently dropping a manager.
+
+	.PARAMETER PackageManager
+		Explicit manager(s) to use instead of resolving from configuration. An explicit request is
+		honoured as given - neither the opt-in list nor the empty-list check second-guesses a caller
+		who named the managers - and is returned in canonical order. This is what backs
+		`Upgrade-All -PackageManager`.
+
+	.PARAMETER MachineType
+		Machine type the app lists are filtered against. Defaults to $global:MachineType.
+
+	.EXAMPLE
+		Resolve-PackageManagers
+		Returns e.g. @("WinGet") on the base configuration, whose Scoop and Chocolatey lists are empty.
+
+	.EXAMPLE
+		Resolve-PackageManagers -PackageManager "Chocolatey"
+		Returns @("Chocolatey") regardless of configuration - an explicit request is honoured.
+
+	.NOTES
+		Rows with an invalid `Machine` token are reported here and again by the installer that reads
+		the same list later in Bootstrap. The duplicate line is deliberate: the alternative is a
+		second, non-validating scope matcher, and one gate for machine scope is exactly what
+		`Test-MachineTypeScope` exists to be.
+	#>
+	[CmdletBinding()]
+	[OutputType([string[]])]
+	param(
+		[Parameter(Mandatory = $false, Position = 0)]
+		[ValidateSet('WinGet', 'Scoop', 'Chocolatey')]
+		[string[]]$PackageManager,
+
+		[Parameter(Mandatory = $false)]
+		[string]$MachineType = $global:MachineType
+	)
+
+	# Canonical spelling, in Bootstrap's install order, each mapped to the DataFiles key its app
+	# list is resolved through.
+	$canonical = [ordered]@{
+		WinGet     = 'WinGetApps'
+		Scoop      = 'ScoopApps'
+		Chocolatey = 'ChocolateyApps'
+	}
+
+	if ($PackageManager) {
+		return [string[]]@($canonical.Keys | Where-Object { $_ -in $PackageManager })
+	}
+
+	$configured = @($global:Configuration.PackageManagers |
+		Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+		ForEach-Object { "$_".Trim() })
+
+	if ($configured.Count -eq 0) {
+		Write-LogWarning "No package managers configured (PackageManagers in Configuration.psd1) - no package manager will be installed or upgraded"
+		return [string[]]@()
+	}
+
+	foreach ($name in $configured) {
+		if ($name -notin @($canonical.Keys)) {
+			Write-LogError "Unknown package manager [$name] in PackageManagers - valid values: $(@($canonical.Keys) -join ', ')"
+		}
+	}
+
+	$inPlay = foreach ($name in $canonical.Keys) {
+		if ($name -notin $configured) { continue }
+
+		$dataFileKey = $canonical[$name]
+
+		$apps = @(Import-AppCsv -DataFileKey $dataFileKey | Where-Object {
+				Test-MachineTypeScope -Scope "$($_.Machine)" -MachineType $MachineType -Context "$dataFileKey [$($_.App)]"
+			})
+
+		if ($apps.Count -eq 0) {
+			Write-LogWarning "[$name] is configured but its app list has no entries for machine type [$MachineType] - not installing or upgrading it"
+			continue
+		}
+
+		$name
+	}
+
+	$resolved = [string[]]@($inPlay)
+
+	Write-LogDebug "Package managers in play for [$MachineType]: $(if ($resolved.Count) { $resolved -join ', ' } else { '<none>' })"
+
+	return $resolved
+}

--- a/Windows/PowerShell/Modules/System/Functions/Get-PinnedApps.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Get-PinnedApps.ps1
@@ -11,9 +11,12 @@ function Get-PinnedApps {
 
 		Reading through `Import-AppCsv` rather than the committed CSV directly is what makes the pin
 		honour the overlay, and it matters in both directions: a version pinned only in the overlay is
-		invisible in the base file, so a direct reader would let `Upgrade-All` upgrade straight past
-		the pin - exactly the outcome pinning exists to prevent - and an app the overlay removed would
-		still be reported as pinned and handed to `winget pin add`.
+		invisible in the base file, so a direct reader would let the upgrade run straight past the pin -
+		exactly the outcome pinning exists to prevent - and an app the overlay removed would still be
+		reported as pinned and handed to the manager's pin command.
+
+		This is the single definition of "what counts as pinned"; `Sync-AppPins` consumes it to decide
+		which apps to lock in each package manager.
 
 	.PARAMETER DataFileKey
 		Which list to read: `WinGetApps`, `ScoopApps` or `ChocolateyApps`. Resolved through

--- a/Windows/PowerShell/Modules/System/Functions/Sync-AppPins.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Sync-AppPins.ps1
@@ -1,0 +1,167 @@
+function Sync-AppPins {
+	<#
+	.SYNOPSIS
+		Reconciles a package manager's own version pins with the effective app list, in both directions.
+
+	.DESCRIPTION
+		Makes the package manager's own pin state match the app list before an upgrade runs, so a bulk
+		upgrade cannot move a version-locked app. All three managers are handled the same way, through
+		each one's native pin mechanism:
+
+		| Manager    | Pin                              | Unpin                        | Current state read       |
+		| ---------- | -------------------------------- | ---------------------------- | ------------------------ |
+		| WinGet     | `winget pin add --blocking`      | `winget pin remove`          | `winget pin list --id`   |
+		| Scoop      | `scoop hold`                     | `scoop unhold`               | `scoop export` (Info)    |
+		| Chocolatey | `choco pin add`                  | `choco pin remove`           | `choco pin list -r`      |
+
+		Both halves of the lifecycle matter:
+
+		- Every row carrying a real version is PINNED. This is the half that stops an upgrade from
+		  walking straight past a deliberate version lock.
+		- Every row back to "track the latest" that is still pinned from an earlier run has its pin
+		  REMOVED. Without this half a pin outlives the decision behind it: unpinning an app in the CSV
+		  leaves the manager's own pin in place and the app frozen forever, with nothing in WinuX left
+		  to explain why it stopped updating. `Install-WinGetApps` already reconciles this way per app
+		  at install time; this is the same reconciliation for the upgrade path.
+
+		Recording the pin in the manager itself - rather than merely excluding the app from the list
+		WinuX passes to the upgrade - is what makes the lock hold outside WinuX too: a hand-run
+		`winget upgrade --all`, `scoop update *` or `choco upgrade all` respects it as well.
+
+		Only apps WinuX manages are touched: the removal side considers exactly the apps in the
+		effective list that are not pinned. A pin somebody added by hand for an app outside the list
+		was not WinuX's to make and is not WinuX's to drop.
+
+		The list is read through `Get-PinnedApps` / `Import-AppCsv`, so a version pinned in a
+		machine-local `<name>.local.csv` overlay counts as a pin and an app the overlay removed is not
+		treated as managed.
+
+	.PARAMETER PackageManager
+		Which manager's pins to reconcile: "WinGet", "Scoop" or "Chocolatey".
+
+	.EXAMPLE
+		Sync-AppPins -PackageManager WinGet
+		Pins every version-locked WinGet app and clears pins for apps that are back to "Latest".
+
+	.EXAMPLE
+		Sync-AppPins -PackageManager Scoop
+		The same through `scoop hold` / `scoop unhold`, so a later `scoop update *` skips the held apps.
+
+	.NOTES
+		Scoop can only hold an installed app, so a version-locked row that is not installed yet is
+		reported and left for the installer - unlike WinGet and Chocolatey, whose pin commands are
+		accepted ahead of installation.
+	#>
+	[CmdletBinding()]
+	param(
+		[Parameter(Mandatory = $true, Position = 0)]
+		[ValidateSet('WinGet', 'Scoop', 'Chocolatey')]
+		[string]$PackageManager
+	)
+
+	$dataFileKey = @{ WinGet = 'WinGetApps'; Scoop = 'ScoopApps'; Chocolatey = 'ChocolateyApps' }[$PackageManager]
+
+	# The Version value that means "not pinned", per manager: WinGet spells it "Latest", Scoop writes
+	# it lower case, and Chocolatey leaves the cell empty - so for Chocolatey any version at all counts
+	# as a pin.
+	$versionExcludeValue = @{ WinGet = 'Latest'; Scoop = 'latest'; Chocolatey = $null }[$PackageManager]
+
+	$pinnedApps = @(Get-PinnedApps -DataFileKey $dataFileKey -VersionExcludeValue $versionExcludeValue)
+
+	# The apps WinuX manages but does not pin - the only ones whose leftover pin may be removed.
+	$managedApps = @(Import-AppCsv -DataFileKey $dataFileKey | ForEach-Object { "$($_.App)".Trim() } | Where-Object { $_ })
+	$unpinnedApps = @($managedApps | Where-Object { $_ -notin $pinnedApps })
+
+	# Current pin state, read once per manager where the CLI can report it in bulk. WinGet has no
+	# machine-readable bulk pin list, so it is queried per app in the removal loop instead.
+	$pinnedNow = @()
+	$scoopInstalled = @()
+	$scoopIsGlobal = @{}
+
+	switch ($PackageManager) {
+		'Scoop' {
+			# `scoop export` returns exactly what `scoop list` produces, whose Info column is a
+			# comma-joined set of markers including 'Held package' and 'Global install'. That makes one
+			# call enough to learn what is installed, what is held, and which scope each app lives in -
+			# and the installed scope, not the CSV's Global column, is what hold/unhold must follow,
+			# since an app may have been installed the other way by hand.
+			try {
+				$scoopApps = @((scoop export | ConvertFrom-Json).apps)
+			}
+			catch {
+				Write-LogWarning "Could not read the installed Scoop apps - skipping Scoop pin reconciliation!"
+				return
+			}
+
+			foreach ($scoopApp in $scoopApps) {
+				$name = "$($scoopApp.Name)".Trim()
+				if (-not $name) { continue }
+
+				$scoopInstalled += $name
+				$scoopIsGlobal[$name] = "$($scoopApp.Info)" -like '*Global install*'
+				if ("$($scoopApp.Info)" -like '*Held package*') { $pinnedNow += $name }
+			}
+		}
+		'Chocolatey' {
+			# `choco pin list -r` reports every pin as "name|version" in one call.
+			$pinnedNow = @(choco pin list -r 2>$null | ForEach-Object { ("$_" -split '\|')[0].Trim() } | Where-Object { $_ })
+		}
+	}
+
+	foreach ($app in $unpinnedApps) {
+		switch ($PackageManager) {
+			'WinGet' {
+				# Queried per app rather than parsed out of a bare `winget pin list` table, matching
+				# what Install-WinGetApps does: the table's columns shift with terminal width and the
+				# installed locale, and a mis-parse here would silently unpin the wrong app.
+				$pinOutput = winget pin list --id $app --accept-source-agreements --disable-interactivity 2>$null
+				if (-not ($pinOutput | Where-Object { $_ -match [regex]::Escape($app) })) { continue }
+
+				Write-LogWarning "Removing stale pin for [$app] - it is no longer version-pinned"
+				winget pin remove --id $app --disable-interactivity | Out-Null
+			}
+			'Scoop' {
+				if ($app -notin $pinnedNow) { continue }
+
+				Write-LogWarning "Removing stale hold for [$app] - it is no longer version-pinned"
+				$scoopArgs = @('unhold')
+				if ($scoopIsGlobal[$app]) { $scoopArgs += '-g' }
+				scoop @scoopArgs $app | Out-Null
+			}
+			'Chocolatey' {
+				if ($app -notin $pinnedNow) { continue }
+
+				Write-LogWarning "Removing stale pin for [$app] - it is no longer version-pinned"
+				choco pin remove --name=$app | Out-Null
+			}
+		}
+	}
+
+	if ($pinnedApps.Count -eq 0) { return }
+
+	Show-PinnedAppsWarning -PinnedApps $pinnedApps -Message "Pinning version-specific packages to prevent upgrades"
+
+	foreach ($app in $pinnedApps) {
+		switch ($PackageManager) {
+			'WinGet' {
+				winget pin add --id $app --blocking --accept-source-agreements --disable-interactivity | Out-Null
+			}
+			'Scoop' {
+				# Unlike a WinGet or Chocolatey pin, a hold only exists on an installed app.
+				if ($app -notin $scoopInstalled) {
+					Write-LogWarning "[$app] is version-pinned but not installed - Install-ScoopApps installs it at the pinned version"
+					continue
+				}
+
+				$scoopArgs = @('hold')
+				if ($scoopIsGlobal[$app]) { $scoopArgs += '-g' }
+				scoop @scoopArgs $app | Out-Null
+			}
+			'Chocolatey' {
+				choco pin add --name=$app | Out-Null
+			}
+		}
+	}
+
+	Write-Host ""
+}

--- a/Windows/PowerShell/Modules/System/Functions/Upgrade-All.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Upgrade-All.ps1
@@ -1,110 +1,104 @@
 function Upgrade-All {
 	<#
 	.SYNOPSIS
-		Upgrades all packages across WinGet, Scoop, and/or Chocolatey.
+		Upgrades all packages across the package managers WinuX actually uses.
 
 	.DESCRIPTION
-		Upgrades packages in the specified package managers. Reads pinned (version-locked) apps
-		from the configured app lists - via `Get-PinnedApps`, so a version pinned in a machine-local
-		`<name>.local.csv` overlay counts too - and prevents them from being upgraded.
+		Upgrades packages in the package managers that are in play on this machine, resolved by
+		`Resolve-PackageManagers`: listed in `PackageManagers` in Configuration.psd1 AND holding at
+		least one app for this machine type. A manager WinuX has no apps for is not upgraded, the
+		same way it is not installed - running its CLI anyway would only produce a failure for a
+		manager the machine deliberately does not have.
 
-		Without `-PackageManager`, upgrades across all managers configured in `PackageManagers` in Configuration.psd1.
-		With `-PackageManager`, upgrades only the specified manager.
+		Version-pinned apps are never upgraded. Every manager is handled identically: `Sync-AppPins`
+		reconciles that manager's own pin mechanism with the app list first - `winget pin`, `scoop hold`
+		or `choco pin`, pinning version-locked apps and clearing pins for apps back to tracking the
+		latest - and the manager then skips what it has pinned during its bulk upgrade. Pins honour the
+		machine-local `<name>.local.csv` overlay, since the lists are read through `Import-AppCsv`.
+
+		With `-PackageManager`, upgrades exactly the named manager(s) and skips resolution from
+		configuration - an explicit request is honoured as given.
 
 		Requires administrator privileges.
 
 	.PARAMETER PackageManager
-		Package manager(s) to upgrade: "WinGet", "Scoop", or "Chocolatey".
-		Omit to upgrade all configured managers.
+		Package manager(s) to upgrade: "WinGet", "Scoop", or "Chocolatey". Omit to upgrade every
+		manager in play for this machine.
 
 	.EXAMPLE
 		Upgrade-All
-		Upgrades all packages across all configured managers.
+		Upgrades every package manager in play on this machine.
 
 	.EXAMPLE
 		Upgrade-All -PackageManager "WinGet"
 		Upgrades only WinGet packages.
+
+	.EXAMPLE
+		Upgrade-All -PackageManager "WinGet", "Scoop"
+		Upgrades WinGet and Scoop, leaving Chocolatey alone.
 	#>
 	param (
-		[Parameter(Mandatory = $false)]
+		[Parameter(Mandatory = $false, Position = 0)]
 		[ValidateSet("WinGet", "Scoop", "Chocolatey")]
-		[string]$PackageManager
+		[string[]]$PackageManager
 	)
 
 	Test-AdminPrivileges
 
-	$PackageManagers = if ($PackageManager) { @($PackageManager) } else { $global:Configuration.PackageManagers }
+	# Splatted rather than passed straight through: -PackageManager carries a ValidateSet, which
+	# rejects the null this parameter holds when the caller omitted it.
+	$resolveParams = @{}
+	if ($PackageManager) { $resolveParams.PackageManager = $PackageManager }
 
-	foreach ($PackageManager in $PackageManagers) {
-		Write-LogTitle "Upgrading all $PackageManager Software"
+	$managers = @(Resolve-PackageManagers @resolveParams)
+
+	if ($managers.Count -eq 0) {
+		Write-LogWarning "No package managers to upgrade"
+		return
+	}
+
+	# The CLI each manager is driven through, used to confirm it is actually present before its
+	# branch runs.
+	$commands = @{ WinGet = "winget"; Scoop = "scoop"; Chocolatey = "choco" }
+
+	foreach ($manager in $managers) {
+		if (-not (Get-Command $commands[$manager] -ErrorAction SilentlyContinue)) {
+			Write-LogWarning "[$manager] is not installed on this machine - skipping its upgrade"
+			continue
+		}
+
+		Write-LogTitle "Upgrading all $manager Software"
+
+		# Reset per manager so a branch whose CLI never sets one cannot inherit the previous manager's
+		# exit code and report a failure that never happened.
+		$exitCode = 0
 
 		try {
-			switch ($PackageManager) {
+			# Every manager follows the same two steps: reconcile its own pins with the app list, then
+			# run its bulk upgrade. The manager itself skips what it has pinned, so the pin holds for a
+			# hand-run upgrade too - not just for this function.
+			Sync-AppPins -PackageManager $manager
+
+			switch ($manager) {
 				"WinGet" {
-					$pinnedApps = Get-PinnedApps -DataFileKey WinGetApps
-
-					if ($pinnedApps.Count -gt 0) {
-						Show-PinnedAppsWarning -PinnedApps $pinnedApps -Message "Pinning version-specific packages to prevent upgrades"
-
-						foreach ($app in $pinnedApps) {
-							winget pin add --id $app --blocking --accept-source-agreements --disable-interactivity | Out-Null
-						}
-						Write-Host ""
-					}
-
 					winget upgrade --all --silent --include-unknown --accept-source-agreements --accept-package-agreements --disable-interactivity
 					$exitCode = $LASTEXITCODE
 				}
 				"Scoop" {
-					$pinnedApps = Get-PinnedApps -DataFileKey ScoopApps -VersionExcludeValue "latest"
-
-					if ($pinnedApps.Count -gt 0) {
-						Show-PinnedAppsWarning -PinnedApps $pinnedApps -Message "Pinning version-specific packages to prevent upgrades"
-
-						try {
-							$scoopExport = scoop export | ConvertFrom-Json
-							$installedApps = $scoopExport.apps | ForEach-Object { $_.Name }
-						}
-						catch {
-							Write-LogWarning "Could not get list of installed apps!"
-							$installedApps = @()
-						}
-
-						$appsToUpdate = $installedApps | Where-Object { $_ -notin $pinnedApps }
-
-						if ($appsToUpdate.Count -gt 0) {
-							scoop update $appsToUpdate
-						}
-						else {
-							Write-LogStep "All apps are version-pinned! Nothing to update!"
-						}
-					}
-					else {
-						scoop update *
-					}
+					scoop update *
 					$exitCode = $LASTEXITCODE
 				}
 				"Chocolatey" {
-					$pinnedApps = Get-PinnedApps -DataFileKey ChocolateyApps -VersionExcludeValue $null
-
-					if ($pinnedApps.Count -gt 0) {
-						Show-PinnedAppsWarning -PinnedApps $pinnedApps -Message "Pinning version-specific packages to prevent upgrades"
-
-						foreach ($app in $pinnedApps) {
-							choco pin add --name=$app | Out-Null
-						}
-					}
-
 					choco upgrade all -y
 					$exitCode = $LASTEXITCODE
 				}
 			}
 
 			if ($exitCode -eq 0) {
-				Write-LogSuccess "Upgrading all $PackageManager Software completed"
+				Write-LogSuccess "Upgrading all $manager Software completed"
 			}
 			else {
-				Write-LogError "Upgrading all $PackageManager Software failed with exit code [$exitCode]"
+				Write-LogError "Upgrading all $manager Software failed with exit code [$exitCode]"
 			}
 		}
 		catch {

--- a/Windows/PowerShell/Modules/System/System.psd1
+++ b/Windows/PowerShell/Modules/System/System.psd1
@@ -55,6 +55,7 @@
 		'Set-Wallpaper',
 		'Show-PinnedAppsWarning',
 		'SymbolicLinkMaker',
+		'Sync-AppPins',
 		'Terminate-AllBrowserProcesses',
 		'Terminate-AllProcessesByName',
 		'Terminate-AllProcessesWithVisibleWindows',

--- a/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Bootstrap.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Bootstrap.Tests.ps1
@@ -14,6 +14,9 @@ BeforeAll {
 	# shared Resolve-Steps).
 	. "$ModuleRoot\Helper\Functions\Resolve-Steps.ps1"
 	. "$BootstrapFunctionsPath\Resolve-BootstrapSteps.ps1"
+	# Bootstrap gates the package-manager steps through Resolve-PackageManagers; dot-source it so it
+	# exists to Mock even in sessions whose imported Bootstrap module predates the export.
+	. "$BootstrapFunctionsPath\Resolve-PackageManagers.ps1"
 }
 
 AfterAll {
@@ -62,6 +65,8 @@ Describe "Bootstrap" {
 		Mock Set-SpecialFolders { }
 		Mock Restart-Explorer { }
 		Mock Configure-WSL { }
+		# All three in play by default, so the step-toggle tests below exercise the toggles alone.
+		Mock Resolve-PackageManagers { @('WinGet', 'Scoop', 'Chocolatey') }
 		Mock Install-WinGetPackageManager { }
 		Mock Install-WinGetApps { }
 		Mock Install-ScoopPackageManager { }
@@ -148,6 +153,55 @@ Describe "Bootstrap" {
 
 		Should -Invoke Upgrade-All -Times 0
 		Should -Invoke Install-WinGetApps -Times 1 -Exactly
+	}
+
+	It "installs only the package managers that are in play" {
+		$global:MachineType = 'Laptop'
+		Mock Resolve-PackageManagers { @('WinGet') }
+
+		Bootstrap
+
+		Should -Invoke Install-WinGetPackageManager -Times 1 -Exactly
+		Should -Invoke Install-WinGetApps -Times 1 -Exactly
+		Should -Invoke Install-ScoopPackageManager -Times 0
+		Should -Invoke Install-ScoopApps -Times 0
+		Should -Invoke Install-ChocolateyPackageManager -Times 0
+		Should -Invoke Install-ChocolateyApps -Times 0
+	}
+
+	It "does not install a package manager an enabled step asks for when it is not in play" {
+		$global:MachineType = 'Laptop'
+		$global:Configuration.BootstrapConfig = @{ Steps = @{ ScoopApps = $true } }
+		Mock Resolve-PackageManagers { @('WinGet') }
+
+		Bootstrap
+
+		Should -Invoke Install-ScoopPackageManager -Times 0
+		Should -Invoke Install-ScoopApps -Times 0
+	}
+
+	It "installs no package manager when none is in play" {
+		$global:MachineType = 'Laptop'
+		Mock Resolve-PackageManagers { @() }
+
+		Bootstrap
+
+		Should -Invoke Install-WinGetPackageManager -Times 0
+		Should -Invoke Install-ScoopPackageManager -Times 0
+		Should -Invoke Install-ChocolateyPackageManager -Times 0
+		# Nothing installed means nothing to upgrade either.
+		Should -Invoke Upgrade-All -Times 0
+	}
+
+	It "hands the resolved managers to Upgrade-All instead of letting it resolve again" {
+		$global:MachineType = 'Laptop'
+		Mock Resolve-PackageManagers { @('WinGet', 'Scoop') }
+
+		Bootstrap
+
+		Should -Invoke Upgrade-All -Times 1 -Exactly -ParameterFilter {
+			$PackageManager.Count -eq 2 -and $PackageManager -contains 'WinGet' -and $PackageManager -contains 'Scoop'
+		}
 	}
 
 	It "uses Update-Repositories -Private when RepositoryUpdateScope maps the machine type to Private" {

--- a/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Resolve-PackageManagers.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Bootstrap/Resolve-PackageManagers.Tests.ps1
@@ -1,0 +1,94 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$script:OriginalConfiguration = $global:Configuration
+	$script:OriginalMachineType = $global:MachineType
+
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$BootstrapFunctionsPath = Join-Path $ModuleRoot "Bootstrap\Functions"
+
+	. "$BootstrapFunctionsPath\Resolve-PackageManagers.ps1"
+	# Dot-sourced so they exist to Mock regardless of what the imported module exports.
+	. "$BootstrapFunctionsPath\Import-AppCsv.ps1"
+	. "$BootstrapFunctionsPath\Test-MachineTypeScope.ps1"
+}
+
+AfterAll {
+	$global:Configuration = $script:OriginalConfiguration
+	$global:MachineType = $script:OriginalMachineType
+}
+
+Describe "Resolve-PackageManagers" {
+	BeforeEach {
+		$global:MachineType = 'Test'
+		$global:Configuration = @{
+			PackageManagers   = @('WinGet', 'Scoop', 'Chocolatey')
+			ValidMachineTypes = @('Test')
+		}
+
+		Mock Write-LogWarning { }
+		Mock Write-LogError { }
+		Mock Write-LogDebug { }
+
+		# Every list holds one All-scoped app unless a test overrides this.
+		Mock Import-AppCsv { @([pscustomobject]@{ App = 'Some.App'; Machine = 'All' }) }
+	}
+
+	It "returns every configured manager whose app list has entries" {
+		Resolve-PackageManagers | Should -Be @('WinGet', 'Scoop', 'Chocolatey')
+	}
+
+	It "returns canonical order and spelling regardless of how the configuration lists them" {
+		$global:Configuration.PackageManagers = @('chocolatey', 'winget')
+
+		Resolve-PackageManagers | Should -Be @('WinGet', 'Chocolatey')
+	}
+
+	It "drops a manager that is not in PackageManagers" {
+		$global:Configuration.PackageManagers = @('WinGet')
+
+		Resolve-PackageManagers | Should -Be @('WinGet')
+	}
+
+	It "drops a configured manager whose app list is empty and says so" {
+		Mock Import-AppCsv -ParameterFilter { $DataFileKey -eq 'ScoopApps' } -MockWith { @() }
+
+		Resolve-PackageManagers | Should -Be @('WinGet', 'Chocolatey')
+		Should -Invoke Write-LogWarning -Times 1 -Exactly
+	}
+
+	It "drops a configured manager whose only apps target another machine type" {
+		$global:Configuration.ValidMachineTypes = @('Test', 'PC')
+		Mock Import-AppCsv -ParameterFilter { $DataFileKey -eq 'ChocolateyApps' } -MockWith {
+			@([pscustomobject]@{ App = 'Other.App'; Machine = 'PC' })
+		}
+
+		Resolve-PackageManagers | Should -Be @('WinGet', 'Scoop')
+	}
+
+	It "returns nothing and warns when PackageManagers is empty" {
+		$global:Configuration.PackageManagers = @()
+
+		@(Resolve-PackageManagers).Count | Should -Be 0
+		Should -Invoke Write-LogWarning -Times 1 -Exactly
+		Should -Invoke Import-AppCsv -Times 0
+	}
+
+	It "reports an unknown entry instead of silently ignoring it" {
+		$global:Configuration.PackageManagers = @('WinGet', 'Chocolatley')
+
+		Resolve-PackageManagers | Should -Be @('WinGet')
+		Should -Invoke Write-LogError -Times 1 -Exactly
+	}
+
+	It "honours an explicit request without consulting configuration or the app lists" {
+		$global:Configuration.PackageManagers = @('WinGet')
+
+		Resolve-PackageManagers -PackageManager 'Chocolatey' | Should -Be @('Chocolatey')
+		Should -Invoke Import-AppCsv -Times 0
+	}
+
+	It "returns an explicit multi-manager request in canonical order" {
+		Resolve-PackageManagers -PackageManager @('Chocolatey', 'WinGet') | Should -Be @('WinGet', 'Chocolatey')
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/System/Sync-AppPins.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/System/Sync-AppPins.Tests.ps1
@@ -1,0 +1,187 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$FunctionsPath = Join-Path $ModuleRoot "System\Functions"
+
+	. "$FunctionsPath\Sync-AppPins.ps1"
+	. "$FunctionsPath\Get-PinnedApps.ps1"
+	. "$ModuleRoot\Bootstrap\Functions\Import-AppCsv.ps1"
+
+	# Function stubs standing in for the CLIs, so the tests do not depend on any manager being
+	# installed on the machine running them. `scoop` additionally resolves to an external script that
+	# Mock cannot bind in script scope even when it is present.
+	function winget { }
+	function scoop { }
+	function choco { }
+}
+
+Describe "Sync-AppPins" {
+	BeforeEach {
+		Mock Show-PinnedAppsWarning { }
+		Mock Write-LogWarning { }
+		Mock Write-Host { }
+		Mock winget { }
+		Mock scoop { }
+		Mock choco { }
+	}
+
+	Context "WinGet" {
+		It "pins every version-locked app" {
+			Mock Import-AppCsv {
+				@(
+					[pscustomobject]@{ App = 'Pinned.App'; Version = '1.2.3' }
+					[pscustomobject]@{ App = 'Latest.App'; Version = 'Latest' }
+				)
+			}
+
+			Sync-AppPins -PackageManager WinGet
+
+			Should -Invoke winget -ParameterFilter {
+				$args -contains 'pin' -and $args -contains 'add' -and $args -contains 'Pinned.App'
+			} -Times 1 -Exactly
+		}
+
+		It "removes a stale pin for an app that is back to Latest" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'Latest.App'; Version = 'Latest' }) }
+			# `winget pin list --id Latest.App` still reports the app => a pin survived from an
+			# earlier run when it was version-locked.
+			Mock winget -ParameterFilter { $args -contains 'list' } -MockWith { 'Latest.App  1.2.3  Pinning' }
+
+			Sync-AppPins -PackageManager WinGet
+
+			Should -Invoke winget -ParameterFilter {
+				$args -contains 'pin' -and $args -contains 'remove' -and $args -contains 'Latest.App'
+			} -Times 1 -Exactly
+		}
+
+		It "leaves an unpinned app alone when no pin exists for it" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'Latest.App'; Version = 'Latest' }) }
+			Mock winget -ParameterFilter { $args -contains 'list' } -MockWith { 'No pins are configured.' }
+
+			Sync-AppPins -PackageManager WinGet
+
+			Should -Invoke winget -ParameterFilter { $args -contains 'remove' } -Times 0
+		}
+
+		It "never removes a pin for an app outside the managed list" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'Latest.App'; Version = 'Latest' }) }
+			Mock winget -ParameterFilter { $args -contains 'list' } -MockWith { 'No pins are configured.' }
+
+			Sync-AppPins -PackageManager WinGet
+
+			# Only the managed app is ever interrogated - a hand-made pin for anything else is not
+			# WinuX's to drop.
+			Should -Invoke winget -ParameterFilter { $args -contains 'list' } -Times 1 -Exactly
+		}
+	}
+
+	Context "Scoop" {
+		BeforeEach {
+			# `scoop export` is the single read of installed / held / global state.
+			Mock scoop -ParameterFilter { $args -contains 'export' } -MockWith {
+				'{"apps":[{"Name":"pinnedapp","Info":""},{"Name":"latestapp","Info":"Held package"},{"Name":"globalapp","Info":"Global install, Held package"}]}'
+			}
+		}
+
+		It "holds a version-locked app through scoop hold" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'pinnedapp'; Version = '1.2.3' }) }
+
+			Sync-AppPins -PackageManager Scoop
+
+			Should -Invoke scoop -ParameterFilter { $args -contains 'hold' -and $args -contains 'pinnedapp' } -Times 1 -Exactly
+		}
+
+		It "releases a stale hold for an app that is back to latest" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'latestapp'; Version = 'latest' }) }
+
+			Sync-AppPins -PackageManager Scoop
+
+			Should -Invoke scoop -ParameterFilter { $args -contains 'unhold' -and $args -contains 'latestapp' } -Times 1 -Exactly
+		}
+
+		It "holds nothing when the app is not installed, since a hold needs an installed app" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'absentapp'; Version = '1.2.3' }) }
+
+			Sync-AppPins -PackageManager Scoop
+
+			Should -Invoke scoop -ParameterFilter { $args -contains 'hold' } -Times 0
+			Should -Invoke Write-LogWarning -Times 1 -Exactly
+		}
+
+		It "follows the installed scope rather than the CSV, passing -g for a global app" {
+			# The row says Global=false, but the app is installed globally - hold must follow reality.
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'globalapp'; Version = 'latest'; Global = 'false' }) }
+
+			Sync-AppPins -PackageManager Scoop
+
+			Should -Invoke scoop -ParameterFilter {
+				$args -contains 'unhold' -and $args -contains '-g' -and $args -contains 'globalapp'
+			} -Times 1 -Exactly
+		}
+
+		It "does not pass -g for a user-scoped app" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'latestapp'; Version = 'latest' }) }
+
+			Sync-AppPins -PackageManager Scoop
+
+			Should -Invoke scoop -ParameterFilter { $args -contains 'unhold' -and $args -contains '-g' } -Times 0
+		}
+
+		It "releases nothing when the app holds no hold" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'pinnedapp'; Version = 'latest' }) }
+
+			Sync-AppPins -PackageManager Scoop
+
+			Should -Invoke scoop -ParameterFilter { $args -contains 'unhold' } -Times 0
+		}
+
+		It "gives up on reconciliation rather than guessing when scoop export fails" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'pinnedapp'; Version = '1.2.3' }) }
+			Mock scoop -ParameterFilter { $args -contains 'export' } -MockWith { 'not json' }
+
+			Sync-AppPins -PackageManager Scoop
+
+			Should -Invoke scoop -ParameterFilter { $args -contains 'hold' } -Times 0
+			Should -Invoke scoop -ParameterFilter { $args -contains 'unhold' } -Times 0
+		}
+	}
+
+	Context "Chocolatey" {
+		It "treats any version as a pin, since an empty cell means latest" {
+			Mock Import-AppCsv {
+				@(
+					[pscustomobject]@{ App = 'pinnedapp'; Version = '1.2.3' }
+					[pscustomobject]@{ App = 'latestapp'; Version = '' }
+				)
+			}
+			Mock choco -ParameterFilter { $args -contains 'list' } -MockWith { @() }
+
+			Sync-AppPins -PackageManager Chocolatey
+
+			Should -Invoke choco -ParameterFilter {
+				$args -contains 'add' -and $args -contains '--name=pinnedapp'
+			} -Times 1 -Exactly
+		}
+
+		It "removes a stale pin reported by choco pin list" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'latestapp'; Version = '' }) }
+			Mock choco -ParameterFilter { $args -contains 'list' } -MockWith { 'latestapp|1.2.3' }
+
+			Sync-AppPins -PackageManager Chocolatey
+
+			Should -Invoke choco -ParameterFilter {
+				$args -contains 'remove' -and $args -contains '--name=latestapp'
+			} -Times 1 -Exactly
+		}
+
+		It "removes nothing when choco reports no pins" {
+			Mock Import-AppCsv { @([pscustomobject]@{ App = 'latestapp'; Version = '' }) }
+			Mock choco -ParameterFilter { $args -contains 'list' } -MockWith { @() }
+
+			Sync-AppPins -PackageManager Chocolatey
+
+			Should -Invoke choco -ParameterFilter { $args -contains 'remove' } -Times 0
+		}
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/System/Upgrade-All.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/System/Upgrade-All.Tests.ps1
@@ -5,6 +5,16 @@ BeforeAll {
 	$FunctionsPath = Join-Path $ModuleRoot "System\Functions"
 
 	. "$FunctionsPath\Upgrade-All.ps1"
+	# Dot-sourced so it exists to Mock regardless of what the imported module exports.
+	. "$ModuleRoot\Bootstrap\Functions\Resolve-PackageManagers.ps1"
+
+	# Function stubs standing in for the three CLIs. None of them is present on a clean CI runner,
+	# and `scoop` resolves to an external script that Mock cannot bind in script scope even when it
+	# is - so the suite provides its own commands to mock instead of depending on the machine.
+	# Upgrade-All's Get-Command presence check sees these, which is what the tests want.
+	function winget { }
+	function scoop { }
+	function choco { }
 }
 
 Describe "Upgrade-All" {
@@ -16,13 +26,121 @@ Describe "Upgrade-All" {
 		Mock Test-AdminPrivileges { }
 		Mock Get-PinnedApps { @() }
 		Mock Show-PinnedAppsWarning { }
+		Mock Sync-AppPins { }
 		Mock Write-Host { }
+		Mock Write-LogTitle { }
+		Mock Write-LogStep { }
+		Mock Write-LogSuccess { }
+		Mock Write-LogWarning { }
+		Mock Write-LogError { }
+		# The stubs set $LASTEXITCODE explicitly. A real CLI sets it; a function stub does not, so
+		# without this the exit-code assertions would read whatever ambient value the previous test
+		# left behind and pass or fail depending on execution order.
+		Mock winget { $global:LASTEXITCODE = 0 }
+		Mock scoop { $global:LASTEXITCODE = 0 }
+		Mock choco { $global:LASTEXITCODE = 0 }
+		Mock Resolve-PackageManagers { @() }
 	}
 
-	It "does nothing when no package managers are configured" {
+	It "does nothing when no package managers are in play" {
 		{ Upgrade-All } | Should -Not -Throw
 
 		Should -Invoke Test-AdminPrivileges -Times 1
 		Should -Invoke Get-PinnedApps -Times 0
+		Should -Invoke winget -Times 0
+	}
+
+	It "upgrades only the managers Resolve-PackageManagers returns" {
+		Mock Resolve-PackageManagers { @('WinGet') }
+
+		Upgrade-All
+
+		Should -Invoke winget -ParameterFilter { $args -contains 'upgrade' } -Times 1 -Exactly
+		Should -Invoke choco -Times 0
+		Should -Invoke scoop -Times 0
+	}
+
+	It "passes an explicit -PackageManager through to the resolver" {
+		Mock Resolve-PackageManagers { @('Chocolatey') } -ParameterFilter { $PackageManager -contains 'Chocolatey' }
+
+		Upgrade-All -PackageManager 'Chocolatey'
+
+		Should -Invoke choco -ParameterFilter { $args -contains 'upgrade' } -Times 1 -Exactly
+		Should -Invoke winget -Times 0
+	}
+
+	It "accepts more than one manager" {
+		Mock Resolve-PackageManagers { @('WinGet', 'Chocolatey') }
+
+		Upgrade-All -PackageManager @('WinGet', 'Chocolatey')
+
+		Should -Invoke winget -ParameterFilter { $args -contains 'upgrade' } -Times 1 -Exactly
+		Should -Invoke choco -ParameterFilter { $args -contains 'upgrade' } -Times 1 -Exactly
+	}
+
+	It "reconciles pins before upgrading, for every manager alike" -ForEach @(
+		@{ Manager = 'WinGet' }
+		@{ Manager = 'Scoop' }
+		@{ Manager = 'Chocolatey' }
+	) {
+		$expected = $Manager
+		Mock Resolve-PackageManagers { @($expected) }
+
+		Upgrade-All
+
+		Should -Invoke Sync-AppPins -ParameterFilter { $PackageManager -eq $expected } -Times 1 -Exactly
+	}
+
+	It "skips a manager whose CLI is not installed instead of failing on it" {
+		Mock Resolve-PackageManagers { @('Chocolatey') }
+		Mock Get-Command { $null } -ParameterFilter { $Name -eq 'choco' }
+
+		Upgrade-All
+
+		Should -Invoke choco -Times 0
+		Should -Invoke Write-LogError -Times 0
+	}
+
+	It "runs the plain bulk update for Scoop and leaves pin handling to Sync-AppPins" {
+		Mock Resolve-PackageManagers { @('Scoop') }
+
+		Upgrade-All
+
+		# No app-list juggling any more: the hold recorded by Sync-AppPins is what makes
+		# `scoop update *` skip a pinned app, so the pin holds for a hand-run update too.
+		Should -Invoke scoop -ParameterFilter { $args -contains 'update' -and $args -contains '*' } -Times 1 -Exactly
+		Should -Invoke scoop -ParameterFilter { $args -contains 'export' } -Times 0
+		Should -Invoke Get-PinnedApps -Times 0
+	}
+
+	It "reports success on a zero exit code" {
+		Mock Resolve-PackageManagers { @('Scoop') }
+
+		Upgrade-All
+
+		Should -Invoke Write-LogSuccess -Times 1 -Exactly
+		Should -Invoke Write-LogError -Times 0
+	}
+
+	It "reports the failing exit code when a manager's upgrade fails" {
+		Mock Resolve-PackageManagers { @('Scoop') }
+		Mock scoop { $global:LASTEXITCODE = 3 }
+
+		Upgrade-All
+
+		Should -Invoke Write-LogError -Times 1 -Exactly
+		Should -Invoke Write-LogSuccess -Times 0
+	}
+
+	It "does not carry one manager's failure over to the next" {
+		Mock Resolve-PackageManagers { @('WinGet', 'Scoop') }
+		Mock winget { $global:LASTEXITCODE = 3 }
+
+		Upgrade-All
+
+		# WinGet failed, Scoop succeeded - the per-iteration reset is what keeps Scoop from
+		# inheriting WinGet's exit code.
+		Should -Invoke Write-LogError -Times 1 -Exactly
+		Should -Invoke Write-LogSuccess -Times 1 -Exactly
 	}
 }

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -754,11 +754,23 @@ SymbolicLinks = @{
 
 Settings used during the Bootstrap process.
 
-### Package Managers
+### PackageManagers
 
-**Key:** `PackageManagers` → Array of enabled package managers (`"WinGet"`, `"Scoop"`, `"Chocolatey"`)
+**Key:** `PackageManagers` → Array of opted-in package managers (`"WinGet"`, `"Scoop"`, `"Chocolatey"`)
 
-**Consumer function:** `Bootstrap`
+**Consumer function:** [`Resolve-PackageManagers`](../modules/bootstrap.md#resolve-packagemanagers), and through it [`Bootstrap`](../modules/bootstrap.md#bootstrap) and [`Upgrade-All`](../modules/system.md#upgrade-all)
+
+The opt-in list of package managers WinuX uses. A manager absent from this list is never installed by Bootstrap and never touched by `Upgrade-All`.
+
+Being listed is necessary but not sufficient: `Resolve-PackageManagers` also drops a listed manager whose effective app list has no entries for the current machine type (overlay included), because installing a package manager that then manages nothing is a download, a PATH entry and a shim directory bought for no apps. The list and the CSVs therefore cannot drift into that state - emptying an overlay is enough to stop installing its manager.
+
+The base ships **WinGet alone**: it carries the framework apps (PowerShell, Windows Terminal, PowerToys), while `ScoopApps.csv` and `ChocolateyApps.csv` ship empty. Add a manager in `Configuration.local.psd1` when your overlay gives it apps - arrays replace wholesale on merge, so name every manager you want, not just the additions:
+
+```powershell
+PackageManagers = @("WinGet", "Scoop")
+```
+
+Anything other than the three valid values is reported as unknown rather than silently ignored.
 
 ### BootstrapConfig
 

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -108,7 +108,7 @@ The configuration uses a hierarchical structure designed to eliminate duplicatio
 
 | Section           | Purpose                     | Consumer Function                |
 | ----------------- | --------------------------- | -------------------------------- |
-| `PackageManagers` | WinGet, Scoop, Chocolatey   | `Bootstrap`                      |
+| `PackageManagers` | Opted-in package managers   | `Resolve-PackageManagers`        |
 | `BootstrapConfig` | Log files, external scripts | `Bootstrap`, `Install-Bootstrap` |
 
 ### Machine Type Detection

--- a/docs/docs_overview.md
+++ b/docs/docs_overview.md
@@ -129,9 +129,11 @@ Phase 3 (System Config):         Set-CustomExecutionPolicy → Enable-DeveloperM
                                  → Display-SystemLanguageSettings → Configure-NerdFont
                                  → Install-PowerShellModules → Set-SpecialFolders
                                  → Restart-Explorer → Configure-WSL (config-gated: Steps.WSL)
-Phase 4 (Packages):              Install-WinGetPackageManager → Install-WinGetApps
+Phase 4 (Packages):              Resolve-PackageManagers (base => WinGet alone)
+                                 → Install-WinGetPackageManager → Install-WinGetApps
                                  → Install-ScoopPackageManager → Install-ScoopApps
                                  → Install-ChocolateyPackageManager → Install-ChocolateyApps → Upgrade-All
+                                 (each manager runs only if in play: PackageManagers + non-empty app list)
 Phase 5 (Dev Tools):             PersonalSteps (fork-defined; base runs none) → Install-DotnetEF
 Phase 6 (Environment):           Set-EnvironmentVariables -Auto → Create-CondaEnvironments
                                  → Configure-NuGetConfig

--- a/docs/getting-started/first-run.md
+++ b/docs/getting-started/first-run.md
@@ -56,13 +56,15 @@ Every step is individually toggleable via `BootstrapConfig.Steps` (or per invoca
 │  └─→ Configure-WSL (config-gated: Steps.WSL)                                │
 │                                                                             │
 │  PHASE 4: PACKAGE MANAGEMENT                                                │
+│  │   Only managers in play run: listed in PackageManagers AND holding at    │
+│  │   least one app for this machine. Base config => WinGet alone.           │
 │  ├─→ Install-WinGetPackageManager                                           │
 │  ├─→ Install-WinGetApps (from WinGetApps.csv)                               │
-│  ├─→ Install-ScoopPackageManager                                            │
+│  ├─→ Install-ScoopPackageManager (skipped: empty ScoopApps.csv)             │
 │  ├─→ Install-ScoopApps (from ScoopApps.csv)                                 │
-│  ├─→ Install-ChocolateyPackageManager                                       │
+│  ├─→ Install-ChocolateyPackageManager (skipped: empty ChocolateyApps.csv)   │
 │  ├─→ Install-ChocolateyApps (from ChocolateyApps.csv)                       │
-│  └─→ Upgrade-All (update all packages)                                      │
+│  └─→ Upgrade-All (update packages of every manager in play)                 │
 │                                                                             │
 │  PHASE 5: DEVELOPMENT TOOLS                                                 │
 │  ├─→ PersonalSteps (fork-defined; base config runs none)                    │

--- a/docs/getting-started/subsequent-runs.md
+++ b/docs/getting-started/subsequent-runs.md
@@ -26,7 +26,7 @@ Bootstrap is **idempotent** - safe to run multiple times:
 | **Update-Repositories**   | Pulls latest, stashes local changes if needed  |
 | **System Configuration**  | Re-applies settings (no-op if already correct) |
 | **Package Installation**  | Installs new apps from CSV, skips existing     |
-| **Upgrade-All**           | Updates all installed packages                 |
+| **Upgrade-All**           | Updates packages of every manager in play      |
 | **Symbolic Links**        | Re-creates (safe if already exist)             |
 | **Environment Variables** | Re-applies (no-op if already set)              |
 | **Taskbar**               | Reconfigures pinned apps                       |
@@ -56,13 +56,16 @@ Update-Repositories WinuX
 ### Package Management
 
 ```powershell
-# Upgrade everything
+# Upgrade every package manager in play (PackageManagers + non-empty app list)
 Upgrade-All
 
-# Upgrade specific manager
+# Upgrade specific manager - honoured as given, even if not in PackageManagers
 Upgrade-All WinGet
 Upgrade-All Scoop
 Upgrade-All Chocolatey
+
+# Upgrade more than one
+Upgrade-All WinGet, Scoop
 
 # Install new WinGet apps (after editing CSV)
 Install-WinGetApps

--- a/docs/modules/bootstrap.md
+++ b/docs/modules/bootstrap.md
@@ -12,6 +12,8 @@ Transforms a fresh Windows installation into a fully configured development envi
 
 Every step is individually toggleable via `BootstrapConfig.Steps`, resolved once per run by [Resolve-BootstrapSteps](#resolve-bootstrapsteps); `-Skip`/`-Include` override the config per invocation. Most steps also no-op on their own when their configuration section is empty, so an enabled step on the empty base config applies nothing. The opt-in steps that act the moment they run default off: `MicrosoftActivationScripts`, `Win11Debloat`, `DeveloperMode`, `NuGetConfig`, `LockedStartLayout`.
 
+The three package-manager steps are additionally gated by [Resolve-PackageManagers](#resolve-packagemanagers), called once per run: a manager is installed only when it is listed in `PackageManagers` **and** has at least one app for this machine type. The step toggle can therefore only turn a manager off - enabling `ScoopApps` does not install Scoop if `PackageManagers` omits it or its app list is empty. On the base configuration that means WinGet alone, because `ScoopApps.csv` and `ChocolateyApps.csv` ship empty.
+
 Execution sequence:
 
 1. (`-WithInitialSetup` only) `Rename-Machine`, `Start-MicrosoftActivationScripts`, `Start-Win11Debloat` (the latter two opt-in via `Steps`)
@@ -20,7 +22,7 @@ Execution sequence:
 4. System theme, locale, display language, keyboard layouts
 5. Nerd Font, PowerShell modules, special folder redirections
 6. WSL configuration
-7. WinGet, Scoop, and Chocolatey - install package managers then apps from CSVs
+7. WinGet, Scoop, and Chocolatey - install each manager in play then its apps from CSVs
 8. Upgrade all packages, fork-defined personal steps (BootstrapConfig.PersonalSteps, each entry optionally machine-gated like the app CSVs' `Machine` column), .NET EF CLI
 9. Environment variables, Conda environments, NuGet config, taskbar pins
 10. WSL environment initialization, symbolic links, WSL SSH setup
@@ -328,6 +330,35 @@ Resolve-BootstrapSteps -Include Win11Debloat
 ```
 
 **See also:** [Bootstrap](#bootstrap), [Resolve-Steps](helper.md#resolve-steps), [Configuration Reference: BootstrapConfig](../configuration/configuration-reference.md#bootstrapconfig)
+
+## [Resolve-PackageManagers](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Bootstrap/Functions/Resolve-PackageManagers.ps1)
+
+- **Description:** The single gate deciding which of WinGet, Scoop and Chocolatey WinuX installs and upgrades. Returns the managers in play, in canonical spelling and canonical order (WinGet, Scoop, Chocolatey - the order Bootstrap installs them in), so callers can switch on the returned strings directly. Consumed by [`Bootstrap`](#bootstrap) and [`Upgrade-All`](system.md#upgrade-all).
+- **Parameters:** -PackageManager (explicit override), -MachineType
+- **Usage:** `Resolve-PackageManagers`, `Resolve-PackageManagers -PackageManager "Chocolatey"`
+
+A manager is in play when **both** conditions hold:
+
+- It is listed in `PackageManagers` in `Configuration.psd1`. That list is the opt-in: a manager absent from it is never installed and never upgraded.
+- Its effective app list holds at least one row applicable to this machine type. The list is read through [`Import-AppCsv`](#import-appcsv), so the machine-local `<name>.local.csv` overlay counts, and each row's `Machine` column is checked with [`Test-MachineTypeScope`](#test-machinetypescope), so a manager whose only apps target other machines counts as empty.
+
+The second condition is what keeps a package manager off a machine that has no use for it. Installing one is not free - it is a download, a PATH entry and a shim directory that then sit there managing nothing - and the base Scoop and Chocolatey lists ship empty, so a vanilla bootstrap used to install two managers for zero apps. Deriving it from the data rather than from the list alone also means the two cannot drift: a fork that empties its Scoop overlay stops installing Scoop without having to remember to also edit `PackageManagers`.
+
+Unknown entries are reported through `Write-LogError` with the valid values, the same way `Test-MachineTypeScope` reports a misspelled machine scope, so a typo like `"Chocolatley"` is surfaced instead of silently dropping a manager. An empty `PackageManagers` returns nothing with a warning.
+
+| Parameter          | Type       | Default               | Description                                                                                                                                    |
+| ------------------ | ---------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-PackageManager`  | `string[]` | -                     | Explicit manager(s) to use instead of resolving from configuration. Honoured as given - neither the opt-in list nor the empty-list check applies. Backs `Upgrade-All -PackageManager`. |
+| `-MachineType`     | `string`   | `$global:MachineType` | Machine type the app lists are filtered against.                                                                                               |
+
+```powershell
+# What would Bootstrap install on this machine?
+Resolve-PackageManagers
+
+# Base configuration => WinGet alone (Scoop and Chocolatey ship empty lists)
+```
+
+**See also:** [Bootstrap](#bootstrap), [Import-AppCsv](#import-appcsv), [Test-MachineTypeScope](#test-machinetypescope), [Upgrade-All](system.md#upgrade-all), [Configuration Reference: PackageManagers](../configuration/configuration-reference.md#packagemanagers)
 
 ## [Test-MachineTypeScope](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Bootstrap/Functions/Test-MachineTypeScope.ps1)
 

--- a/docs/modules/system.md
+++ b/docs/modules/system.md
@@ -256,7 +256,7 @@ Get-InstalledApps
 
 ## [Get-PinnedApps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Get-PinnedApps.ps1)
 
-- **Description:** Returns the version-pinned apps of one app list, machine-local overlay included. Reads the list through [`Import-AppCsv`](bootstrap.md#import-appcsv) and returns the `App` of every row whose `Version` is a real version rather than the "track the latest" value. Used to identify apps that should NOT be upgraded because they are locked to a specific version. Helper function for `Upgrade-All`.
+- **Description:** Returns the version-pinned apps of one app list, machine-local overlay included. Reads the list through [`Import-AppCsv`](bootstrap.md#import-appcsv) and returns the `App` of every row whose `Version` is a real version rather than the "track the latest" value. The single definition of "what counts as pinned", used by [`Sync-AppPins`](#sync-apppins) to decide which apps to lock in each package manager.
 - **Parameters:** -DataFileKey, -VersionExcludeValue
 - **Usage:** `Get-PinnedApps -DataFileKey WinGetApps`, `Get-PinnedApps -DataFileKey ScoopApps -VersionExcludeValue "latest"`
 
@@ -277,7 +277,7 @@ Get-PinnedApps -DataFileKey WinGetApps
 Get-PinnedApps -DataFileKey ScoopApps -VersionExcludeValue "latest"
 ```
 
-**See also:** [Import-AppCsv](bootstrap.md#import-appcsv), [Upgrade-All](#upgrade-all)
+**See also:** [Import-AppCsv](bootstrap.md#import-appcsv), [Sync-AppPins](#sync-apppins), [Upgrade-All](#upgrade-all)
 
 ## [Initialize-OhMyPosh](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Initialize-OhMyPosh.ps1)
 
@@ -1028,6 +1028,46 @@ The machine type is resolved via `DetermineMachineType`, then the `SymbolicLinks
 SymbolicLinkMaker
 ```
 
+## [Sync-AppPins](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Sync-AppPins.ps1)
+
+- **Description:** Reconciles a package manager's own version pins with the effective app list, in both directions, so a bulk upgrade cannot move a version-locked app. All three managers are handled through their native pin mechanism. Called by [`Upgrade-All`](#upgrade-all) before the upgrade runs.
+- **Parameters:** -PackageManager (`WinGet`, `Scoop` or `Chocolatey`)
+- **Usage:** `Sync-AppPins -PackageManager WinGet`, `Sync-AppPins -PackageManager Scoop`
+
+| Manager      | Pin                         | Unpin               | Current state read     |
+| ------------ | --------------------------- | ------------------- | ---------------------- |
+| `WinGet`     | `winget pin add --blocking` | `winget pin remove` | `winget pin list --id` |
+| `Scoop`      | `scoop hold`                | `scoop unhold`      | `scoop export` (Info)  |
+| `Chocolatey` | `choco pin add`             | `choco pin remove`  | `choco pin list -r`    |
+
+Both halves of the pin lifecycle matter:
+
+- Every row carrying a real version is **pinned**. This is what stops `winget upgrade --all`, `scoop update *` and `choco upgrade all` from walking straight past a deliberate version lock.
+- Every row back to tracking the latest that is still pinned from an earlier run has its pin **removed**. Without this half a pin outlives the decision behind it: unpinning an app in the CSV would leave the manager's own pin in place and the app frozen forever, with nothing in WinuX left to explain why it stopped updating. [`Install-WinGetApps`](application.md#install-wingetapps) already reconciles this way per app at install time; this is the same reconciliation for the upgrade path.
+
+Recording the pin **in the manager itself** - rather than merely excluding the app from the list WinuX passes to the upgrade - is what makes the lock hold outside WinuX too: a hand-run `winget upgrade --all`, `scoop update *` or `choco upgrade all` respects it as well.
+
+Only apps WinuX manages are touched - the removal side considers exactly the apps in the effective list that are not pinned, so a pin somebody added by hand for an app outside the list is left alone. Pinned apps come from [`Get-PinnedApps`](#get-pinnedapps) and the managed set from [`Import-AppCsv`](bootstrap.md#import-appcsv), so the machine-local `<name>.local.csv` overlay counts on both sides.
+
+Two Scoop specifics, both consequences of how scoop stores a hold (in the installed app's `install.json`):
+
+- A hold only exists on an **installed** app, so a version-locked row that is not installed yet is reported and left to [`Install-ScoopApps`](application.md#install-scoopapps), which installs it at the pinned version. WinGet and Chocolatey accept a pin ahead of installation.
+- `scoop hold`/`unhold` need `-g` for a globally installed app, and the flag follows the **installed scope** read from `scoop export`, not the CSV's `Global` column - an app may have been installed the other way by hand, and the hold has to land where the app actually is. The single `scoop export` call reports installed, held and global state together, since its `Info` column is the comma-joined marker set `scoop list` builds.
+
+| Parameter         | Description                                                                                                                                                                          |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `-PackageManager` | Which manager's pins to reconcile: `WinGet` (unpinned value is `Latest`), `Scoop` (lower-case `latest`), or `Chocolatey` (an empty `Version` cell means latest, so any version counts as a pin). |
+
+```powershell
+# Pin every version-locked WinGet app and clear pins for apps back to "Latest"
+Sync-AppPins -PackageManager WinGet
+
+# The same through scoop hold / unhold, so a later `scoop update *` skips the held apps
+Sync-AppPins -PackageManager Scoop
+```
+
+**See also:** [Upgrade-All](#upgrade-all), [Get-PinnedApps](#get-pinnedapps), [Show-PinnedAppsWarning](#show-pinnedappswarning)
+
 ## [Terminate-AllBrowserProcesses](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Terminate-AllBrowserProcesses.ps1)
 
 - **Description:** Gracefully terminates every browser declared in `Configuration.Universal.Browsers` (Firefox, Tor, Chrome, Edge, Brave) by posting `WM_CLOSE` to each browser's visible top-level windows. Browsers are disambiguated by both process name (derived from the configured `Exe` filename) and a brand-specific window title regex, so browsers that share a process name (Firefox vs. Tor, both `firefox.exe`) and chromium child processes (GPU/renderer/utility) are handled correctly. With `-Exclude`, `WM_CLOSE` is posted only to non-matching windows - kept windows are never touched, so there is no foreground-focus race.
@@ -1282,23 +1322,33 @@ Update-DirectoryNames -Path "C:\My Folders" -WhatIf
 
 ## [Upgrade-All](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Upgrade-All.ps1)
 
-- **Description:** Upgrades all packages across WinGet, Scoop, and/or Chocolatey. Reads pinned (version-locked) apps from the configured app lists - via `Get-PinnedApps`, so a version pinned in a machine-local `<name>.local.csv` overlay counts too - and prevents them from being upgraded. Without `-PackageManager` it upgrades across all managers listed in `PackageManagers` in `Configuration.psd1`; with `-PackageManager` it upgrades only the specified manager. Requires administrator privileges.
+- **Description:** Upgrades all packages across the package managers WinuX actually uses on this machine, resolved by [`Resolve-PackageManagers`](bootstrap.md#resolve-packagemanagers): listed in `PackageManagers` in `Configuration.psd1` **and** holding at least one app for this machine type. Version-pinned apps are never upgraded. Without `-PackageManager` it upgrades every manager in play; with `-PackageManager` it upgrades exactly the manager(s) named. Requires administrator privileges.
 - **Parameters:** -PackageManager
-- **Usage:** `Upgrade-All`, `Upgrade-All -PackageManager "WinGet"`
+- **Usage:** `Upgrade-All`, `Upgrade-All -PackageManager "WinGet"`, `Upgrade-All -PackageManager "WinGet", "Scoop"`
 
-For each targeted manager the function first loads its version-pinned apps through [`Get-PinnedApps`](#get-pinnedapps) (which reads the effective list, overlay included), warns about them, and pins them so they are excluded from the upgrade, then runs the manager's bulk upgrade (`winget upgrade --all`, `scoop update *`, or `choco upgrade all -y`) and reports success or the failing exit code per manager.
+For each manager in play the function first confirms the manager's CLI is actually present - a manager this machine never installed is skipped with a warning rather than driven into a guaranteed failure - then follows the same two steps for every manager alike:
 
-| Parameter         | Description                                                                                                                   |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `-PackageManager` | Single manager to upgrade: `WinGet`, `Scoop`, or `Chocolatey`. Omit to upgrade every manager configured in `PackageManagers`. |
+1. [`Sync-AppPins`](#sync-apppins) reconciles that manager's own pin mechanism (`winget pin`, `scoop hold`, `choco pin`) with the app list, pinning version-locked apps and clearing pins for apps back to tracking the latest.
+2. The manager's bulk upgrade runs unconditionally - `winget upgrade --all`, `scoop update *`, or `choco upgrade all -y` - and the manager itself skips what it has pinned.
+
+Success or the failing exit code is reported per manager. The pinned set comes from [`Get-PinnedApps`](#get-pinnedapps), which reads the effective list, so a version pinned in a machine-local `<name>.local.csv` overlay counts too.
+
+| Parameter         | Description                                                                                                                      |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `-PackageManager` | Manager(s) to upgrade: `WinGet`, `Scoop`, or `Chocolatey`. Accepts more than one. Omit to upgrade every manager in play. |
 
 ```powershell
-# Upgrade all packages across every configured manager (run as admin)
+# Upgrade every package manager in play on this machine (run as admin)
 Upgrade-All
 
 # Upgrade only WinGet packages
 Upgrade-All -PackageManager "WinGet"
+
+# Upgrade WinGet and Scoop, leaving Chocolatey alone
+Upgrade-All -PackageManager "WinGet", "Scoop"
 ```
+
+**See also:** [Sync-AppPins](#sync-apppins), [Get-PinnedApps](#get-pinnedapps), [Resolve-PackageManagers](bootstrap.md#resolve-packagemanagers)
 
 ## Testing
 


### PR DESCRIPTION
## Description

`PackageManagers` was a near-dead configuration key: `Upgrade-All` was its only consumer in the whole repository, and it did not gate installation at all. Bootstrap installed WinGet, Scoop and Chocolatey unconditionally (subject only to the step toggles, all defaulting `$true`) even though the base `ScoopApps.csv` and `ChocolateyApps.csv` ship empty - so a vanilla bootstrap downloaded and PATH-registered two package managers that then managed nothing.

This PR makes `PackageManagers` the opt-in list it always read like, and derives the rest from the data:

- **`Resolve-PackageManagers`** (new, Bootstrap module) is the single gate. A manager is in play only when it is listed in `PackageManagers` **and** its effective app list holds at least one row for this machine type - read through `Import-AppCsv` so the `<name>.local.csv` overlay counts, with each row's `Machine` column checked via `Test-MachineTypeScope`. The second condition is what keeps the list and the CSVs from drifting: emptying an overlay is enough to stop installing its manager, without also having to remember to edit `PackageManagers`.
- **Bootstrap** gates its three `*Apps` steps on the resolved set, so a step toggle can now only turn a manager _off_ - enabling `ScoopApps` does not install Scoop if its list is empty. It resolves once and hands the set to `Upgrade-All`, so there is one set of skip warnings per run and the upgrade provably covers exactly what was installed.
- **`Upgrade-All`** upgrades only the managers in play, accepts more than one manager (`Upgrade-All WinGet, Scoop`), honours an explicit `-PackageManager` as given, and skips a manager whose CLI is absent instead of running it anyway. With Chocolatey listed but never installed, `choco upgrade all` used to fail and log an error for a manager the machine deliberately did not have.

It also closes two pin bugs found while reading that code, and makes pinning uniform across the three managers.

**Pins were applied but never removed.** `Install-WinGetApps` cleared a stale winget pin at install time, and nothing anywhere ever cleared a stale `choco pin`. Unpinning an app in the CSV therefore left the manager's own pin in place and the app frozen forever, with nothing in WinuX left to explain why it had stopped updating.

**A version-pinned Scoop app was never actually held in Scoop.** Scoop supports `hold`/`unhold`, but WinuX never used it: the Scoop branch merely left pinned apps out of the app list it passed to `scoop update`, so the lock existed only inside `Upgrade-All` and a hand-run `scoop update *` upgraded straight past the pin.

**`Sync-AppPins`** (new, System module) reconciles both directions for all three managers through each one's native mechanism, touching only apps WinuX manages so hand-made pins for other apps survive:

| Manager      | Pin                         | Unpin               | Current state read     |
| ------------ | --------------------------- | ------------------- | ---------------------- |
| `WinGet`     | `winget pin add --blocking` | `winget pin remove` | `winget pin list --id` |
| `Scoop`      | `scoop hold`                | `scoop unhold`      | `scoop export` (Info)  |
| `Chocolatey` | `choco pin add`             | `choco pin remove`  | `choco pin list -r`    |

Recording the pin in the manager rather than only in WinuX is what makes the lock hold outside WinuX too. It also collapses `Upgrade-All` to the same two steps for every manager - reconcile pins, then run the bulk upgrade - deleting Scoop's `scoop export`-and-filter special case, because `scoop update *` skips a held app on its own (`scoop-update.ps1` guards on `$status.hold` and warns `'app' is held to version X`).

Two Scoop specifics, both consequences of scoop storing a hold in the installed app's `install.json`: a hold only exists on an _installed_ app, so a version-locked row that is not installed yet is reported and left to `Install-ScoopApps`; and `-g` is passed based on the _installed scope_ read from `scoop export`, not the CSV's `Global` column, since an app may have been installed the other way by hand.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [x] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

**Breaking, and how to migrate.** `PackageManagers` in the base configuration is now `@("WinGet")` instead of all three, and it gates installation rather than only upgrades. A fork that relied on the base list to get Scoop or Chocolatey installed will stop getting them. If your `<name>.local.csv` overlay gives either manager apps, name it in `Configuration.local.psd1`:

```powershell
PackageManagers = @("WinGet", "Scoop")
```

Arrays replace wholesale on merge, so list every manager you want, not just the additions. No action is needed if your Scoop and Chocolatey lists are empty - that is the case this release exists to fix. `Resolve-PackageManagers` reports every manager it drops and why, so a bootstrap log says immediately whether an expected manager is missing.

## Quality bar

- [x] The change is **minimal and focused** (one logical change; reuses existing helpers, no duplication / DRY).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` using placeholder paths (`{Dev}`, `{User}`, `{MachineType}`, `{RepoRoot}`, `{AppData}`).

Reuse notes: the resolver reads app lists through the existing `Import-AppCsv` and gates machine scope through the existing `Test-MachineTypeScope` rather than re-implementing either, and `Sync-AppPins` builds on `Get-PinnedApps` and `Show-PinnedAppsWarning`. No new configuration key was introduced - `PackageManagers` already existed.

## Tests

```powershell
Run-Tests -TestName "Resolve-PackageManagers"   # 9 passed
Run-Tests -TestName "Sync-AppPins"              # 14 passed
Run-Tests -TestName "Upgrade-All"               # 12 passed
Run-Tests                                       # 1563 passed, 0 failed
```

Full suite: **1563 passed, 0 failed, 0 skipped** across 8 workers (296 files, Pester 5.7.1), run twice with different worker bucketing to confirm no order dependence.

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/`.
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text.
- [ ] N/A - no testable behavior changed (docs/chore only).

32 new tests.

- `Resolve-PackageManagers` (9): canonical ordering and case-insensitive matching, dropping an unlisted manager, dropping a listed manager with an empty list, dropping one whose only apps target another machine type, the empty-`PackageManagers` warning, unknown-entry reporting, and explicit-request pass-through.
- `Sync-AppPins` (14): pin-add for version-locked rows and stale-pin removal for each of the three managers, no removal when no pin exists, never interrogating apps outside the managed list, Chocolatey's empty-cell-means-latest rule, Scoop skipping a hold for an app that is not installed, `-g` following the installed scope rather than the CSV, and bailing out of reconciliation instead of guessing when `scoop export` cannot be parsed.
- `Upgrade-All` (12): only in-play managers upgraded, multi-manager requests, pin reconciliation for every manager alike, CLI-absent skip, the plain `scoop update *` with no app-list juggling, success and failure exit-code reporting, and one manager's failure not carrying over to the next.
- `Bootstrap` (4): only in-play managers installed, an enabled step not overriding the gate, nothing installed when nothing is in play, and the resolved set being handed to `Upgrade-All`.

The new tests declare function stubs for `winget` / `scoop` / `choco` in `BeforeAll` instead of mocking the real CLIs, following the existing note in `Install-ScoopApps.Tests.ps1` - `scoop` resolves to an external script that Pester cannot bind in script scope. Side benefit: the tests no longer depend on which managers are installed on the runner. The stubs set `$LASTEXITCODE` explicitly, since a function does not set it and the exit-code assertions would otherwise read whatever ambient value the previous test left behind (this bit once during development - a green isolated run, a red full-suite run).

## Documentation & manifests

- [x] I updated `docs/modules/<Module>.md` for any added/renamed/removed/changed function.
- [x] I updated the module `.psd1` `FunctionsToExport`.
- [x] I updated `docs/docs_overview.md` (and `docs/_sidebar.md` if a page was added/removed).
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds.
- [ ] N/A - no exported function changed.

`Resolve-PackageManagers` added to `Bootstrap.psd1`, `Sync-AppPins` to `System.psd1`. Docs updated: `docs/modules/bootstrap.md`, `docs/modules/system.md`, `docs/configuration/configuration-reference.md` (the `Package Managers` heading is now `PackageManagers` with the full contract; no inbound links used the old anchor), `docs/configuration/overview.md`, `docs/docs_overview.md`, `docs/getting-started/first-run.md`, `docs/getting-started/subsequent-runs.md`. No page was added or removed, so `_sidebar.md` is unchanged. `List-Functions -ListDiscrepancies` => "No discrepancies found between the documentation and loaded functions!"

## Tested on

- Windows version: Windows 11 Pro 25H2 (10.0.26200)
- PowerShell version: 7.6.4
- Machine type(s): PC via a private fork

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] This PR contains no secrets or personal data (tokens, real paths/hostnames/emails).
