### PR TITLE
Add Set-ShortcutAumid and pin apps that register their own AppUserModelID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.29] - 2026-08-05
+
+### Added
+
+- `Set-ShortcutAumid` (System module): creates or updates a `.lnk` shortcut and stamps an explicit AppUserModelID (`System.AppUserModel.ID`) on it through the shell's property store - the same property the manual "Pin to taskbar" flow records, persisted into the `.lnk` itself so it travels with any copy Explorer makes when applying a taskbar layout.
+- `TaskbarConfiguration` `Path` rows accept an optional `Aumid` key, consumed by `Configure-Taskbar`. The taskbar groups a pinned icon with a running window only when both carry the same application identity; an app that registers its own AppUserModelID at runtime via `SetCurrentProcessExplicitAppUserModelID` (Eclipse/SWT apps such as DBeaver, some Java and Electron apps) never matches a pin created from its exe path, so it launches as a second, separate taskbar icon next to its own pin. With `Aumid`, the row is pinned through a shortcut stamped with that identity (a `.lnk` Value is stamped in place, an `.exe` Value gets a machine-local shortcut generated under `TaskbarPins\<Name>.lnk` next to the layout file), and the running window docks onto the pin. If stamping fails, the row falls back to the raw path with a warning. The configuration reference documents how to discover an app's runtime AUMID when `Get-StartApps` does not show it.
+
 ## [0.1.28] - 2026-08-05
 
 ### Added
@@ -454,7 +461,8 @@ The first public release of WinuX.
 - Governance and licensing: MIT license, contributor guide, code of conduct, security policy, and third-party notices.
 - CI: the full Pester suite on every pull request, and a release workflow that builds `WinuX.exe` from every version tag and attaches it - with a SHA-256 checksum - to the GitHub release.
 
-[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.28...HEAD
+[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.29...HEAD
+[0.1.29]: https://github.com/IvanPavlak/WinuX/compare/v0.1.28...v0.1.29
 [0.1.28]: https://github.com/IvanPavlak/WinuX/compare/v0.1.27...v0.1.28
 [0.1.27]: https://github.com/IvanPavlak/WinuX/compare/v0.1.26...v0.1.27
 [0.1.26]: https://github.com/IvanPavlak/WinuX/compare/v0.1.25...v0.1.26

--- a/Windows/PowerShell/Configuration.psd1
+++ b/Windows/PowerShell/Configuration.psd1
@@ -1688,6 +1688,13 @@
 	# in ValidMachineTypes or it is reported as an unknown token. A row without a Machine key
 	# (or a blank one) defaults to "All", so one list can drive every machine.
 	#
+	# A Path row may also carry an Aumid key for apps that register their own AppUserModelID
+	# at runtime (Eclipse/SWT apps like DBeaver, some Java/Electron apps) and therefore open
+	# as a second, separate taskbar icon instead of docking onto their pin. The row is then
+	# pinned through a shortcut stamped with that identity (Set-ShortcutAumid), so the pin
+	# and the running window group as one. See docs/configuration/configuration-reference.md
+	# (Taskbar Configuration) for how to discover an app's runtime AUMID.
+	#
 	# Ships empty - Configure-Taskbar leaves the taskbar pins exactly as they are
 	# (no clearing, no pinning) until you opt in. Keep your real, machine-tagged
 	# list in Configuration.local.psd1 - it replaces this array wholesale on merge.
@@ -1698,7 +1705,7 @@
 	#       @{ Name = "WindowsTerminal"; Type = "AUMID"; Value = "Microsoft.WindowsTerminal_8wekyb3d8bbwe!App"; Machine = "All" }
 	#       @{ Name = "Firefox";      Type = "AUMID"; Value = "308046B0AF4A39CB";                              Machine = "All" }
 	#       @{ Name = "VSCode";       Type = "AUMID"; Value = "Microsoft.VisualStudioCode";                    Machine = "All" }
-	#       @{ Name = "DBeaver";      Type = "Path";  Value = "{User}\AppData\Local\DBeaver\dbeaver.exe";      Machine = "All" }
+	#       @{ Name = "DBeaver";      Type = "Path";  Value = "{User}\AppData\Local\DBeaver\dbeaver.exe";      Aumid = "DBeaver"; Machine = "All" }
 	#       @{ Name = "FileExplorer"; Type = "AUMID"; Value = "Microsoft.Windows.Explorer";                    Machine = "All" }
 	#       @{ Name = "WorkTool";     Type = "AUMID"; Value = "Contoso.Tool";                                  Machine = "PC/Work" }
 	#   )

--- a/Windows/PowerShell/Modules/System/Functions/Configure-Taskbar.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Configure-Taskbar.ps1
@@ -16,6 +16,15 @@ function Configure-Taskbar {
 		the same gate the app CSVs use - so one list can drive every machine. A row without a
 		`Machine` key (or a blank one) defaults to "All" and pins on every machine.
 
+		A `Path` row may additionally carry an `Aumid` key for apps that register their own
+		AppUserModelID at runtime (Eclipse/SWT apps such as DBeaver, some Java and Electron
+		apps). Without it such an app never docks onto its pin: the pin is identified by the
+		exe path while the running window is identified by the runtime AUMID, so the app
+		opens as a second, separate taskbar icon. With `Aumid`, the row is pinned through a
+		shortcut stamped with that identity (via Set-ShortcutAumid) - a `.lnk` Value is
+		stamped in place, an `.exe` Value gets a machine-local shortcut generated under
+		`TaskbarPins\<Name>.lnk` next to the layout file.
+
 		With `-FromBootstrap`, skips a 5-second initialization delay (used when called
 		during the bootstrap sequence before all processes are fully settled).
 
@@ -81,6 +90,21 @@ function Configure-Taskbar {
 		Write-LogStep "Configuring taskbar for the default machine set (hostname [$hostname] is not mapped) => [$MachineType]"
 	}
 
+	$layoutFile = $MachineSpecificPaths.TaskbarLayoutFile
+	if (-not $layoutFile) {
+		Write-LogError "TaskbarLayoutFile not found in configuration!"
+		return
+	}
+
+	# The layout is produced entirely from configuration, so it is written straight to its
+	# machine-local path (created if missing) - no versioned copy in the repo, no symlink.
+	# Resolved before the pin loop because AUMID-stamped rows generate their shortcuts
+	# into a TaskbarPins folder alongside it.
+	$layoutDir = Split-Path -Parent $layoutFile
+	if ($layoutDir -and -not (Test-Path $layoutDir)) {
+		New-Item -Path $layoutDir -ItemType Directory -Force | Out-Null
+	}
+
 	$taskbarPinList = ""
 	foreach ($app in $taskbarConfig) {
 		# A row's Machine scope ("All", "Test", "PC/Laptop", ...) is validated and matched by
@@ -96,6 +120,35 @@ function Configure-Taskbar {
 		}
 		elseif ($app.Type -eq "Path") {
 			$appPath = $app.Value -replace '\{User\}', "C:\Users\$env:USERNAME"
+
+			# An app that registers its own AppUserModelID at runtime never groups with a pin
+			# that points at its exe - pin and window carry different identities, so the app
+			# opens as a second, separate icon. An `Aumid` key names the runtime identity and
+			# the row is pinned through a shortcut stamped with it, giving both sides one
+			# identity: a .lnk Value is stamped in place, an .exe Value gets a machine-local
+			# shortcut generated next to the layout file.
+			if ($app.Aumid) {
+				$pinShortcut = if ([System.IO.Path]::GetExtension($appPath) -eq ".lnk") {
+					$appPath
+				}
+				else {
+					Join-Path (Join-Path $layoutDir "TaskbarPins") "$($app.Name).lnk"
+				}
+
+				try {
+					if ($pinShortcut -eq $appPath) {
+						Set-ShortcutAumid -LinkPath $pinShortcut -Aumid $app.Aumid
+					}
+					else {
+						Set-ShortcutAumid -LinkPath $pinShortcut -TargetPath $appPath -Aumid $app.Aumid
+					}
+					$appPath = $pinShortcut
+				}
+				catch {
+					Write-LogWarning "Could not stamp AUMID [$($app.Aumid)] on the [$($app.Name)] pin shortcut => [$($_.Exception.Message)] - pinning the raw path instead!"
+				}
+			}
+
 			$taskbarPinList += "`n        <taskbar:DesktopApp DesktopApplicationLinkPath=`"$appPath`" />"
 		}
 	}
@@ -116,19 +169,6 @@ function Configure-Taskbar {
  </CustomTaskbarLayoutCollection>
 </LayoutModificationTemplate>
 "@
-
-	$layoutFile = $MachineSpecificPaths.TaskbarLayoutFile
-	if (-not $layoutFile) {
-		Write-LogError "TaskbarLayoutFile not found in configuration!"
-		return
-	}
-
-	# The layout is produced entirely from configuration, so it is written straight to its
-	# machine-local path (created if missing) - no versioned copy in the repo, no symlink.
-	$layoutDir = Split-Path -Parent $layoutFile
-	if ($layoutDir -and -not (Test-Path $layoutDir)) {
-		New-Item -Path $layoutDir -ItemType Directory -Force | Out-Null
-	}
 
 	# A machine provisioned by the old design has a symlink here pointing into the repo; writing
 	# through it would modify the versioned file. Remove any such link (live or dangling) first so

--- a/Windows/PowerShell/Modules/System/Functions/Set-ShortcutAumid.ps1
+++ b/Windows/PowerShell/Modules/System/Functions/Set-ShortcutAumid.ps1
@@ -1,0 +1,142 @@
+function Set-ShortcutAumid {
+	<#
+	.SYNOPSIS
+		Creates or updates a .lnk shortcut and stamps an explicit AppUserModelID on it.
+
+	.DESCRIPTION
+		The taskbar groups a pinned icon with a running window only when the two share an
+		application identity (AppUserModelID). An app that registers its own identity at
+		startup via SetCurrentProcessExplicitAppUserModelID - Eclipse/SWT apps such as
+		DBeaver, and some Java and Electron apps - advertises an AUMID that can never match
+		a pin created from its exe path, so launching it opens a second, separate taskbar
+		icon next to its own pin. Stamping the pin's shortcut with the app's runtime AUMID
+		(the System.AppUserModel.ID property, the same one the manual "Pin to taskbar" flow
+		records) gives both sides one identity, and the running window docks onto the pin.
+
+		With -TargetPath, the shortcut is created first when missing (parent folder
+		included) and its target and working directory are set; without it, LinkPath must
+		already exist. The property is written through the shell's IPropertyStore on the
+		shortcut file and persisted into the .lnk itself, so it travels with any copy
+		Explorer makes when applying a taskbar layout. Throws on any COM failure - callers
+		decide whether that is fatal.
+
+	.PARAMETER LinkPath
+		Full path of the .lnk file to stamp (and create, when -TargetPath is given).
+
+	.PARAMETER TargetPath
+		Executable the shortcut should launch. When given, the shortcut is created if
+		missing and its target and working directory are (re)set before stamping. When
+		omitted, LinkPath must already exist.
+
+	.PARAMETER Aumid
+		The explicit AppUserModelID to stamp - the identity the running app registers.
+		Discover it via Get-StartApps, or from the app's jump-list file name (see
+		docs/configuration/configuration-reference.md, Taskbar Configuration).
+
+	.EXAMPLE
+		Set-ShortcutAumid -LinkPath "C:\ProgramData\provisioning\TaskbarPins\DBeaver.lnk" -TargetPath "$env:LOCALAPPDATA\DBeaver\dbeaver.exe" -Aumid "DBeaver"
+		Creates the shortcut and stamps DBeaver's runtime identity on it.
+	#>
+	[CmdletBinding()]
+	param(
+		[Parameter(Mandatory = $true)]
+		[string]$LinkPath,
+
+		[Parameter(Mandatory = $false)]
+		[string]$TargetPath,
+
+		[Parameter(Mandatory = $true)]
+		[string]$Aumid
+	)
+
+	if (-not ([System.Management.Automation.PSTypeName]'ShortcutAumidHelper').Type) {
+		Add-Type @"
+			using System;
+			using System.Runtime.InteropServices;
+
+			[StructLayout(LayoutKind.Sequential, Pack = 4)]
+			public struct ShortcutPropertyKey {
+				public Guid fmtid;
+				public uint pid;
+				public ShortcutPropertyKey(Guid f, uint p) { fmtid = f; pid = p; }
+			}
+
+			// Header layout of PROPVARIANT: 8 bytes (vt + reserved) before the data union,
+			// identical on x86 and x64, so the fixed offset is safe for both.
+			[StructLayout(LayoutKind.Explicit)]
+			public struct ShortcutPropVariant {
+				[FieldOffset(0)] public ushort vt;
+				[FieldOffset(8)] public IntPtr pointerValue;
+			}
+
+			[ComImport, Guid("886d8eeb-8cf2-4446-8d02-cdba1dbdcf99"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+			public interface IShortcutPropertyStore {
+				int GetCount(out uint count);
+				int GetAt(uint index, out ShortcutPropertyKey key);
+				int GetValue(ref ShortcutPropertyKey key, out ShortcutPropVariant value);
+				int SetValue(ref ShortcutPropertyKey key, ref ShortcutPropVariant value);
+				int Commit();
+			}
+
+			[ComImport, Guid("0000010b-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+			public interface IShortcutPersistFile {
+				int GetClassID(out Guid classId);
+				int IsDirty();
+				int Load([MarshalAs(UnmanagedType.LPWStr)] string fileName, uint mode);
+				int Save([MarshalAs(UnmanagedType.LPWStr)] string fileName, bool remember);
+				int SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string fileName);
+				int GetCurFile(out IntPtr fileName);
+			}
+
+			[ComImport, Guid("00021401-0000-0000-C000-000000000046")]
+			public class ShortcutShellLink { }
+
+			public static class ShortcutAumidHelper {
+				static readonly ShortcutPropertyKey PKEY_AppUserModel_ID =
+					new ShortcutPropertyKey(new Guid("9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3"), 5);
+				const ushort VT_LPWSTR = 31;
+				const uint STGM_READWRITE = 0x00000002;
+
+				public static void Set(string linkPath, string aumid) {
+					var link = new ShortcutShellLink();
+					try {
+						var persistFile = (IShortcutPersistFile)link;
+						Check(persistFile.Load(linkPath, STGM_READWRITE));
+						var store = (IShortcutPropertyStore)link;
+						var key = PKEY_AppUserModel_ID;
+						var value = new ShortcutPropVariant { vt = VT_LPWSTR, pointerValue = Marshal.StringToCoTaskMemUni(aumid) };
+						try {
+							Check(store.SetValue(ref key, ref value));
+							Check(store.Commit());
+						}
+						finally { Marshal.FreeCoTaskMem(value.pointerValue); }
+						Check(persistFile.Save(linkPath, true));
+					}
+					finally { Marshal.ReleaseComObject(link); }
+				}
+
+				static void Check(int hr) {
+					if (hr != 0) Marshal.ThrowExceptionForHR(hr);
+				}
+			}
+"@
+	}
+
+	if ($TargetPath) {
+		$linkDir = Split-Path -Parent $LinkPath
+		if ($linkDir -and -not (Test-Path $linkDir)) {
+			New-Item -Path $linkDir -ItemType Directory -Force | Out-Null
+		}
+
+		$shell = New-Object -ComObject WScript.Shell
+		$shortcut = $shell.CreateShortcut($LinkPath)
+		$shortcut.TargetPath = $TargetPath
+		$shortcut.WorkingDirectory = Split-Path -Parent $TargetPath
+		$shortcut.Save()
+	}
+	elseif (-not (Test-Path $LinkPath)) {
+		throw "Shortcut [$LinkPath] does not exist and no -TargetPath was given to create it!"
+	}
+
+	[ShortcutAumidHelper]::Set($LinkPath, $Aumid)
+}

--- a/Windows/PowerShell/Modules/System/System.psd1
+++ b/Windows/PowerShell/Modules/System/System.psd1
@@ -48,6 +48,7 @@
 		'Set-LockScreenWallpaper',
 		'Set-PowerButtonActions',
 		'Set-PowerPlan',
+		'Set-ShortcutAumid',
 		'Set-SpecialFolders',
 		'Set-SystemTheme',
 		'Set-TaskbarSettings',

--- a/Windows/PowerShell/Modules/Tests/Modules/System/Configure-Taskbar.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/System/Configure-Taskbar.Tests.ps1
@@ -11,6 +11,8 @@ BeforeAll {
 	. "$ModuleRoot\Helper\Functions\Confirm-ConfigValue.ps1"
 
 	. "$FunctionsPath\Configure-Taskbar.ps1"
+	# Dot-source the AUMID stamper so the Aumid-row tests can mock it instead of hitting COM.
+	. "$FunctionsPath\Set-ShortcutAumid.ps1"
 	# Dot-source the machine-scope gate and machine-type resolver so both are mockable here,
 	# regardless of whether the imported Bootstrap module in this session already exports them.
 	. (Join-Path $ModuleRoot "Bootstrap\Functions\Test-MachineTypeScope.ps1")
@@ -123,6 +125,73 @@ Describe "Configure-Taskbar" {
 			Configure-Taskbar -FromBootstrap
 
 			Should -Invoke Remove-Item -Times 1 -Exactly -ParameterFilter { "$LiteralPath" -like "*taskbar_layout.xml" }
+		}
+	}
+
+	Context "AUMID-stamped Path rows" {
+		BeforeEach {
+			$global:MachineSpecificPaths = [PSCustomObject]@{ TaskbarLayoutFile = (Join-Path "$TestDrive" "taskbar_layout.xml") }
+			Mock New-Item { }
+			Mock Set-ItemProperty { }
+			Mock Test-MachineTypeScope { $true }
+			Mock Set-ShortcutAumid { }
+		}
+
+		It "pins an exe row with an Aumid through a generated, stamped TaskbarPins shortcut" {
+			$script:Configuration.TaskbarConfiguration = @(
+				@{ Name = "DBeaver"; Type = "Path"; Value = "{User}\AppData\Local\DBeaver\dbeaver.exe"; Aumid = "DBeaver" }
+			)
+
+			Configure-Taskbar -FromBootstrap
+
+			$expectedShortcut = Join-Path (Join-Path "$TestDrive" "TaskbarPins") "DBeaver.lnk"
+			# The shortcut is generated from the resolved exe path and stamped with the identity.
+			Should -Invoke Set-ShortcutAumid -Times 1 -Exactly -ParameterFilter {
+				$LinkPath -eq $expectedShortcut -and $TargetPath -like "*\AppData\Local\DBeaver\dbeaver.exe" -and $Aumid -eq "DBeaver"
+			}
+			# The layout pins the stamped shortcut, not the raw exe.
+			$layout = Get-Content -Path (Join-Path "$TestDrive" "taskbar_layout.xml") -Raw
+			$layout | Should -Match ([regex]::Escape("DesktopApplicationLinkPath=`"$expectedShortcut`""))
+			$layout | Should -Not -Match ([regex]::Escape("dbeaver.exe"))
+		}
+
+		It "stamps a .lnk row with an Aumid in place instead of generating a shortcut" {
+			$script:Configuration.TaskbarConfiguration = @(
+				@{ Name = "SomeApp"; Type = "Path"; Value = "C:\Apps\SomeApp.lnk"; Aumid = "Some.App" }
+			)
+
+			Configure-Taskbar -FromBootstrap
+
+			Should -Invoke Set-ShortcutAumid -Times 1 -Exactly -ParameterFilter {
+				$LinkPath -eq "C:\Apps\SomeApp.lnk" -and -not $TargetPath -and $Aumid -eq "Some.App"
+			}
+			$layout = Get-Content -Path (Join-Path "$TestDrive" "taskbar_layout.xml") -Raw
+			$layout | Should -Match ([regex]::Escape("DesktopApplicationLinkPath=`"C:\Apps\SomeApp.lnk`""))
+		}
+
+		It "falls back to pinning the raw path with a warning when stamping fails" {
+			$script:Configuration.TaskbarConfiguration = @(
+				@{ Name = "DBeaver"; Type = "Path"; Value = "{User}\AppData\Local\DBeaver\dbeaver.exe"; Aumid = "DBeaver" }
+			)
+			Mock Set-ShortcutAumid { throw "COM says no" }
+
+			Configure-Taskbar -FromBootstrap
+
+			Should -Invoke Write-LogWarning -Times 1 -ParameterFilter { $Message -match "Could not stamp AUMID \[DBeaver\]" }
+			$layout = Get-Content -Path (Join-Path "$TestDrive" "taskbar_layout.xml") -Raw
+			$layout | Should -Match ([regex]::Escape("\AppData\Local\DBeaver\dbeaver.exe"))
+		}
+
+		It "leaves a plain Path row without an Aumid untouched" {
+			$script:Configuration.TaskbarConfiguration = @(
+				@{ Name = "PlainApp"; Type = "Path"; Value = "C:\Apps\plain.exe" }
+			)
+
+			Configure-Taskbar -FromBootstrap
+
+			Should -Invoke Set-ShortcutAumid -Times 0
+			$layout = Get-Content -Path (Join-Path "$TestDrive" "taskbar_layout.xml") -Raw
+			$layout | Should -Match ([regex]::Escape("DesktopApplicationLinkPath=`"C:\Apps\plain.exe`""))
 		}
 	}
 }

--- a/Windows/PowerShell/Modules/Tests/Modules/System/Set-ShortcutAumid.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/System/Set-ShortcutAumid.Tests.ps1
@@ -1,0 +1,44 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	. (Join-Path $ModuleRoot "System\Functions\Set-ShortcutAumid.ps1")
+}
+
+Describe "Set-ShortcutAumid" {
+	# These tests exercise the real shell COM plumbing on purpose - the property-store
+	# round trip IS the function - but all shortcuts live and die inside TestDrive.
+	It "creates the shortcut (parent folder included) and stamps the AUMID when TargetPath is given" {
+		$linkPath = Join-Path "$TestDrive" "Pins\Stamped.lnk"
+		$target = "$env:SystemRoot\System32\notepad.exe"
+
+		Set-ShortcutAumid -LinkPath $linkPath -TargetPath $target -Aumid "WinuX.Test.App"
+
+		Test-Path $linkPath | Should -BeTrue
+		$shell = New-Object -ComObject WScript.Shell
+		$shell.CreateShortcut($linkPath).TargetPath | Should -Be $target
+		# Read the stamped identity back through the shell's property system.
+		$item = (New-Object -ComObject Shell.Application).Namespace((Split-Path $linkPath)).ParseName((Split-Path $linkPath -Leaf))
+		$item.ExtendedProperty("System.AppUserModel.ID") | Should -Be "WinuX.Test.App"
+	}
+
+	It "stamps an existing shortcut in place without TargetPath, keeping its target" {
+		$linkPath = Join-Path "$TestDrive" "Existing.lnk"
+		$target = "$env:SystemRoot\System32\notepad.exe"
+		$shell = New-Object -ComObject WScript.Shell
+		$shortcut = $shell.CreateShortcut($linkPath)
+		$shortcut.TargetPath = $target
+		$shortcut.Save()
+
+		Set-ShortcutAumid -LinkPath $linkPath -Aumid "WinuX.Test.Existing"
+
+		$item = (New-Object -ComObject Shell.Application).Namespace((Split-Path $linkPath)).ParseName((Split-Path $linkPath -Leaf))
+		$item.ExtendedProperty("System.AppUserModel.ID") | Should -Be "WinuX.Test.Existing"
+		# The target survives the property-store round trip.
+		$shell.CreateShortcut($linkPath).TargetPath | Should -Be $target
+	}
+
+	It "throws when the shortcut is missing and no TargetPath was given" {
+		{ Set-ShortcutAumid -LinkPath (Join-Path "$TestDrive" "Missing.lnk") -Aumid "X" } | Should -Throw "*does not exist*"
+	}
+}

--- a/docs/configuration/configuration-reference.md
+++ b/docs/configuration/configuration-reference.md
@@ -646,6 +646,39 @@ Keep your real, machine-tagged list in `Configuration.local.psd1` (it replaces t
 wholesale on merge). The base ships the section empty; `Configure-Taskbar` warns and leaves the
 existing pins as-is until it is set (an empty list never clears your pins).
 
+A `Path` row may additionally carry an `Aumid` key for apps that register their own
+AppUserModelID at runtime via `SetCurrentProcessExplicitAppUserModelID` - Eclipse/SWT apps such
+as DBeaver, and some Java and Electron apps. The taskbar groups a pin with a running window only
+when both carry the same identity: without `Aumid`, such an app's pin is identified by the exe
+path while its window is identified by the runtime AUMID, so launching it opens a second,
+separate taskbar icon next to the pin. With `Aumid`, `Configure-Taskbar` pins the row through a
+shortcut stamped with that identity (via `Set-ShortcutAumid`), and the running window docks onto
+the pin:
+
+```powershell
+@{ Name = "DBeaver"; Type = "Path"; Value = "{User}\AppData\Local\DBeaver\dbeaver.exe"; Aumid = "DBeaver"; Machine = "All" }
+```
+
+**Discovering a runtime AUMID.** `Get-StartApps` only shows the identity a shortcut declares -
+for exactly the apps that need this key, that differs from the identity the running process
+registers. To read the runtime identity, launch the app, use it once (open a file/connection so
+Windows records a jump list), then match its jump-list file name against a candidate identity -
+the file name is a CRC64 hash of the uppercased AUMID:
+
+```powershell
+# Hash a candidate AUMID (e.g. "DBeaver") and look for a matching jump-list file:
+#   $env:APPDATA\Microsoft\Windows\Recent\AutomaticDestinations\<hash>.automaticDestinations-ms
+# For SWT/Eclipse apps the AUMID is usually the plain product name ("DBeaver").
+```
+
+Alternatively, right-click the running app's taskbar icon → Pin to taskbar, then read the
+identity the shell recorded on the created pin:
+
+```powershell
+$pin = "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\<App>.lnk"
+(New-Object -ComObject Shell.Application).Namespace((Split-Path $pin)).ParseName((Split-Path $pin -Leaf)).ExtendedProperty("System.AppUserModel.ID")
+```
+
 **Consumer functions:** `Configure-Taskbar`, `Clear-TaskbarPins`, `Unpin-TaskbarApps`
 
 ### Kill-All Step Toggles

--- a/docs/modules/system.md
+++ b/docs/modules/system.md
@@ -129,7 +129,7 @@ Configure-PostgreSqlPasswords -DefaultOrCurrentPassword foo -NewPassword bar
 - **Parameters:** -FromBootstrap
 - **Usage:** `Configure-Taskbar`, `Configure-Taskbar -FromBootstrap`
 
-Resolves the current machine type (via `DetermineMachineType`) and states in the output which machine the pins are being configured for (or that the hostname is unmapped and the default set is used). Reads the pin list from `TaskbarConfiguration` (each entry is either an `AUMID` or a `Path`, with `{User}` tokens expanded to the current profile), keeping only rows whose `Machine` scope matches the machine type - the same `Test-MachineTypeScope` gate the app CSVs use; a row without `Machine` defaults to `All`. It writes the generated layout directly to the machine-local `TaskbarLayoutFile` (`C:\ProgramData\provisioning\taskbar_layout.xml`) - not versioned in the repo and needing no symlink - sets the `StartLayoutFile` and `LockedStartLayout` registry policies under `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer`, restarts Explorer (`Restart-Explorer`), and rebuilds the icon cache (`Rebuild-IconCache`). With `-FromBootstrap`, it skips the 5-second Explorer-initialization wait and leaves the layout unlocked so the Bootstrap script can lock it after its own Explorer restart.
+Resolves the current machine type (via `DetermineMachineType`) and states in the output which machine the pins are being configured for (or that the hostname is unmapped and the default set is used). Reads the pin list from `TaskbarConfiguration` (each entry is either an `AUMID` or a `Path`, with `{User}` tokens expanded to the current profile), keeping only rows whose `Machine` scope matches the machine type - the same `Test-MachineTypeScope` gate the app CSVs use; a row without `Machine` defaults to `All`. A `Path` row may carry an `Aumid` key for apps that register their own AppUserModelID at runtime and would otherwise open as a second, separate icon next to their pin (Eclipse/SWT apps such as DBeaver): the row is then pinned through a shortcut stamped with that identity via `Set-ShortcutAumid` - a `.lnk` Value is stamped in place, an `.exe` Value gets a machine-local shortcut generated under `TaskbarPins\<Name>.lnk` next to the layout file (falling back to the raw path with a warning if stamping fails). It writes the generated layout directly to the machine-local `TaskbarLayoutFile` (`C:\ProgramData\provisioning\taskbar_layout.xml`) - not versioned in the repo and needing no symlink - sets the `StartLayoutFile` and `LockedStartLayout` registry policies under `HKLM:\SOFTWARE\Policies\Microsoft\Windows\Explorer`, restarts Explorer (`Restart-Explorer`), and rebuilds the icon cache (`Rebuild-IconCache`). With `-FromBootstrap`, it skips the 5-second Explorer-initialization wait and leaves the layout unlocked so the Bootstrap script can lock it after its own Explorer restart.
 
 | Parameter        | Description                                                                                                                                                |
 | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -143,7 +143,7 @@ Configure-Taskbar
 Configure-Taskbar -FromBootstrap
 ```
 
-**See also:** [Clear-TaskbarPins](system.md#clear-taskbarpins), [Get-PinnedApps](system.md#get-pinnedapps)
+**See also:** [Clear-TaskbarPins](system.md#clear-taskbarpins), [Get-PinnedApps](system.md#get-pinnedapps), [Set-ShortcutAumid](system.md#set-shortcutaumid)
 
 ## [Configure-WSL](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Configure-WSL.ps1)
 
@@ -861,6 +861,32 @@ PowerPlans = @{
     "Test"   = "Balanced"
 }
 ```
+
+## [Set-ShortcutAumid](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Set-ShortcutAumid.ps1)
+
+- **Description:** Creates or updates a `.lnk` shortcut and stamps an explicit AppUserModelID (the `System.AppUserModel.ID` shell property) on it. The taskbar groups a pinned icon with a running window only when the two share an application identity: an app that registers its own AUMID at runtime via `SetCurrentProcessExplicitAppUserModelID` (Eclipse/SWT apps such as DBeaver, some Java and Electron apps) never docks onto a pin created from its exe path, and instead opens as a second, separate taskbar icon. Stamping the pin's shortcut with the app's runtime AUMID gives both sides one identity - the same property the manual "Pin to taskbar" flow records. Throws on any COM failure.
+- **Parameters:** -LinkPath, -TargetPath, -Aumid
+- **Usage:** `Set-ShortcutAumid -LinkPath <path.lnk> -TargetPath <path.exe> -Aumid <id>`, `Set-ShortcutAumid -LinkPath <existing.lnk> -Aumid <id>`
+
+With `-TargetPath`, the shortcut is created first when missing (parent folder included) and its target and working directory are set; without it, `-LinkPath` must already exist. The property is written through the shell's `IPropertyStore` on the shortcut file and persisted into the `.lnk` itself, so it travels with any copy Explorer makes when applying a taskbar layout. Consumed by `Configure-Taskbar` for `TaskbarConfiguration` rows carrying an `Aumid` key.
+
+| Parameter     | Description                                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `-LinkPath`   | Full path of the `.lnk` file to stamp (and create, when `-TargetPath` is given).                                          |
+| `-TargetPath` | Executable the shortcut should launch. When given, the shortcut is created if missing; when omitted, `-LinkPath` must exist. |
+| `-Aumid`      | The explicit AppUserModelID to stamp - the identity the running app registers.                                            |
+
+```powershell
+# Generate a shortcut for DBeaver and stamp its runtime identity on it
+Set-ShortcutAumid -LinkPath "C:\ProgramData\provisioning\TaskbarPins\DBeaver.lnk" -TargetPath "$env:LOCALAPPDATA\DBeaver\dbeaver.exe" -Aumid "DBeaver"
+
+# Stamp an existing Start Menu shortcut in place
+Set-ShortcutAumid -LinkPath "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\DBeaver Community\DBeaver.lnk" -Aumid "DBeaver"
+```
+
+To discover an app's runtime AUMID, check `Get-StartApps` first; when the app is not listed there (typical for the apps that need this), see the jump-list hash technique in [Taskbar Configuration](../configuration/configuration-reference.md#taskbar-configuration).
+
+**See also:** [Configure-Taskbar](system.md#configure-taskbar)
 
 ## [Set-SpecialFolders](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/System/Functions/Set-SpecialFolders.ps1)
 


### PR DESCRIPTION
## Description

The Windows taskbar groups a pinned icon with a running window only when both carry the same AppUserModelID (AUMID). An app that registers its own identity at startup via `SetCurrentProcessExplicitAppUserModelID` - Eclipse/SWT apps such as DBeaver, and some Java and Electron apps - advertises an AUMID that can never match a pin created from its exe path. So a `TaskbarConfiguration` row of `Type = "Path"` pins the app, but launching it opens a *second*, separate taskbar icon next to that pin. On my machine the pin identified itself as "DBeaver Community" while the running window identified itself as "DBeaver 26.1.4". Right-clicking the stray icon and choosing "Pin to taskbar" fixed it by hand, because the shell stamps the running window's AUMID onto the pin it creates - which is precisely what this PR automates.

I confirmed the runtime identity rather than guessing it: jump-list files are named after a CRC64 hash of the uppercased AUMID, and DBeaver's jump list on this machine hashes to `DBEAVER` (the algorithm calibrated against Explorer's well-known `f01b4d95cf55d32a`).

**`Set-ShortcutAumid`** (new, System module) creates or updates a `.lnk` and stamps `System.AppUserModel.ID` on it through the shell's `IPropertyStore`. The property is persisted into the `.lnk` itself, so it survives the copy Explorer makes when applying a taskbar layout.

**`TaskbarConfiguration`** `Path` rows now accept an optional `Aumid` key naming that runtime identity. `Configure-Taskbar` pins such a row through a stamped shortcut instead of the raw exe: a `.lnk` Value is stamped in place, an `.exe` Value gets a machine-local shortcut generated under `TaskbarPins\<Name>.lnk` beside the layout file. Both sides then share one identity and the window docks onto its pin.

Backward compatible by construction: a row without `Aumid` takes exactly the old code path, and a stamping failure warns and falls back to the raw-path pin rather than dropping the pin entirely. The configuration reference documents two ways to discover an app's runtime AUMID, since `Get-StartApps` reports the identity a *shortcut declares* - which for exactly these apps is not the one the process registers.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [ ] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

## Quality bar

- [x] The change is **minimal and focused** (one logical change; reuses existing helpers, no duplication / DRY).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` using placeholder paths (`{Dev}`, `{User}`, `{MachineType}`, `{RepoRoot}`, `{AppData}`).

## Tests

```powershell
Run-Tests -TestName "Set-ShortcutAumid"
Run-Tests -TestName "Configure-Taskbar"
```

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/`.
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text.
- [ ] N/A - no testable behavior changed (docs/chore only).

New `Set-ShortcutAumid.Tests.ps1` covers the real property-store round trip (create-and-stamp, stamp-in-place preserving the target, and the throw when the shortcut is missing with no `-TargetPath`), all confined to `TestDrive`. `Configure-Taskbar.Tests.ps1` gains four cases: an `.exe` row stamped through a generated `TaskbarPins` shortcut and pinned as that shortcut rather than the raw exe, a `.lnk` row stamped in place, the warn-and-fall-back path when stamping throws, and a plain `Path` row with no `Aumid` left completely untouched.

## Documentation & manifests

- [x] I updated `docs/modules/<Module>.md` for any added/renamed/removed/changed function.
- [x] I updated the module `.psd1` `FunctionsToExport`.
- [x] I updated `docs/docs_overview.md` (and `docs/_sidebar.md` if a page was added/removed).
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds.
- [ ] N/A - no exported function changed.

`docs/modules/system.md` gains the `Set-ShortcutAumid` entry in alphabetical order and the `Configure-Taskbar` entry now describes the `Aumid` branch. `docs/configuration/configuration-reference.md` documents the key plus how to discover a runtime AUMID. `docs/docs_overview.md` and `docs/_sidebar.md` needed no edit: no page was added or removed, its `TaskbarConfiguration` → `Configure-Taskbar` consumer row is still accurate (`Set-ShortcutAumid` reads no configuration), and function lists are deliberately not duplicated there.

## Tested on

- Windows version: Windows 11 Pro 25H2 (10.0.26200)
- PowerShell version: 7.6.4
- Machine type(s): PC via a private fork

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] This PR contains no secrets or personal data (tokens, real paths/hostnames/emails).
