### PR TITLE
Add Start-Containers, Docker-Cleanup and opt-in Run-Project Docker step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.1.37] - 2026-08-18
+
+### Added
+
+- **`Start-Containers` (Workflow module): start the configured Docker Compose stacks without running any project.** `DockerWizard` with no arguments starts Docker Desktop and stops there, and the knowledge of which compose file the databases need lived only inside `Run-Project`, inlined between the project menu and the terminal-tab logic - there was no way to bring up the database containers (e.g. for DBeaver) without also opening tabs and starting servers. The unit of control is deliberately the compose file, not a project: the stacks are shared by design (every PostgreSQL project talks to the same centralized containers), so a project menu would offer choices that all mean the same stack. `Start-Containers` reads `Configuration.DockerComposeFiles` (name => compose file, resolved relative to `MachineSpecificPaths.DockerDirectory` or used as-is when absolute, so arbitrary non-database stacks can be registered too); with a single configured entry it is a pure on/off switch that asks nothing, with several it shows a multi-select menu. After a start it prints the compose file's published host ports so the connection target is obvious. `-Stop` runs `docker compose stop` (containers kept, fast resume); adding `-Down` runs `docker compose down` instead (containers and network removed, volumes kept). Docker Desktop itself stays up either way - that remains `DockerWizard -Stop`'s job. Also works as a workspace/project action: `@{ Action = "Start-Containers" }`.
+
+- **`Resolve-ProjectDockerCompose` (Workflow module): the Docker Compose resolution extracted from `Run-Project`.** Takes `-ProjectName` and an optional `-DatabaseProvider` (which skips the provider menu), and returns either `$null` (project needs no Docker) or the resolved provider plus exactly one of `ComposeFilePath` (centralized compose file under `MachineSpecificPaths.DockerDirectory`) / `ComposeProjectPath` (project root with its own `docker-compose.yml`) - the same shapes `DockerWizard` accepts. `Run-Project` stays thin, and the compose knowledge is no longer buried between its menu and its tab logic.
+
+- **`RunProject.Steps.Docker` + `Run-Project -Skip`/`-Include` (via the new `Resolve-RunProjectSteps`, Helper module): Docker as an opt-in step, following the `KillAll.Steps` pattern.** `Run-Project` was tied to Docker too closely: the generic configuration ships a PostgreSQL-to-compose-file mapping, so merely declaring `DatabaseProviders = @("PostgreSQL")` on a project mapping forced Docker onto setups that run PostgreSQL locally and use no Docker at all. The Docker step now resolves through `Resolve-RunProjectSteps` - a thin wrapper over the shared `Resolve-Steps`, exactly like `Resolve-KillAllSteps` - so `RunProject = @{ Steps = @{ Docker = $false } }` (a plain boolean or a per-machine-type hashtable with a `Default` fallback) turns it off once in `Configuration.local.psd1`, and `Run-Project -Skip Docker` / `-Include Docker` override per invocation. Disabled means genuinely untouched: not even the database provider prompt appears. The default is on, which is inert unless a project mapping declares `DatabaseProviders` or `UsesDocker`, so existing setups are unchanged.
+
+- **`Docker-Cleanup` (Workflow module): menu-driven Docker maintenance behind confirmation safeguards.** The actions come from the new `DockerCleanupActions` configuration - each entry a `Name` (menu label), a `Command` (the PowerShell command line to run) and an optional `ConfirmationMessage`. The shipped defaults cover the three classic teardown moves: stop all containers, `docker system prune -a --volumes -f`, and delete all volumes. An action carrying a `ConfirmationMessage` only runs after an explicit "Yes" on a red confirmation prompt, and pressing Enter defaults to "No", so a slip of muscle memory cannot delete every volume on the machine. Forks replace the list wholesale in `Configuration.local.psd1` to add their own actions.
+
+- **`Resolve-Selection -ConfirmationMessage`: a reusable destructive-action safeguard.** The message is rendered as the prompt in red, and when the OptionList contains "No" (the default Yes/No list does) Enter selects it, so the destructive path always takes an explicit "Yes". An explicitly passed `-PromptMessage` or `-DefaultOptionIndex` still wins, and `-InputObject` bypasses the prompt entirely - never pass it on a confirmation call. `Docker-Cleanup` is the first consumer; any menu offering something irreversible can reuse it.
+
+- **`DockerTimeouts` (Configuration.psd1): configurable `DockerWizard` polling budgets.** `StartSeconds`/`StopSeconds`/`CleanupSeconds` replace the hardcoded 180/60/30 second loops (which remain the defaults when the configuration is absent), so machines where Docker Desktop boots slowly can raise them instead of editing the function.
+
+### Changed
+
+- **`DockerWizard` runs `docker compose up -d` unconditionally when a compose source is given.** It used to skip compose startup while *any* container of the stack was running, so a half-stopped stack never healed. `up -d` is idempotent - running it always reconciles the stack to the compose file. A compose path that does not exist (typoed `-ComposeFilePath`, project directory without a compose file) is now reported instead of being silently swallowed by the path guard, and counts as a **failure** rather than a no-op: compose work was requested and did not happen, so `-PassThru` reports `Success = $false` and callers stop instead of announcing containers that never started. A failing `up -d` is reported the same way.
+
+### Fixed
+
+- **`Run-Project` never actually skipped a project when Docker failed to start.** `DockerWizard` set `$script:DockerStartFailed` in the **Workflow** module's script scope while `Run-Project` read the **Helper** module's - both `.psm1` files dot-source their functions into their own module scope, so these were two different variables and the guard could never trip: when the daemon did not come up, the terminal tabs opened anyway against a database that was not there. `DockerWizard` now reports its outcome through `-PassThru` (`[PSCustomObject]@{ Success; ComposeFilePath }`), `Run-Project` branches on the return value, and the module-scoped flag is gone.
+
 ## [0.1.36] - 2026-08-17
 
 ### Added
@@ -684,7 +708,8 @@ The first public release of WinuX.
 - Governance and licensing: MIT license, contributor guide, code of conduct, security policy, and third-party notices.
 - CI: the full Pester suite on every pull request, and a release workflow that builds `WinuX.exe` from every version tag and attaches it - with a SHA-256 checksum - to the GitHub release.
 
-[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.36...HEAD
+[Unreleased]: https://github.com/IvanPavlak/WinuX/compare/v0.1.37...HEAD
+[0.1.37]: https://github.com/IvanPavlak/WinuX/compare/v0.1.36...v0.1.37
 [0.1.36]: https://github.com/IvanPavlak/WinuX/compare/v0.1.35...v0.1.36
 [0.1.35]: https://github.com/IvanPavlak/WinuX/compare/v0.1.34...v0.1.35
 [0.1.34]: https://github.com/IvanPavlak/WinuX/compare/v0.1.33...v0.1.34

--- a/Windows/PowerShell/Configuration.psd1
+++ b/Windows/PowerShell/Configuration.psd1
@@ -89,6 +89,10 @@
 # → Projects, ProjectActions      : Open-Project
 # → ProjectTerminals              : Open-ProjectTerminals, Run-Project, Resolve-ProjectPath
 # → RunnableProjects              : Run-Project
+# → RunProject.Steps              : Run-Project (optional steps, e.g. Docker)
+# → DockerComposeFiles            : Start-Containers, Resolve-ProjectDockerCompose (Run-Project)
+# → DockerTimeouts                : DockerWizard
+# → DockerCleanupActions          : Docker-Cleanup
 # → VisualStudioSolutions         : Open-VisualStudio
 # → VSCodeProjects                : Open-VSCode
 #
@@ -1500,6 +1504,8 @@
 			#@{ Action = "Open-VisualStudio"; Parameters = @{ Solution = "{ProjectName}" } }
 			@{ Action = "Open-VSCode"; Parameters = @{ Folder = "{ProjectName}" } }
 			@{ Action = "Open-ProjectTerminals-Or-RunProject"; Parameters = @{ Project = "{ProjectName}" } }
+			# Bring up only the configured Docker Compose stack (no API/UI) instead:
+			#@{ Action = "Start-Containers" }
 		)
 
 		Server         = @(
@@ -1532,12 +1538,60 @@
 	# ==========================================================================
 	DefaultDatabaseProvider       = "PostgreSQL"
 
-	# Docker Compose file mappings for database providers managed by WinuX.
-	# These are NOT committed to individual project repos - they live in WinuX/Docker/
-	# and are used by Run-Project to spin up containers transparently.
+	# Optional Run-Project steps, resolved like KillAll.Steps: each entry is a plain
+	# boolean or a per-machine-type hashtable with a Default fallback, and
+	# Run-Project -Skip / -Include override config per invocation.
+	# → Docker : resolve the project's Docker Compose source and start containers
+	#            before the project runs. On by default (inert unless a project
+	#            mapping declares DatabaseProviders or UsesDocker); set $false if
+	#            your databases run locally and Docker is not part of your setup.
+	RunProject                    = @{
+		Steps = @{
+			Docker = $true
+		}
+	}
+
+	# Docker Compose stacks by name. Used two ways:
+	# - Start-Containers: the menu source. One entry = on/off switch (no menu);
+	#   several = multi-select menu. Any stack qualifies, not just databases.
+	# - Run-Project: database providers map onto these stacks via the provider name
+	#   (Resolve-ProjectDockerCompose), so containers start before a project runs.
+	# Values resolve relative to MachineSpecificPaths.DockerDirectory; absolute
+	# paths are used as-is. These compose files are NOT committed to individual
+	# project repos - they live in WinuX/Docker/.
 	DockerComposeFiles            = @{
 		PostgreSQL = "docker-compose.postgresql.yml"
 	}
+
+	# Timeouts (in seconds) for DockerWizard's polling loops. Raise StartSeconds on
+	# machines where Docker Desktop takes longer to boot. Omitted keys fall back to
+	# these same built-in defaults.
+	DockerTimeouts                = @{
+		StartSeconds   = 180 # wait for the daemon to become ready after a start
+		StopSeconds    = 60  # wait for a graceful shutdown before force-cleanup escalates
+		CleanupSeconds = 30  # wait for a partial-state cleanup before starting anyway
+	}
+
+	# Docker maintenance actions offered by Docker-Cleanup. Each entry:
+	# - Name                : menu label (also accepted directly: Docker-Cleanup "<Name>")
+	# - Command             : PowerShell command line to run
+	# - ConfirmationMessage : optional - when present, the action only runs after an
+	#                         explicit "Yes" on a red confirmation prompt (Enter cancels)
+	# Override this list wholesale in Configuration.local.psd1 to add your own actions.
+	DockerCleanupActions          = @(
+		@{ Name                = "Stop all containers";
+			Command             = 'docker ps -q | ForEach-Object { docker stop $_ }';
+			ConfirmationMessage = "Are you sure you want to stop all running containers?"
+		}
+		@{ Name                = "Delete all containers, images and volumes";
+			Command             = 'docker system prune -a --volumes -f';
+			ConfirmationMessage = "Are you sure you want to delete ALL containers, images and volumes?"
+		}
+		@{ Name                = "Delete all volumes";
+			Command             = 'docker volume ls -q | ForEach-Object { docker volume rm $_ }';
+			ConfirmationMessage = "Are you sure you want to delete ALL volumes?"
+		}
+	)
 
 	RunnableProjects              = @(
 		"WinuX",

--- a/Windows/PowerShell/Modules/Helper/Functions/Resolve-RunProjectSteps.ps1
+++ b/Windows/PowerShell/Modules/Helper/Functions/Resolve-RunProjectSteps.ps1
@@ -1,0 +1,64 @@
+function Resolve-RunProjectSteps {
+	<#
+	.SYNOPSIS
+		Resolves which optional Run-Project steps should run.
+
+	.DESCRIPTION
+		Single-pass tri-state resolution (via Resolve-Steps) for every optional
+		Run-Project step. Per step, -Skip beats -Include beats config
+		(RunProject.Steps.<Name> in $global:Configuration - a plain boolean, or a
+		per-machine-type hashtable with a Default fallback, the
+		BootstrapConfig.Steps.WSL shape) beats the built-in defaults.
+
+		Docker is the one step so far: it resolves the project's Docker Compose
+		source and starts containers before the project runs. It defaults to on -
+		which is inert unless a project's mapping actually declares a database
+		provider or UsesDocker - and a setup that runs its databases locally turns
+		it off once in Configuration.local.psd1 instead of stripping provider
+		metadata from every project mapping.
+
+		$false is a real config value, so booleans resolve with explicit $null
+		checks - truthiness would misread them.
+
+		Returns an ordered hashtable of step name -> boolean. Run-Project calls
+		this exactly once per invocation. The only side effect is a warning for
+		each step that appears in both -Skip and -Include (the step is skipped).
+
+	.PARAMETER Skip
+		Step names forced off for this invocation. Wins over -Include with a
+		warning when the same name appears in both.
+
+	.PARAMETER Include
+		Step names forced on for this invocation, overriding config.
+
+	.EXAMPLE
+		Resolve-RunProjectSteps
+		Returns the step map a parameterless Run-Project would use with the current config.
+
+	.EXAMPLE
+		Resolve-RunProjectSteps -Skip Docker
+		Returns the map with Docker forced off.
+	#>
+	[CmdletBinding()]
+	[OutputType([System.Collections.Specialized.OrderedDictionary])]
+	param(
+		[Parameter()]
+		[string[]]$Skip,
+
+		[Parameter()]
+		[string[]]$Include
+	)
+
+	# Built-in defaults. Docker on by default reproduces the classic behavior:
+	# projects without database providers or UsesDocker never touch Docker anyway.
+	$defaults = [ordered]@{
+		Docker = $true
+	}
+
+	$configSteps = $null
+	if ($global:Configuration -and $global:Configuration.RunProject -is [hashtable]) {
+		$configSteps = $global:Configuration.RunProject.Steps
+	}
+
+	return Resolve-Steps -Defaults $defaults -ConfigSteps $configSteps -Skip $Skip -Include $Include
+}

--- a/Windows/PowerShell/Modules/Helper/Functions/Resolve-Selection.ps1
+++ b/Windows/PowerShell/Modules/Helper/Functions/Resolve-Selection.ps1
@@ -44,6 +44,13 @@ function Resolve-Selection {
 	.PARAMETER DefaultOptionIndex
 		1-based index of the default option (returned if user presses Enter with no input); 0 = no default.
 
+	.PARAMETER ConfirmationMessage
+		Turns the menu into a safeguard for destructive actions: the message is shown as the
+		prompt in red, and when the OptionList contains "No" (it does by default) pressing
+		Enter selects it, so the destructive option always takes an explicit "Yes". An
+		explicitly passed -PromptMessage or -DefaultOptionIndex still wins. Note that
+		-InputObject bypasses the prompt entirely - do not pass it on a confirmation call.
+
 	.PARAMETER GroupsConfig
 		For hierarchical mode: hashtable of nested group definitions. Enables parent/child navigation and
 		expansion. Required to unlock hierarchical menu functionality.
@@ -55,6 +62,10 @@ function Resolve-Selection {
 	.EXAMPLE
 		Resolve-Selection -GroupsConfig $Configuration.BrowserGroups -AllowMultipleSelections
 		Shows a hierarchical browser group menu with multi-select support.
+
+	.EXAMPLE
+		Resolve-Selection -ConfirmationMessage "Are you sure you want to delete all volumes?"
+		Red Yes/No confirmation prompt; Enter defaults to "No". Returns "Yes" or "No".
 	#>
 	[CmdletBinding()]
 	param(
@@ -87,6 +98,9 @@ function Resolve-Selection {
 
 		[Parameter(Mandatory = $false)]
 		[int]$DefaultOptionIndex = 0,
+
+		[Parameter(Mandatory = $false)]
+		[string]$ConfirmationMessage,
 
 		[Parameter(Mandatory = $false)]
 		$GroupsConfig
@@ -217,17 +231,33 @@ function Resolve-Selection {
 		}
 	}
 
+	# A confirmation prompt must never confirm on muscle memory: pressing Enter
+	# selects "No" (when present), and the message itself is rendered in red
+	if ($ConfirmationMessage -and -not $PSBoundParameters.ContainsKey('DefaultOptionIndex')) {
+		for ($noIndex = 0; $noIndex -lt $OptionList.Count; $noIndex++) {
+			if ($OptionList[$noIndex] -eq "No") {
+				$DefaultOptionIndex = $noIndex + 1
+				break
+			}
+		}
+	}
+
 	$hasDefault = $DefaultOptionIndex -ge 1 -and $DefaultOptionIndex -le $OptionList.Count
 	$defaultLabel = if ($hasDefault) { $OptionList[$DefaultOptionIndex - 1] } else { $null }
 
 	if (-not $PSBoundParameters.ContainsKey('PromptMessage')) {
-		$PromptMessage = if ($AllowMultipleSelections) {
+		$PromptMessage = if ($ConfirmationMessage) {
+			$ConfirmationMessage
+		}
+		elseif ($AllowMultipleSelections) {
 			"Enter selection(s) by number or name"
 		}
 		else {
 			"Enter selection by number or name"
 		}
 	}
+
+	$promptColor = if ($ConfirmationMessage) { "Red" } else { "White" }
 
 	do {
 		if ($HideSelection) {
@@ -241,7 +271,7 @@ function Resolve-Selection {
 
 		$defaultHint = if ($hasDefault) { " (default: $defaultLabel)" } else { "" }
 		$displayPrompt = if ($HidePromptMessage) { "$promptPrefix$promptSuffix" } else { "$promptPrefix$($PromptMessage)$defaultHint$promptSuffix" }
-		$userInput = Custom-ReadHost $displayPrompt -AddNewLine:$false
+		$userInput = Custom-ReadHost $displayPrompt -ForegroundColor $promptColor -AddNewLine:$false
 		if ([string]::IsNullOrWhiteSpace($userInput)) {
 			if ($hasDefault) {
 				return $defaultLabel

--- a/Windows/PowerShell/Modules/Helper/Functions/Run-Project.ps1
+++ b/Windows/PowerShell/Modules/Helper/Functions/Run-Project.ps1
@@ -8,16 +8,33 @@ function Run-Project {
 		Opens Windows Terminal tabs configured for each selected project.
 		Uses Resolve-Selection for interactive menu with -InSameShell option to run in current tab.
 
+		The Docker step (resolving a project's compose source and starting containers)
+		is optional, resolved Kill-All-style via Resolve-RunProjectSteps: configure it
+		persistently with RunProject.Steps.Docker in Configuration.psd1 /
+		Configuration.local.psd1 (a plain boolean or a per-machine-type hashtable with
+		a Default fallback), or override per invocation with -Skip / -Include. A setup
+		that runs its databases locally sets it to $false once and Run-Project never
+		touches Docker - not even the database provider prompt.
+
 	.PARAMETER Project
 		Optional project name(s) to run. If omitted, shows interactive menu.
 
 	.PARAMETER InSameShell
 		If $true (default), use current shell tab. If $false, open new tabs.
 
+	.PARAMETER Skip
+		Step names to skip for this invocation, overriding config. Valid names: Docker.
+		Wins over -Include when a step appears in both.
+
+	.PARAMETER Include
+		Step names to run for this invocation even if config disables them.
+		Same valid names as -Skip.
+
 	.EXAMPLE
 		Run-Project  # Interactive menu
 		Run-Project -Project "MyApp", "OtherApp"
 		Run-Project -Project "MyApp" -InSameShell:$false
+		Run-Project -Project "MyApp" -Skip Docker
 	#>
 	[CmdletBinding()]
 	param (
@@ -25,8 +42,18 @@ function Run-Project {
 		[string[]]$Project,
 
 		[Parameter()]
-		[switch]$InSameShell = $true
+		[switch]$InSameShell = $true,
+
+		[Parameter()]
+		[ValidateSet("Docker")]
+		[string[]]$Skip,
+
+		[Parameter()]
+		[ValidateSet("Docker")]
+		[string[]]$Include
 	)
+
+	$stepStates = Resolve-RunProjectSteps -Skip $Skip -Include $Include
 
 	$resolveParams = @{
 		InputObject             = $Project
@@ -60,73 +87,23 @@ function Run-Project {
 				continue
 			}
 
-			# Resolve database provider
-			$usesDocker = $runnableMapping.UsesDocker
-			$selectedProvider = $null
+			# Resolve the project's Docker Compose source (provider menu included) and
+			# start Docker if the project requires it - unless the Docker step is
+			# disabled, in which case not even the provider prompt appears
+			$dockerCompose = if ($stepStates.Docker) { Resolve-ProjectDockerCompose -ProjectName $Name } else { $null }
 
-			$hasDatabaseProviders = $runnableMapping.DatabaseProviders -and $runnableMapping.DatabaseProviders.Count -gt 0
+			if ($dockerCompose) {
+				$dockerParams = @{ PassThru = $true }
 
-			if ($hasDatabaseProviders -and $runnableMapping.DatabaseProviders.Count -gt 1) {
-				# Multiple providers available - ask which one to use
-				$providerParams = @{
-					InputObject        = $null
-					OptionList         = $runnableMapping.DatabaseProviders
-					MenuTitle          = "[Database providers for $Name]"
-					DefaultOptionIndex = 1
-				}
-				$selectedProvider = Resolve-Selection @providerParams
-
-				if (-not $selectedProvider) {
-					Write-LogError "No database provider selected! Skipping [$Name]!"
-					continue
-				}
-
-				Write-LogDebug " Selected database provider => [$selectedProvider]" -Style Step
-			}
-			elseif ($hasDatabaseProviders -and $runnableMapping.DatabaseProviders.Count -eq 1) {
-				$selectedProvider = $runnableMapping.DatabaseProviders[0]
-				Write-LogDebug " Single database provider configured => [$selectedProvider]" -Style Step
-			}
-			else {
-				# No database providers configured - project does not use a database
-				Write-LogDebug " No database providers configured => Docker not required for database" -Style Step
-			}
-
-			# Determine if Docker is needed: either explicitly set on the mapping,
-			# or the selected provider has a centralized/project Docker Compose file
-			if ($selectedProvider -and ($selectedProvider -eq "Oracle" -or $Configuration.DockerComposeFiles.ContainsKey($selectedProvider))) {
-				$usesDocker = $true
-			}
-
-			# Start Docker service and compose if the project requires it
-			if ($usesDocker) {
-				$script:DockerStartFailed = $false
-				$dockerParams = @{}
-
-				# Check if this provider has a centralized Docker Compose file in WinuX
-				$centralComposeFile = $Configuration.DockerComposeFiles[$selectedProvider]
-				if ($centralComposeFile) {
-					# Use the centralized compose file from WinuX/Docker/
-					$composeFilePath = Join-Path $MachineSpecificPaths.DockerDirectory $centralComposeFile
-					$dockerParams["ComposeFilePath"] = $composeFilePath
-
-					Write-LogDebug "Using centralized Docker Compose => [$composeFilePath]" -Style Step -NoLeadingNewline
+				if ($dockerCompose.ComposeFilePath) {
+					$dockerParams["ComposeFilePath"] = $dockerCompose.ComposeFilePath
 				}
 				else {
-					# Fall back to project-specific docker-compose.yml (e.g., Oracle in ExampleProject)
-					$mapping = $Configuration.ProjectTerminals | Where-Object { $_.Name -eq $Name }
-					$current = $MachineSpecificPaths
-					foreach ($property in $mapping.BasePath.Split('.')) {
-						$current = $current.$property
-					}
-					$projectRoot = $current.Root
-					$dockerParams["ComposeProjectPath"] = $projectRoot
-
-					Write-LogDebug "Using project Docker Compose => [$projectRoot]" -Style Step -NoLeadingNewline
+					$dockerParams["ComposeProjectPath"] = $dockerCompose.ComposeProjectPath
 				}
 
-				DockerWizard @dockerParams
-				if ($script:DockerStartFailed) {
+				$dockerResult = DockerWizard @dockerParams
+				if (-not $dockerResult.Success) {
 					Write-LogError "Docker is required but could not be started! Skipping [$Name]!"
 					continue
 				}

--- a/Windows/PowerShell/Modules/Helper/Helper.psd1
+++ b/Windows/PowerShell/Modules/Helper/Helper.psd1
@@ -56,6 +56,7 @@
 		'ReRun-LastCommand',
 		'Resolve-HostingTerminalTab',
 		'Resolve-ProjectPath',
+		'Resolve-RunProjectSteps',
 		'Resolve-Selection',
 		'Run-Project',
 		'Show-FunctionDetails',

--- a/Windows/PowerShell/Modules/Tests/Modules/Helper/Resolve-RunProjectSteps.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Helper/Resolve-RunProjectSteps.Tests.ps1
@@ -1,0 +1,73 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$script:OriginalConfiguration = $global:Configuration
+	$script:OriginalMachineType = $global:MachineType
+
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$FunctionsPath = Join-Path $ModuleRoot "Helper\Functions"
+
+	# Resolve-RunProjectSteps delegates the resolution loop to the shared Resolve-Steps.
+	. "$FunctionsPath\Resolve-Steps.ps1"
+	. "$FunctionsPath\Resolve-RunProjectSteps.ps1"
+}
+
+AfterAll {
+	$global:Configuration = $script:OriginalConfiguration
+	$global:MachineType = $script:OriginalMachineType
+}
+
+Describe "Resolve-RunProjectSteps" {
+	BeforeEach {
+		$global:Configuration = @{}
+		$global:MachineType = "Test"
+
+		Mock Write-LogWarning { }
+	}
+
+	It "Should default Docker to on when nothing decides otherwise" {
+		(Resolve-RunProjectSteps)["Docker"] | Should -BeTrue
+	}
+
+	It "Should return the defaults when Configuration itself is null" {
+		$global:Configuration = $null
+
+		(Resolve-RunProjectSteps)["Docker"] | Should -BeTrue
+	}
+
+	It "Should use a plain boolean config value" {
+		$global:Configuration.RunProject = @{ Steps = @{ Docker = $false } }
+
+		(Resolve-RunProjectSteps)["Docker"] | Should -BeFalse
+	}
+
+	It "Should use the machine type key of a hashtable value" {
+		$global:Configuration.RunProject = @{ Steps = @{ Docker = @{ Default = $true; Test = $false } } }
+
+		(Resolve-RunProjectSteps)["Docker"] | Should -BeFalse
+	}
+
+	It "Should fall back to Default when the machine type is not mapped" {
+		$global:MachineType = "Laptop"
+		$global:Configuration.RunProject = @{ Steps = @{ Docker = @{ Default = $false; Test = $true } } }
+
+		(Resolve-RunProjectSteps)["Docker"] | Should -BeFalse
+	}
+
+	It "Should force a step off with Skip" {
+		(Resolve-RunProjectSteps -Skip @("Docker"))["Docker"] | Should -BeFalse
+	}
+
+	It "Should force a config-disabled step on with Include" {
+		$global:Configuration.RunProject = @{ Steps = @{ Docker = $false } }
+
+		(Resolve-RunProjectSteps -Include @("Docker"))["Docker"] | Should -BeTrue
+	}
+
+	It "Should let Skip win over Include and warn once" {
+		$states = Resolve-RunProjectSteps -Skip @("Docker") -Include @("Docker")
+
+		$states["Docker"] | Should -BeFalse
+		Should -Invoke Write-LogWarning -Times 1 -Exactly -ParameterFilter { $Message -match "Docker" }
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/Helper/Resolve-Selection.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Helper/Resolve-Selection.Tests.ps1
@@ -8,7 +8,7 @@ BeforeAll {
 	. "$FunctionsPath\Resolve-Selection.ps1"
 
 	# Stub Custom-ReadHost for interactive prompts
-	function Custom-ReadHost { param($Prompt, [switch]$AddNewLine) "" }
+	function Custom-ReadHost { param($Prompt, [string]$ForegroundColor, [switch]$AddNewLine) "" }
 }
 
 Describe "Resolve-Selection" {
@@ -109,6 +109,54 @@ Describe "Resolve-Selection" {
 			$result = Resolve-Selection -AllowEmptyPromptResponse -OptionList @("A", "B")
 
 			$result | Should -BeNullOrEmpty
+		}
+	}
+
+	Context "When ConfirmationMessage is provided" {
+		BeforeEach {
+			Mock Write-Host { }
+		}
+
+		It "Should default to No when Enter is pressed" {
+			Mock Custom-ReadHost { "" }
+
+			$result = Resolve-Selection -ConfirmationMessage "Are you sure?"
+
+			$result | Should -Be "No"
+		}
+
+		It "Should return Yes only on explicit confirmation" {
+			Mock Custom-ReadHost { "Yes" }
+
+			$result = Resolve-Selection -ConfirmationMessage "Are you sure?"
+
+			$result | Should -Be "Yes"
+		}
+
+		It "Should render the confirmation message as a red prompt" {
+			Mock Custom-ReadHost { "No" }
+
+			Resolve-Selection -ConfirmationMessage "Are you sure you want to delete all volumes?" | Out-Null
+
+			Should -Invoke Custom-ReadHost -Times 1 -ParameterFilter {
+				$ForegroundColor -eq "Red" -and $Prompt -match 'Are you sure you want to delete all volumes\?'
+			}
+		}
+
+		It "Should let an explicit DefaultOptionIndex win over the No default" {
+			Mock Custom-ReadHost { "" }
+
+			$result = Resolve-Selection -ConfirmationMessage "Are you sure?" -DefaultOptionIndex 1
+
+			$result | Should -Be "Yes"
+		}
+
+		It "Should not force a default when the OptionList has no No option" {
+			Mock Custom-ReadHost { "Proceed" }
+
+			$result = Resolve-Selection -ConfirmationMessage "Are you sure?" -OptionList @("Proceed", "Abort")
+
+			$result | Should -Be "Proceed"
 		}
 	}
 }

--- a/Windows/PowerShell/Modules/Tests/Modules/Helper/Run-Project.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Helper/Run-Project.Tests.ps1
@@ -5,6 +5,30 @@ BeforeAll {
 	$FunctionsPath = Join-Path $ModuleRoot "Helper\Functions"
 
 	. "$FunctionsPath\Run-Project.ps1"
+
+	function Resolve-ProjectDockerCompose {
+		param(
+			[string]$ProjectName,
+			[string]$DatabaseProvider
+		)
+	}
+
+	function DockerWizard {
+		param(
+			[switch]$Stop,
+			[string]$ComposeProjectPath,
+			[string]$ComposeFilePath,
+			[switch]$PassThru
+		)
+	}
+
+	function Resolve-RunProjectSteps {
+		param(
+			[string[]]$Skip,
+			[string[]]$Include
+		)
+		[ordered]@{ Docker = $true }
+	}
 }
 
 Describe "Run-Project" {
@@ -20,7 +44,14 @@ Describe "Run-Project" {
 		Mock Write-Host { }
 		Mock Write-LogStep { }
 		Mock Write-LogError { }
+		Mock Write-LogSuccess { }
 		Mock Focus-TerminalTab { }
+		Mock Resolve-ProjectDockerCompose { $null }
+		Mock Resolve-RunProjectSteps { [ordered]@{ Docker = $true } }
+		Mock DockerWizard { [PSCustomObject]@{ Success = $true; ComposeFilePath = $null } }
+		Mock Close-ProjectTerminals { 0 }
+		Mock Open-Terminal { }
+		Mock Resolve-ProjectPath { "C:\Dev\Demo" }
 	}
 
 	It "continues safely when no runnable mapping exists for selected project" {
@@ -28,5 +59,70 @@ Describe "Run-Project" {
 		Should -Invoke Resolve-Selection -Times 1
 		Should -Invoke Write-LogStep -Times 1
 		Should -Invoke Write-LogError -Times 1
+	}
+
+	It "passes the resolved compose file to DockerWizard and opens the project tabs" {
+		$script:Configuration = [PSCustomObject]@{
+			RunnableProjects        = @("Demo")
+			RunnableProjectMappings = @(@{ Name = "Demo"; Commands = @("dnr"); DatabaseProviders = @("PostgreSQL") })
+			ProjectTerminals        = @(@{ Name = "Demo"; Paths = @("Api") })
+			DockerComposeFiles      = @{ PostgreSQL = "docker-compose.postgresql.yml" }
+		}
+		Mock Resolve-ProjectDockerCompose {
+			[PSCustomObject]@{
+				Provider           = "PostgreSQL"
+				ComposeFilePath    = "C:\Repo\Docker\docker-compose.postgresql.yml"
+				ComposeProjectPath = $null
+			}
+		}
+
+		Run-Project
+
+		Should -Invoke DockerWizard -Times 1 -ParameterFilter {
+			$PassThru -and $ComposeFilePath -eq "C:\Repo\Docker\docker-compose.postgresql.yml"
+		}
+		Should -Invoke Open-Terminal -Times 1
+		Should -Invoke Write-LogError -Times 0
+	}
+
+	It "skips the project when Docker is required but fails to start" {
+		$script:Configuration = [PSCustomObject]@{
+			RunnableProjects        = @("Demo")
+			RunnableProjectMappings = @(@{ Name = "Demo"; Commands = @("dnr"); DatabaseProviders = @("PostgreSQL") })
+			ProjectTerminals        = @(@{ Name = "Demo"; Paths = @("Api") })
+			DockerComposeFiles      = @{ PostgreSQL = "docker-compose.postgresql.yml" }
+		}
+		Mock Resolve-ProjectDockerCompose {
+			[PSCustomObject]@{
+				Provider           = "PostgreSQL"
+				ComposeFilePath    = "C:\Repo\Docker\docker-compose.postgresql.yml"
+				ComposeProjectPath = $null
+			}
+		}
+		Mock DockerWizard { [PSCustomObject]@{ Success = $false; ComposeFilePath = $null } }
+
+		Run-Project
+
+		Should -Invoke DockerWizard -Times 1
+		Should -Invoke Write-LogError -Times 1 -ParameterFilter { $Message -match 'could not be started' }
+		Should -Invoke Close-ProjectTerminals -Times 0
+		Should -Invoke Open-Terminal -Times 0
+	}
+
+	It "never touches Docker or the provider prompt when the Docker step is disabled" {
+		$script:Configuration = [PSCustomObject]@{
+			RunnableProjects        = @("Demo")
+			RunnableProjectMappings = @(@{ Name = "Demo"; Commands = @("dnr"); DatabaseProviders = @("PostgreSQL") })
+			ProjectTerminals        = @(@{ Name = "Demo"; Paths = @("Api") })
+			DockerComposeFiles      = @{ PostgreSQL = "docker-compose.postgresql.yml" }
+		}
+		Mock Resolve-RunProjectSteps { [ordered]@{ Docker = $false } }
+
+		Run-Project -Skip Docker
+
+		Should -Invoke Resolve-RunProjectSteps -Times 1 -ParameterFilter { $Skip -contains "Docker" }
+		Should -Invoke Resolve-ProjectDockerCompose -Times 0
+		Should -Invoke DockerWizard -Times 0
+		Should -Invoke Open-Terminal -Times 1
 	}
 }

--- a/Windows/PowerShell/Modules/Tests/Modules/Workflow/Docker-Cleanup.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Workflow/Docker-Cleanup.Tests.ps1
@@ -1,0 +1,136 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$FunctionsPath = Join-Path $ModuleRoot "Workflow\Functions"
+
+	. "$FunctionsPath\Docker-Cleanup.ps1"
+}
+
+Describe "Docker-Cleanup" {
+	BeforeEach {
+		$script:Configuration = [PSCustomObject]@{
+			DockerCleanupActions = @(
+				@{ Name                = "Delete all volumes";
+					Command             = 'docker volume ls -q | ForEach-Object { docker volume rm $_ }';
+					ConfirmationMessage = "Are you sure you want to delete ALL volumes?"
+				}
+				@{ Name    = "Harmless action";
+					Command = 'docker version'
+				}
+			)
+		}
+
+		Mock Write-Host { }
+		Mock Write-LogStep { }
+		Mock Write-LogSuccess { }
+		Mock Write-LogWarning { }
+		Mock Write-LogError { }
+		Mock Get-Command { [PSCustomObject]@{ Name = 'docker' } } -ParameterFilter { $Name -eq 'docker' }
+		Mock Invoke-Expression { $global:LASTEXITCODE = 0 }
+
+		Mock docker {
+			param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+			$global:LASTEXITCODE = 0
+		}
+
+		Mock Resolve-Selection {
+			if ($ConfirmationMessage) {
+				return "Yes"
+			}
+			return "Delete all volumes"
+		}
+	}
+
+	It "runs the selected destructive action only after an explicit Yes" {
+		Docker-Cleanup
+
+		Should -Invoke Resolve-Selection -Times 1 -ParameterFilter {
+			$ConfirmationMessage -eq "Are you sure you want to delete ALL volumes?"
+		}
+		Should -Invoke Invoke-Expression -Times 1 -ParameterFilter {
+			$Command -eq 'docker volume ls -q | ForEach-Object { docker volume rm $_ }'
+		}
+		Should -Invoke Write-LogSuccess -Times 1
+	}
+
+	It "does not run the action when the confirmation is declined" {
+		Mock Resolve-Selection {
+			if ($ConfirmationMessage) {
+				return "No"
+			}
+			return "Delete all volumes"
+		}
+
+		Docker-Cleanup
+
+		Should -Invoke Invoke-Expression -Times 0
+		Should -Invoke Write-LogWarning -Times 1 -ParameterFilter { $Message -match 'Cancelled' }
+	}
+
+	It "runs an action without a ConfirmationMessage immediately" {
+		Mock Resolve-Selection { "Harmless action" }
+
+		Docker-Cleanup
+
+		Should -Invoke Resolve-Selection -Times 1 -Exactly
+		Should -Invoke Invoke-Expression -Times 1 -ParameterFilter { $Command -eq 'docker version' }
+	}
+
+	It "accepts a configured action name directly while keeping the safeguard" {
+		Mock Resolve-Selection {
+			if ($ConfirmationMessage) {
+				return "Yes"
+			}
+			return $InputObject
+		}
+
+		Docker-Cleanup "Delete all volumes"
+
+		Should -Invoke Resolve-Selection -Times 1 -ParameterFilter { $InputObject -eq "Delete all volumes" }
+		Should -Invoke Invoke-Expression -Times 1
+	}
+
+	It "warns and stops when the Docker daemon is not running" {
+		Mock docker {
+			param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+			$global:LASTEXITCODE = 1
+		}
+
+		Docker-Cleanup
+
+		Should -Invoke Resolve-Selection -Times 0
+		Should -Invoke Invoke-Expression -Times 0
+		Should -Invoke Write-LogWarning -Times 1 -ParameterFilter { $Message -match 'not running' }
+	}
+
+	It "warns when no cleanup actions are configured" {
+		$script:Configuration = [PSCustomObject]@{ DockerCleanupActions = @() }
+
+		Docker-Cleanup
+
+		Should -Invoke Resolve-Selection -Times 0
+		Should -Invoke Write-LogWarning -Times 1 -ParameterFilter { $Message -match 'No cleanup actions' }
+	}
+
+	It "warns instead of offering a blank menu entry when the configuration key is absent" {
+		# @($null).Count is 1, so an unwrapped guard would pass and build a menu with
+		# one empty option - the realistic case for a fork that drops the key entirely
+		$script:Configuration = [PSCustomObject]@{}
+
+		Docker-Cleanup
+
+		Should -Invoke Resolve-Selection -Times 0
+		Should -Invoke Invoke-Expression -Times 0
+		Should -Invoke Write-LogWarning -Times 1 -ParameterFilter { $Message -match 'No cleanup actions' }
+	}
+
+	It "reports a failing action instead of claiming success" {
+		Mock Invoke-Expression { $global:LASTEXITCODE = 1 }
+
+		Docker-Cleanup
+
+		Should -Invoke Write-LogSuccess -Times 0
+		Should -Invoke Write-LogError -Times 1
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/Workflow/DockerWizard.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Workflow/DockerWizard.Tests.ps1
@@ -33,7 +33,14 @@ Describe "DockerWizard" {
 		$script:wslListVCall = 0
 		$script:wslTerminateCalls = @()
 
+		# Pinned so every test starts from the built-in timeout defaults regardless of
+		# the machine's real configuration, and so the DockerTimeouts test below cannot
+		# leak its override into whatever test is added after it
+		$script:Configuration = $null
+
 		Mock Write-Host { }
+		Mock Write-LogWarning { }
+		Mock Write-LogError { }
 		Mock Start-Sleep { }
 		Mock Get-Command { [PSCustomObject]@{ Name = 'docker' } } -ParameterFilter { $Name -eq 'docker' }
 		Mock Loading-Spinner {
@@ -133,8 +140,69 @@ Describe "DockerWizard" {
 
 		DockerWizard -ComposeFilePath 'C:\repo\docker-compose.yml'
 
-		$script:dockerComposePsCall | Should -Be 1
+		# `up -d` is idempotent, so it runs unconditionally - no `ps` pre-check that
+		# would skip reconciling a half-stopped stack
+		$script:dockerComposePsCall | Should -Be 0
 		$script:dockerComposeUpCall | Should -Be 1
+	}
+
+	It "warns when the provided compose file path does not exist" {
+		DockerWizard -ComposeFilePath 'C:\repo\missing-compose.yml'
+
+		$script:dockerComposeUpCall | Should -Be 0
+		Should -Invoke Write-LogWarning -Times 1 -ParameterFilter { $Message -match 'missing-compose\.yml' }
+	}
+
+	It "PassThru reports failure when a requested compose file does not exist" {
+		# Reporting success here would have callers announce containers that never
+		# started: compose work was asked for and did not happen
+		$result = DockerWizard -ComposeFilePath 'C:\repo\missing-compose.yml' -PassThru
+
+		$result.Success | Should -BeFalse
+		$result.ComposeFilePath | Should -BeNullOrEmpty
+	}
+
+	It "PassThru reports failure when a requested compose project directory has no compose file" {
+		$result = DockerWizard -ComposeProjectPath 'C:\repo\no-compose-here' -PassThru
+
+		$result.Success | Should -BeFalse
+		Should -Invoke Write-LogWarning -Times 1 -ParameterFilter { $Message -match 'no-compose-here' }
+	}
+
+	It "PassThru reports failure when compose up returns a nonzero exit code" {
+		Mock Test-Path { $Path -eq 'C:\repo\docker-compose.yml' }
+		Mock docker {
+			param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+			$cmd = @($Args)
+			if ($cmd.Count -ge 4 -and $cmd[0] -eq 'compose' -and $cmd[3] -eq 'up') {
+				$script:dockerComposeUpCall++
+				$global:LASTEXITCODE = 1
+				return
+			}
+			$global:LASTEXITCODE = 0
+		}
+
+		$result = DockerWizard -ComposeFilePath 'C:\repo\docker-compose.yml' -PassThru
+
+		$result.Success | Should -BeFalse
+		Should -Invoke Write-LogError -Times 1
+	}
+
+	It "PassThru reports success when the daemon is already running" {
+		$result = DockerWizard -PassThru
+
+		$result.Success | Should -BeTrue
+	}
+
+	It "PassThru reports the started compose file" {
+		Mock Test-Path {
+			$Path -eq 'C:\repo\docker-compose.yml'
+		}
+
+		$result = DockerWizard -ComposeFilePath 'C:\repo\docker-compose.yml' -PassThru
+
+		$result.Success | Should -BeTrue
+		$result.ComposeFilePath | Should -Be 'C:\repo\docker-compose.yml'
 	}
 
 	It "starts Docker via Open-Docker when docker desktop CLI is unavailable" {
@@ -223,9 +291,7 @@ Describe "DockerWizard" {
 		Should -Invoke Stop-Process -Times 1
 	}
 
-	It "sets DockerStartFailed when daemon does not become ready within timeout" {
-		$script:DockerStartFailed = $false
-
+	It "PassThru reports failure when daemon does not become ready within timeout" {
 		Mock docker {
 			param([Parameter(ValueFromRemainingArguments = $true)]$Args)
 			$cmd = @($Args)
@@ -256,11 +322,44 @@ Describe "DockerWizard" {
 			if ($cmd.Count -ge 2 -and $cmd[0] -eq '-l' -and $cmd[1] -eq '-v') { return '' }
 		}
 
-		DockerWizard
+		$result = DockerWizard -PassThru
 
-		$script:DockerStartFailed | Should -BeTrue
+		$result.Success | Should -BeFalse
 		$script:dockerDesktopStartCall | Should -Be 1
 		Should -Invoke Loading-Spinner -Times 1 -ParameterFilter { $Start }
 		Should -Invoke Loading-Spinner -Times 1 -ParameterFilter { $Stop }
+	}
+
+	It "honors Configuration.DockerTimeouts for the daemon readiness timeout" {
+		$script:Configuration = [PSCustomObject]@{
+			DockerTimeouts = @{ StartSeconds = 6 }
+		}
+
+		Mock docker {
+			param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+			$cmd = @($Args)
+			if ($cmd.Count -ge 2 -and $cmd[0] -eq 'desktop' -and $cmd[1] -eq 'version') {
+				$global:LASTEXITCODE = 0
+				return
+			}
+			if ($cmd.Count -ge 2 -and $cmd[0] -eq 'desktop' -and $cmd[1] -eq 'start') {
+				$global:LASTEXITCODE = 0
+				return
+			}
+			if ($cmd.Count -ge 1 -and $cmd[0] -eq 'info') {
+				$script:dockerInfoCall++
+				$global:LASTEXITCODE = 1
+				return
+			}
+			$global:LASTEXITCODE = 0
+		}
+
+		$result = DockerWizard -PassThru
+
+		$result.Success | Should -BeFalse
+		# 6-second budget polled in 3-second steps => exactly two readiness probes
+		# (plus the initial daemon check before the start is requested)
+		$script:dockerInfoCall | Should -Be 3
+		Should -Invoke Write-LogError -Times 1 -ParameterFilter { $Message -match 'within 6 seconds' }
 	}
 }

--- a/Windows/PowerShell/Modules/Tests/Modules/Workflow/Resolve-ProjectDockerCompose.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Workflow/Resolve-ProjectDockerCompose.Tests.ps1
@@ -1,0 +1,127 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$FunctionsPath = Join-Path $ModuleRoot "Workflow\Functions"
+
+	. "$FunctionsPath\Resolve-ProjectDockerCompose.ps1"
+}
+
+Describe "Resolve-ProjectDockerCompose" {
+	BeforeEach {
+		$script:Configuration = [PSCustomObject]@{
+			RunnableProjectMappings = @(
+				@{ Name = "PostgresProject"; Commands = @("dnr"); DatabaseProviders = @("PostgreSQL") }
+				@{ Name = "OracleProject"; Commands = @("dnr"); DatabaseProviders = @("Oracle") }
+				@{ Name = "MultiProviderProject"; Commands = @("dnr"); DatabaseProviders = @("PostgreSQL", "Oracle") }
+				@{ Name = "PlainProject"; Commands = @("dnr") }
+			)
+			DockerComposeFiles      = @{ PostgreSQL = "docker-compose.postgresql.yml" }
+			ProjectTerminals        = @(
+				@{ Name = "OracleProject"; BasePath = "Projects.OracleProject"; Paths = @("Api") }
+			)
+		}
+		$script:MachineSpecificPaths = [PSCustomObject]@{
+			DockerDirectory = "C:\Repo\Docker"
+			Projects        = [PSCustomObject]@{
+				OracleProject = [PSCustomObject]@{ Root = "C:\Dev\OracleProject" }
+			}
+		}
+
+		Mock Write-Host { }
+		Mock Write-LogError { }
+		Mock Resolve-Selection { "PostgreSQL" }
+	}
+
+	It "resolves a centralized provider to the compose file under DockerDirectory" {
+		$result = Resolve-ProjectDockerCompose -ProjectName "PostgresProject"
+
+		$result.Provider | Should -Be "PostgreSQL"
+		$result.ComposeFilePath | Should -Be "C:\Repo\Docker\docker-compose.postgresql.yml"
+		$result.ComposeProjectPath | Should -BeNullOrEmpty
+		Should -Invoke Resolve-Selection -Times 0
+	}
+
+	It "falls back to the project root for a provider without a centralized compose file" {
+		$result = Resolve-ProjectDockerCompose -ProjectName "OracleProject"
+
+		$result.Provider | Should -Be "Oracle"
+		$result.ComposeFilePath | Should -BeNullOrEmpty
+		$result.ComposeProjectPath | Should -Be "C:\Dev\OracleProject"
+	}
+
+	It "returns null for a project with no database providers and no UsesDocker" {
+		$result = Resolve-ProjectDockerCompose -ProjectName "PlainProject"
+
+		$result | Should -BeNullOrEmpty
+		Should -Invoke Resolve-Selection -Times 0
+	}
+
+	It "prompts for the provider when several are configured" {
+		$result = Resolve-ProjectDockerCompose -ProjectName "MultiProviderProject"
+
+		Should -Invoke Resolve-Selection -Times 1
+		$result.Provider | Should -Be "PostgreSQL"
+	}
+
+	It "skips the provider menu when -DatabaseProvider is given" {
+		$result = Resolve-ProjectDockerCompose -ProjectName "MultiProviderProject" -DatabaseProvider "PostgreSQL"
+
+		Should -Invoke Resolve-Selection -Times 0
+		$result.Provider | Should -Be "PostgreSQL"
+		$result.ComposeFilePath | Should -Be "C:\Repo\Docker\docker-compose.postgresql.yml"
+	}
+
+	It "honors UsesDocker on a mapping without database providers" {
+		$script:Configuration.RunnableProjectMappings += @{ Name = "ComposeOnlyProject"; Commands = @("dnr"); UsesDocker = $true }
+		$script:Configuration.ProjectTerminals += @{ Name = "ComposeOnlyProject"; BasePath = "Projects.OracleProject"; Paths = @("Api") }
+
+		$result = Resolve-ProjectDockerCompose -ProjectName "ComposeOnlyProject"
+
+		$result.Provider | Should -BeNullOrEmpty
+		$result.ComposeProjectPath | Should -Be "C:\Dev\OracleProject"
+	}
+
+	It "returns null and logs an error when no runnable mapping exists" {
+		$result = Resolve-ProjectDockerCompose -ProjectName "GhostProject"
+
+		$result | Should -BeNullOrEmpty
+		Should -Invoke Write-LogError -Times 1
+	}
+
+	It "returns null and logs an error when the project-local fallback has no ProjectTerminals mapping" {
+		$script:Configuration.ProjectTerminals = @()
+
+		$result = Resolve-ProjectDockerCompose -ProjectName "OracleProject"
+
+		$result | Should -BeNullOrEmpty
+		Should -Invoke Write-LogError -Times 1
+	}
+
+	It "returns null and logs an error when the BasePath does not resolve to a Root" {
+		# Silently returning an empty ComposeProjectPath would have DockerWizard start
+		# Docker and then quietly do nothing else
+		$script:Configuration.ProjectTerminals = @(
+			@{ Name = "OracleProject"; BasePath = "Projects.NoSuchProject"; Paths = @("Api") }
+		)
+
+		$result = Resolve-ProjectDockerCompose -ProjectName "OracleProject"
+
+		$result | Should -BeNullOrEmpty
+		Should -Invoke Write-LogError -Times 1
+	}
+
+	It "does not throw when DockerComposeFiles is absent from the configuration" {
+		# A setup with no Docker at all drops the key; ContainsKey is a method call, so an
+		# unguarded null would throw rather than resolve to "no centralized compose file"
+		$script:Configuration = [PSCustomObject]@{
+			RunnableProjectMappings = @(
+				@{ Name = "PostgresProject"; Commands = @("dnr"); DatabaseProviders = @("PostgreSQL") }
+			)
+			ProjectTerminals        = @()
+		}
+
+		{ Resolve-ProjectDockerCompose -ProjectName "PostgresProject" } | Should -Not -Throw
+		Resolve-ProjectDockerCompose -ProjectName "PostgresProject" | Should -BeNullOrEmpty
+	}
+}

--- a/Windows/PowerShell/Modules/Tests/Modules/Workflow/Start-Containers.Tests.ps1
+++ b/Windows/PowerShell/Modules/Tests/Modules/Workflow/Start-Containers.Tests.ps1
@@ -1,0 +1,206 @@
+#Requires -Modules Pester
+
+BeforeAll {
+	$ModuleRoot = (Get-RepositoryPath).Modules
+	$FunctionsPath = Join-Path $ModuleRoot "Workflow\Functions"
+
+	. "$FunctionsPath\Start-Containers.ps1"
+
+	function DockerWizard {
+		param(
+			[switch]$Stop,
+			[string]$ComposeProjectPath,
+			[string]$ComposeFilePath,
+			[switch]$PassThru
+		)
+	}
+}
+
+Describe "Start-Containers" {
+	BeforeEach {
+		$script:composeCalls = @()
+
+		$script:Configuration = [PSCustomObject]@{
+			DockerComposeFiles = @{
+				PostgreSQL = "docker-compose.postgresql.yml"
+			}
+		}
+		$script:MachineSpecificPaths = [PSCustomObject]@{
+			DockerDirectory = "C:\Repo\Docker"
+		}
+
+		Mock Write-Host { }
+		Mock Write-LogTitle { }
+		Mock Write-LogStep { }
+		Mock Write-LogSuccess { }
+		Mock Write-LogWarning { }
+		Mock Write-LogError { }
+		Mock Get-Command { [PSCustomObject]@{ Name = 'docker' } } -ParameterFilter { $Name -eq 'docker' }
+		Mock Get-Content { @() }
+		Mock Test-Path { $true }
+
+		Mock Resolve-Selection { @("PostgreSQL") }
+
+		Mock DockerWizard {
+			[PSCustomObject]@{
+				Success         = $true
+				ComposeFilePath = "C:\Repo\Docker\docker-compose.postgresql.yml"
+			}
+		}
+
+		Mock docker {
+			param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+			$cmd = @($Args)
+			if ($cmd.Count -ge 1 -and $cmd[0] -eq 'compose') {
+				$script:composeCalls += , $cmd
+			}
+			$global:LASTEXITCODE = 0
+		}
+	}
+
+	It "starts the single configured stack without showing a menu" {
+		Start-Containers
+
+		Should -Invoke Resolve-Selection -Times 0
+		Should -Invoke DockerWizard -Times 1 -Exactly -ParameterFilter {
+			$PassThru -and $ComposeFilePath -eq "C:\Repo\Docker\docker-compose.postgresql.yml"
+		}
+		Should -Invoke Write-LogSuccess -Times 1
+	}
+
+	It "shows a multi-select menu when several stacks are configured" {
+		$script:Configuration = [PSCustomObject]@{
+			DockerComposeFiles = @{
+				PostgreSQL = "docker-compose.postgresql.yml"
+				Redis      = "docker-compose.redis.yml"
+			}
+		}
+
+		Start-Containers
+
+		Should -Invoke Resolve-Selection -Times 1 -ParameterFilter {
+			$OptionList.Count -eq 2 -and
+			$OptionList -contains "PostgreSQL" -and
+			$OptionList -contains "Redis" -and
+			$AllowMultipleSelections
+		}
+		Should -Invoke DockerWizard -Times 1 -Exactly
+	}
+
+	It "resolves a stack by name even when only one is configured" {
+		Start-Containers PostgreSQL
+
+		Should -Invoke Resolve-Selection -Times 1 -ParameterFilter { $InputObject -eq "PostgreSQL" }
+		Should -Invoke DockerWizard -Times 1 -Exactly
+	}
+
+	It "uses an absolute compose path as-is instead of joining DockerDirectory" {
+		$script:Configuration = [PSCustomObject]@{
+			DockerComposeFiles = @{
+				PostgreSQL = "D:\Stacks\docker-compose.postgresql.yml"
+			}
+		}
+
+		Start-Containers
+
+		Should -Invoke DockerWizard -Times 1 -Exactly -ParameterFilter {
+			$ComposeFilePath -eq "D:\Stacks\docker-compose.postgresql.yml"
+		}
+	}
+
+	It "fails fast without starting Docker when the compose file does not exist" {
+		Mock Test-Path { $false }
+
+		Start-Containers
+
+		Should -Invoke DockerWizard -Times 0
+		Should -Invoke Write-LogError -Times 1 -ParameterFilter { $Message -match 'not found' }
+		Should -Invoke Write-LogSuccess -Times 0
+	}
+
+	It "warns when no stacks are configured" {
+		$script:Configuration = [PSCustomObject]@{ DockerComposeFiles = @{} }
+
+		Start-Containers
+
+		Should -Invoke DockerWizard -Times 0
+		Should -Invoke Write-LogWarning -Times 1 -ParameterFilter { $Message -match 'No Docker Compose stacks' }
+	}
+
+	It "reports an error when DockerWizard fails to start Docker" {
+		Mock DockerWizard {
+			[PSCustomObject]@{ Success = $false; ComposeFilePath = $null }
+		}
+
+		Start-Containers
+
+		Should -Invoke Write-LogError -Times 1
+		Should -Invoke Write-LogSuccess -Times 0
+	}
+
+	It "prints the published host ports after the containers are up" {
+		Mock Get-Content {
+			@(
+				'services:',
+				'  postgres-17:',
+				'    image: postgres:17',
+				'    ports:',
+				'      - "5432:5432"',
+				'  postgres-16:',
+				'    image: postgres:16',
+				'    ports:',
+				'      - "5433:5432"'
+			)
+		}
+
+		Start-Containers
+
+		Should -Invoke Write-LogStep -Times 1 -ParameterFilter { $Message -match '\[postgres-17\] => localhost:5432' }
+		Should -Invoke Write-LogStep -Times 1 -ParameterFilter { $Message -match '\[postgres-16\] => localhost:5433' }
+	}
+
+	It "Stop runs docker compose stop and leaves DockerWizard untouched" {
+		Start-Containers -Stop
+
+		Should -Invoke DockerWizard -Times 0
+		$script:composeCalls.Count | Should -Be 1
+		$script:composeCalls[0] | Should -Contain 'stop'
+		$script:composeCalls[0] | Should -Contain 'C:\Repo\Docker\docker-compose.postgresql.yml'
+	}
+
+	It "Stop with Down runs docker compose down" {
+		Start-Containers -Stop -Down
+
+		$script:composeCalls.Count | Should -Be 1
+		$script:composeCalls[0] | Should -Contain 'down'
+	}
+
+	It "Down alone implies Stop" {
+		Start-Containers -Down
+
+		Should -Invoke DockerWizard -Times 0
+		$script:composeCalls.Count | Should -Be 1
+		$script:composeCalls[0] | Should -Contain 'down'
+	}
+
+	It "Stop warns per stack when the compose file does not exist" {
+		Mock Test-Path { $false }
+
+		Start-Containers -Stop
+
+		$script:composeCalls.Count | Should -Be 0
+		Should -Invoke Write-LogWarning -Times 1 -ParameterFilter { $Message -match 'not found' }
+	}
+
+	It "Stop warns and does nothing when the Docker daemon is not running" {
+		Mock docker {
+			param([Parameter(ValueFromRemainingArguments = $true)]$Args)
+			$global:LASTEXITCODE = 1
+		}
+
+		Start-Containers -Stop
+
+		Should -Invoke Write-LogWarning -Times 1 -ParameterFilter { $Message -match 'not running' }
+		$script:composeCalls.Count | Should -Be 0
+	}
+}

--- a/Windows/PowerShell/Modules/Workflow/Functions/Docker-Cleanup.ps1
+++ b/Windows/PowerShell/Modules/Workflow/Functions/Docker-Cleanup.ps1
@@ -1,0 +1,84 @@
+function Docker-Cleanup {
+	<#
+	.SYNOPSIS
+		Menu-driven Docker cleanup with per-action confirmation safeguards.
+
+	.DESCRIPTION
+		Presents the cleanup actions defined in Configuration.DockerCleanupActions and
+		runs the selected one. Each configured entry has a Name (the menu label), a
+		Command (the PowerShell command line to run) and an optional
+		ConfirmationMessage - when present, the action only runs after an explicit
+		"Yes" on a red confirmation prompt (pressing Enter defaults to "No"), so
+		destructive operations can never fire on muscle memory.
+
+		The shipped defaults cover stopping all containers, deleting all containers/
+		images/volumes (docker system prune) and deleting all volumes; forks can
+		replace the list wholesale in Configuration.local.psd1.
+
+	.PARAMETER Action
+		Optional action name to run directly (must match a configured Name). The
+		confirmation safeguard still applies.
+
+	.EXAMPLE
+		Docker-Cleanup
+
+	.EXAMPLE
+		Docker-Cleanup "Delete all volumes"
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Position = 0)]
+		[string]$Action
+	)
+
+	if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+		Write-LogWarning "Docker is not installed!"
+		return
+	}
+
+	# Filtered, not just wrapped: an absent DockerCleanupActions yields @($null), whose
+	# Count is 1, which would sail past the guard and offer a blank menu entry
+	$cleanupActions = @($Configuration.DockerCleanupActions | Where-Object { $_ -and $_.Name })
+	if ($cleanupActions.Count -eq 0) {
+		Write-LogWarning "No cleanup actions configured in Configuration.DockerCleanupActions!"
+		return
+	}
+
+	docker info *> $null
+	if ($LASTEXITCODE -ne 0) {
+		Write-LogWarning "Docker is not running!"
+		return
+	}
+
+	$resolveParams = @{
+		InputObject = $Action
+		OptionList  = @($cleanupActions | ForEach-Object { $_.Name })
+		MenuTitle   = "[Docker cleanup actions]"
+	}
+
+	$selectedAction = @(Resolve-Selection @resolveParams) | Select-Object -First 1
+	if (-not $selectedAction) {
+		return
+	}
+
+	$actionEntry = $cleanupActions | Where-Object { $_.Name -eq $selectedAction } | Select-Object -First 1
+
+	if ($actionEntry.ConfirmationMessage) {
+		$confirmation = Resolve-Selection -ConfirmationMessage $actionEntry.ConfirmationMessage -HideMenuTitle
+
+		if ($confirmation -ne "Yes") {
+			Write-LogWarning "Cancelled - nothing was touched!"
+			return
+		}
+	}
+
+	Write-LogStep "=> $($actionEntry.Name)..."
+	Invoke-Expression $actionEntry.Command
+
+	if ($LASTEXITCODE -eq 0 -or $null -eq $LASTEXITCODE) {
+		Write-LogSuccess "$($actionEntry.Name) completed!"
+	}
+	else {
+		Write-LogError "$($actionEntry.Name) failed with exit code [$LASTEXITCODE]!"
+	}
+}

--- a/Windows/PowerShell/Modules/Workflow/Functions/DockerWizard.ps1
+++ b/Windows/PowerShell/Modules/Workflow/Functions/DockerWizard.ps1
@@ -9,6 +9,17 @@ function DockerWizard {
 		When stopping, first requests a graceful Docker Desktop shutdown and then
 		cleans up any Docker-owned WSL distros or helper processes that remain.
 
+		Polling timeouts are configurable via Configuration.DockerTimeouts
+		(StartSeconds/StopSeconds/CleanupSeconds); built-in defaults apply when the
+		configuration is absent.
+
+		With -PassThru, returns a status object callers can branch on instead of
+		communicating through module-scoped state:
+		[PSCustomObject]@{ Success = <bool>; ComposeFilePath = <string or $null> }
+		Success means everything ASKED for happened: the daemon came up, and - when a
+		compose source was given - it resolved to a real file and `up -d` returned 0.
+		A requested compose file that does not exist is a failure, not a no-op.
+
     .EXAMPLE
         DockerWizard
 
@@ -20,6 +31,9 @@ function DockerWizard {
 
     .EXAMPLE
         DockerWizard -ComposeFilePath "C:\WinuX\Docker\docker-compose.postgresql.yml"
+
+    .EXAMPLE
+        $result = DockerWizard -ComposeFilePath "C:\WinuX\Docker\docker-compose.postgresql.yml" -PassThru
     #>
 	[CmdletBinding()]
 	param (
@@ -30,11 +44,28 @@ function DockerWizard {
 		[string]$ComposeProjectPath,
 
 		[Parameter()]
-		[string]$ComposeFilePath
+		[string]$ComposeFilePath,
+
+		[Parameter()]
+		[switch]$PassThru
 	)
+
+	$newStatus = {
+		param($Success, $ComposeFile)
+		return [PSCustomObject]@{
+			Success         = $Success
+			ComposeFilePath = $ComposeFile
+		}
+	}
+
+	$dockerTimeouts = $Configuration.DockerTimeouts
+	$startTimeoutSeconds = if ($dockerTimeouts -and $dockerTimeouts.StartSeconds) { [int]$dockerTimeouts.StartSeconds } else { 180 }
+	$stopTimeoutSeconds = if ($dockerTimeouts -and $dockerTimeouts.StopSeconds) { [int]$dockerTimeouts.StopSeconds } else { 60 }
+	$cleanupTimeoutSeconds = if ($dockerTimeouts -and $dockerTimeouts.CleanupSeconds) { [int]$dockerTimeouts.CleanupSeconds } else { 30 }
 
 	if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
 		Write-LogWarning "Docker is not installed!"
+		if ($PassThru) { return & $newStatus $false $null }
 		return
 	}
 
@@ -102,6 +133,7 @@ function DockerWizard {
 
 		if (& $testDockerFullyStopped) {
 			Write-LogWarning "Docker Desktop is already stopped!"
+			if ($PassThru) { return & $newStatus $true $null }
 			return
 		}
 
@@ -117,7 +149,7 @@ function DockerWizard {
 			& $stopDockerResidualState
 		}
 
-		$timeout = 60
+		$timeout = $stopTimeoutSeconds
 		$elapsed = 0
 		$dockerStopped = $false
 
@@ -136,6 +168,7 @@ function DockerWizard {
 		}
 
 		Loading-Spinner -Stop -Spinner $spinner
+		if ($PassThru) { return & $newStatus $dockerStopped $null }
 		return
 	}
 
@@ -146,6 +179,7 @@ function DockerWizard {
 	if ($daemonAlreadyRunning) {
 		if (-not $ComposeProjectPath -and -not $ComposeFilePath) {
 			Write-LogWarning "Docker is already running!"
+			if ($PassThru) { return & $newStatus $true $null }
 			return
 		}
 	}
@@ -165,7 +199,7 @@ function DockerWizard {
 		if ($requiresCleanup) {
 			& $stopDockerResidualState
 
-			$cleanupTimeout = 30
+			$cleanupTimeout = $cleanupTimeoutSeconds
 			$cleanupElapsed = 0
 
 			while ($cleanupElapsed -lt $cleanupTimeout) {
@@ -191,7 +225,7 @@ function DockerWizard {
 			}
 		}
 
-		$timeout = 180
+		$timeout = $startTimeoutSeconds
 		$elapsed = 0
 		$dockerReady = $false
 
@@ -208,20 +242,28 @@ function DockerWizard {
 		Loading-Spinner -Stop -Spinner $spinner
 
 		if (-not $dockerReady) {
-			Write-LogError "Docker daemon did not become ready within 180 seconds!"
-			$script:DockerStartFailed = $true
+			Write-LogError "Docker daemon did not become ready within $startTimeoutSeconds seconds!"
+			if ($PassThru) { return & $newStatus $false $null }
 			return
 		}
-
-		$script:DockerStartFailed = $false
 	}
 
 	# Docker Compose handling
 	$composeFile = $null
 
+	# Whether compose work was ASKED for, which is not the same as it being
+	# resolvable: a requested-but-missing compose file is a failure, and reporting
+	# Success for it would have callers announce containers that never started
+	$composeRequested = [bool]$ComposeFilePath -or [bool]$ComposeProjectPath
+
 	# Use explicit compose file path if provided
-	if ($ComposeFilePath -and (Test-Path $ComposeFilePath -ErrorAction SilentlyContinue)) {
-		$composeFile = $ComposeFilePath
+	if ($ComposeFilePath) {
+		if (Test-Path $ComposeFilePath -ErrorAction SilentlyContinue) {
+			$composeFile = $ComposeFilePath
+		}
+		else {
+			Write-LogWarning "Docker Compose file not found => [$ComposeFilePath]"
+		}
 	}
 	elseif ($ComposeProjectPath) {
 		if (Test-Path (Join-Path $ComposeProjectPath "docker-compose.yml") -ErrorAction SilentlyContinue) {
@@ -230,16 +272,26 @@ function DockerWizard {
 		elseif (Test-Path (Join-Path $ComposeProjectPath "compose.yml") -ErrorAction SilentlyContinue) {
 			$composeFile = Join-Path $ComposeProjectPath "compose.yml"
 		}
+		else {
+			Write-LogWarning "No Docker Compose file found in => [$ComposeProjectPath]"
+		}
 	}
 
+	# `up -d` is idempotent - running it unconditionally reconciles a half-stopped
+	# stack to the compose file instead of skipping while any one container runs
+	$composeStarted = $false
+
 	if ($composeFile) {
-		$runningContainers = docker compose -f $composeFile ps -q 2>$null
-		if (-not $runningContainers) {
-			Write-LogStep "=> Starting Docker Compose services..."
-			docker compose -f $composeFile up -d
+		Write-LogStep "=> Starting Docker Compose services..."
+		docker compose -f $composeFile up -d
+		$composeStarted = $LASTEXITCODE -eq 0
+
+		if (-not $composeStarted) {
+			Write-LogError "Docker Compose failed to start services from => [$composeFile]"
 		}
-		elseif ($daemonAlreadyRunning) {
-			Write-LogWarning "Docker is already running!"
-		}
+	}
+
+	if ($PassThru) {
+		return & $newStatus (-not $composeRequested -or $composeStarted) $composeFile
 	}
 }

--- a/Windows/PowerShell/Modules/Workflow/Functions/Resolve-ProjectDockerCompose.ps1
+++ b/Windows/PowerShell/Modules/Workflow/Functions/Resolve-ProjectDockerCompose.ps1
@@ -1,0 +1,138 @@
+function Resolve-ProjectDockerCompose {
+	<#
+	.SYNOPSIS
+		Resolves the Docker Compose source a runnable project needs, if any.
+
+	.DESCRIPTION
+		The single place that knows which Docker Compose file a project's database
+		containers come from. Looks up the project's RunnableProjectMappings entry,
+		resolves the database provider (prompting when several are configured), and
+		decides whether Docker is required: either the mapping sets UsesDocker, or the
+		provider maps to a centralized compose file in Configuration.DockerComposeFiles,
+		or the provider is Oracle (project-local compose file).
+
+		Returns $null when the project needs no Docker, otherwise an object with the
+		resolved provider and exactly one of ComposeFilePath (centralized compose file
+		under MachineSpecificPaths.DockerDirectory) or ComposeProjectPath (project root
+		containing its own docker-compose.yml) - the same shapes DockerWizard accepts.
+
+		Used by Run-Project (behind its optional Docker step); Start-Containers works
+		directly on the DockerComposeFiles entries instead.
+
+	.PARAMETER ProjectName
+		Name of the runnable project to resolve (a RunnableProjectMappings entry).
+
+	.PARAMETER DatabaseProvider
+		Optional database provider to use; skips the provider menu when given.
+
+	.EXAMPLE
+		Resolve-ProjectDockerCompose -ProjectName "ExampleProject"
+
+	.EXAMPLE
+		Resolve-ProjectDockerCompose -ProjectName "ExampleProject" -DatabaseProvider "PostgreSQL"
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Mandatory = $true)]
+		[string]$ProjectName,
+
+		[Parameter()]
+		[string]$DatabaseProvider
+	)
+
+	$runnableMapping = $Configuration.RunnableProjectMappings | Where-Object { $_.Name -eq $ProjectName }
+	if (-not $runnableMapping) {
+		Write-LogError "No runnable project mapping found for [$ProjectName] in Configuration.ps1"
+		return $null
+	}
+
+	$usesDocker = $runnableMapping.UsesDocker
+	$selectedProvider = $null
+
+	$hasDatabaseProviders = $runnableMapping.DatabaseProviders -and $runnableMapping.DatabaseProviders.Count -gt 0
+
+	if ($DatabaseProvider) {
+		$selectedProvider = $DatabaseProvider
+		Write-LogDebug " Database provider passed in => [$selectedProvider]" -Style Step
+	}
+	elseif ($hasDatabaseProviders -and $runnableMapping.DatabaseProviders.Count -gt 1) {
+		# Multiple providers available - ask which one to use
+		$providerParams = @{
+			InputObject        = $null
+			OptionList         = $runnableMapping.DatabaseProviders
+			MenuTitle          = "[Database providers for $ProjectName]"
+			DefaultOptionIndex = 1
+		}
+		$selectedProvider = Resolve-Selection @providerParams
+
+		if (-not $selectedProvider) {
+			Write-LogError "No database provider selected for [$ProjectName]!"
+			return $null
+		}
+
+		Write-LogDebug " Selected database provider => [$selectedProvider]" -Style Step
+	}
+	elseif ($hasDatabaseProviders) {
+		$selectedProvider = $runnableMapping.DatabaseProviders[0]
+		Write-LogDebug " Single database provider configured => [$selectedProvider]" -Style Step
+	}
+	else {
+		# No database providers configured - project does not use a database
+		Write-LogDebug " No database providers configured => Docker not required for database" -Style Step
+	}
+
+	# Resolved once, and defaulted, because ContainsKey below is a METHOD call: a setup
+	# that drops DockerComposeFiles entirely would throw on a null-valued expression
+	$composeFileMap = if ($Configuration.DockerComposeFiles) { $Configuration.DockerComposeFiles } else { @{} }
+
+	# Determine if Docker is needed: either explicitly set on the mapping,
+	# or the selected provider has a centralized/project Docker Compose file
+	if ($selectedProvider -and ($selectedProvider -eq "Oracle" -or $composeFileMap.ContainsKey($selectedProvider))) {
+		$usesDocker = $true
+	}
+
+	if (-not $usesDocker) {
+		return $null
+	}
+
+	$composeFilePath = $null
+	$composeProjectPath = $null
+
+	# Check if this provider has a centralized Docker Compose file in WinuX
+	$centralComposeFile = if ($selectedProvider) { $composeFileMap[$selectedProvider] } else { $null }
+	if ($centralComposeFile) {
+		# Use the centralized compose file from WinuX/Docker/
+		$composeFilePath = Join-Path $MachineSpecificPaths.DockerDirectory $centralComposeFile
+
+		Write-LogDebug "Using centralized Docker Compose => [$composeFilePath]" -Style Step -NoLeadingNewline
+	}
+	else {
+		# Fall back to project-specific docker-compose.yml (e.g., Oracle in ExampleProject)
+		$mapping = $Configuration.ProjectTerminals | Where-Object { $_.Name -eq $ProjectName }
+		if (-not $mapping -or -not $mapping.BasePath) {
+			Write-LogError "No ProjectTerminals mapping with a BasePath found for [$ProjectName] - cannot resolve its project-local Docker Compose file!"
+			return $null
+		}
+
+		$current = $MachineSpecificPaths
+		foreach ($property in $mapping.BasePath.Split('.')) {
+			$current = $current.$property
+		}
+		$composeProjectPath = $current.Root
+
+		# A BasePath that does not resolve leaves this empty, and handing DockerWizard an
+		# empty path would start Docker and quietly do nothing else
+		if ([string]::IsNullOrWhiteSpace($composeProjectPath)) {
+			Write-LogError "BasePath [$($mapping.BasePath)] for [$ProjectName] does not resolve to a path with a Root in MachineSpecificPaths!"
+			return $null
+		}
+
+		Write-LogDebug "Using project Docker Compose => [$composeProjectPath]" -Style Step -NoLeadingNewline
+	}
+
+	return [PSCustomObject]@{
+		Provider           = $selectedProvider
+		ComposeFilePath    = $composeFilePath
+		ComposeProjectPath = $composeProjectPath
+	}
+}

--- a/Windows/PowerShell/Modules/Workflow/Functions/Start-Containers.ps1
+++ b/Windows/PowerShell/Modules/Workflow/Functions/Start-Containers.ps1
@@ -1,0 +1,194 @@
+function Start-Containers {
+	<#
+	.SYNOPSIS
+		Starts or stops the configured Docker Compose stacks without running any project.
+
+	.DESCRIPTION
+		First-class entry point for the containers themselves: starts Docker Desktop
+		(via DockerWizard) and brings up a Docker Compose stack registered in
+		Configuration.DockerComposeFiles, so tools like DBeaver can connect while the
+		project APIs/UIs stay closed.
+
+		The stacks are the DockerComposeFiles entries (name => compose file). Values
+		resolve relative to MachineSpecificPaths.DockerDirectory, or are used as-is
+		when they are absolute paths, so any stack can be registered - not just
+		database providers. With a single configured entry there is nothing to choose:
+		the stack simply starts (or stops). With several, a multi-select menu is
+		shown. After a start, the compose file's published host ports are printed so
+		the connection target is obvious.
+
+		-Stop runs `docker compose stop` for the selected stacks (containers are kept
+		and fast to resume); adding -Down runs `docker compose down` instead
+		(containers and network removed, volumes kept). Docker Desktop itself is left
+		running either way - use DockerWizard -Stop to shut it down.
+
+	.PARAMETER Name
+		Optional stack name(s) from Configuration.DockerComposeFiles. If omitted, the
+		single configured stack is used directly, or a menu is shown when several are
+		configured.
+
+	.PARAMETER Stop
+		Stops the selected stacks' compose services instead of starting them.
+
+	.PARAMETER Down
+		With -Stop, removes the containers and network (`docker compose down`)
+		instead of just stopping them. Volumes are kept. Implies -Stop.
+
+	.EXAMPLE
+		Start-Containers
+
+	.EXAMPLE
+		Start-Containers PostgreSQL
+
+	.EXAMPLE
+		Start-Containers -Stop
+
+	.EXAMPLE
+		Start-Containers PostgreSQL -Stop -Down
+	#>
+	[CmdletBinding()]
+	param (
+		[Parameter(Position = 0)]
+		[string[]]$Name,
+
+		[Parameter()]
+		[switch]$Stop,
+
+		[Parameter()]
+		[switch]$Down
+	)
+
+	if ($Down) {
+		$Stop = $true
+	}
+
+	if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+		Write-LogWarning "Docker is not installed!"
+		return
+	}
+
+	$composeStacks = $Configuration.DockerComposeFiles
+	if (-not $composeStacks -or $composeStacks.Count -eq 0) {
+		Write-LogWarning "No Docker Compose stacks configured in Configuration.DockerComposeFiles!"
+		return
+	}
+
+	$stackNames = @($composeStacks.Keys | Sort-Object)
+
+	if ($stackNames.Count -eq 1 -and -not $Name) {
+		# A single configured stack is an on/off switch - there is nothing to choose
+		$resolvedNames = @($stackNames[0])
+	}
+	else {
+		$resolveParams = @{
+			InputObject             = $Name
+			OptionList              = $stackNames
+			MenuTitle               = "[Docker Compose stacks]"
+			AllowMultipleSelections = $true
+			DefaultOptionIndex      = 1
+		}
+
+		$resolvedNames = @(Resolve-Selection @resolveParams)
+	}
+
+	if ($resolvedNames.Count -eq 0) {
+		Write-LogWarning "No stack selected!"
+		return
+	}
+
+	$resolveStackFile = {
+		param($StackName)
+
+		$configuredPath = $composeStacks[$StackName]
+		if ([System.IO.Path]::IsPathRooted($configuredPath)) {
+			return $configuredPath
+		}
+
+		return Join-Path $MachineSpecificPaths.DockerDirectory $configuredPath
+	}
+
+	$writeComposePorts = {
+		param($ComposeFile)
+
+		$currentService = $null
+		$inPorts = $false
+
+		foreach ($line in @(Get-Content $ComposeFile -ErrorAction SilentlyContinue)) {
+			if ($line -match '^\s{2}(\S[^:\s]*):\s*$') {
+				$currentService = $Matches[1]
+				$inPorts = $false
+				continue
+			}
+
+			if ($line -match '^\s+ports:\s*$') {
+				$inPorts = $true
+				continue
+			}
+
+			if ($inPorts) {
+				if ($line -match '^\s+-\s*"?(\d+):\d+"?\s*$') {
+					Write-LogStep "=> [$currentService] => localhost:$($Matches[1])" -NoLeadingNewline
+				}
+				elseif ($line -notmatch '^\s+-') {
+					$inPorts = $false
+				}
+			}
+		}
+	}
+
+	if ($Stop) {
+		docker info *> $null
+		if ($LASTEXITCODE -ne 0) {
+			Write-LogWarning "Docker is not running - nothing to stop!"
+			return
+		}
+
+		$composeCommand = if ($Down) { "down" } else { "stop" }
+		Write-LogTitle "Stopping containers"
+
+		foreach ($stackName in $resolvedNames) {
+			$composeFile = & $resolveStackFile $stackName
+
+			if (-not (Test-Path $composeFile -ErrorAction SilentlyContinue)) {
+				Write-LogWarning "Docker Compose file not found for [$stackName] => [$composeFile]"
+				continue
+			}
+
+			Write-LogStep "=> Running docker compose $composeCommand for [$stackName]..."
+			docker compose -f $composeFile $composeCommand
+
+			if ($LASTEXITCODE -eq 0) {
+				Write-LogSuccess "[$stackName] containers $(if ($Down) { "removed (volumes kept)" } else { "stopped" })!"
+			}
+			else {
+				Write-LogError "docker compose $composeCommand failed for [$stackName]!"
+			}
+		}
+
+		return
+	}
+
+	foreach ($stackName in $resolvedNames) {
+		$composeFile = & $resolveStackFile $stackName
+
+		# Checked before DockerWizard so a misconfigured path fails immediately
+		# instead of after a full Docker Desktop cold start
+		if (-not (Test-Path $composeFile -ErrorAction SilentlyContinue)) {
+			Write-LogError "Docker Compose file not found for [$stackName] => [$composeFile]"
+			continue
+		}
+
+		$dockerResult = DockerWizard -ComposeFilePath $composeFile -PassThru
+
+		if (-not $dockerResult.Success) {
+			Write-LogError "Containers could not be started for [$stackName]!"
+			continue
+		}
+
+		Write-LogSuccess "[$stackName] containers are up!"
+
+		if ($dockerResult.ComposeFilePath) {
+			& $writeComposePorts $dockerResult.ComposeFilePath
+		}
+	}
+}

--- a/Windows/PowerShell/Modules/Workflow/Workflow.psd1
+++ b/Windows/PowerShell/Modules/Workflow/Workflow.psd1
@@ -9,6 +9,7 @@
 		'Close-Project',
 		'Close-ProjectTerminals',
 		'Close-Workspace',
+		'Docker-Cleanup',
 		'DockerWizard',
 		'EfCoreMigrationWizard',
 		'Focus-TerminalTab',
@@ -23,8 +24,10 @@
 		'Open-ProjectTerminals',
 		'Open-Training',
 		'Open-Workspace',
+		'Resolve-ProjectDockerCompose',
 		'Resolve-SwaggerBrowserGroup',
 		'Save-WorkspaceState',
+		'Start-Containers',
 		'Test-TerminalTabsAlreadyOpen',
 		'Training-Backup'
 	)

--- a/docs/modules/helper.md
+++ b/docs/modules/helper.md
@@ -1058,13 +1058,33 @@ Resolve-ProjectPath -ProjectName MyProject
 $repo = Resolve-ProjectPath -ProjectName MyRepo -ForRepository
 ```
 
+## [Resolve-RunProjectSteps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Helper/Functions/Resolve-RunProjectSteps.ps1)
+
+- **Description:** Resolves which optional `Run-Project` steps should run - a thin wrapper over [Resolve-Steps](#resolve-steps), the same shape as `Resolve-KillAllSteps`. Per step, `-Skip` beats `-Include` beats config (`RunProject.Steps.<Name>` - a plain boolean or a per-machine-type hashtable with a `Default` fallback) beats the built-in defaults. `Docker` is the one step so far, on by default.
+- **Parameters:** -Skip, -Include
+- **Usage:** `Resolve-RunProjectSteps`, `Resolve-RunProjectSteps -Skip Docker`
+
+Docker on by default reproduces the classic behavior - it is inert unless a project's mapping actually declares `DatabaseProviders` or `UsesDocker`. Its purpose is the opposite direction: a setup that runs its databases locally (no Docker at all) sets `RunProject = @{ Steps = @{ Docker = $false } }` once in `Configuration.local.psd1` instead of stripping provider metadata from every project mapping, and `Run-Project` then never touches Docker - not even the database provider prompt.
+
+```powershell
+# The step map a parameterless Run-Project would use with the current config
+Resolve-RunProjectSteps
+
+# Docker forced off for one resolution
+Resolve-RunProjectSteps -Skip Docker
+```
+
+**See also:** [Resolve-Steps](#resolve-steps), [Run-Project](#run-project), [Resolve-KillAllSteps](system.md#resolve-killallsteps)
+
 ## [Resolve-Selection](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Helper/Functions/Resolve-Selection.ps1)
 
-- **Description:** The canonical interactive menu selector used throughout the system. Presents a numbered menu and returns the selected option(s) by number or name. Supports a flat mode (simple Yes/No or custom option list) and a hierarchical mode (when `-GroupsConfig` is provided) that navigates nested groups with dot-notation selection ("Parent.ChildGroup"), automatic expansion of parent groups, and parent/child navigation. Honors a default option via `-DefaultOptionIndex` so pressing Enter with no input selects it.
-- **Parameters:** -OptionList, -InputObject, -MenuTitle, -HideMenuTitle, -HideSelection, -PromptMessage, -HidePromptMessage, -AllowEmptyPromptResponse, -AllowMultipleSelections, -DefaultOptionIndex, -GroupsConfig
-- **Usage:** `Resolve-Selection`, `Resolve-Selection -OptionList @("Alpha", "Beta", "Gamma")`, `Resolve-Selection -OptionList @("English", "Espanol", "Francais") -PromptMessage "Select a language"`, `Resolve-Selection -OptionList @("Alpha", "Beta", "Gamma") -DefaultOptionIndex 1`, `Resolve-Selection -GroupsConfig $Configuration.BrowserGroups -AllowMultipleSelections`
+- **Description:** The canonical interactive menu selector used throughout the system. Presents a numbered menu and returns the selected option(s) by number or name. Supports a flat mode (simple Yes/No or custom option list) and a hierarchical mode (when `-GroupsConfig` is provided) that navigates nested groups with dot-notation selection ("Parent.ChildGroup"), automatic expansion of parent groups, and parent/child navigation. Honors a default option via `-DefaultOptionIndex` so pressing Enter with no input selects it, and doubles as a destructive-action safeguard via `-ConfirmationMessage`.
+- **Parameters:** -OptionList, -InputObject, -MenuTitle, -HideMenuTitle, -HideSelection, -PromptMessage, -HidePromptMessage, -AllowEmptyPromptResponse, -AllowMultipleSelections, -DefaultOptionIndex, -ConfirmationMessage, -GroupsConfig
+- **Usage:** `Resolve-Selection`, `Resolve-Selection -OptionList @("Alpha", "Beta", "Gamma")`, `Resolve-Selection -OptionList @("English", "Espanol", "Francais") -PromptMessage "Select a language"`, `Resolve-Selection -OptionList @("Alpha", "Beta", "Gamma") -DefaultOptionIndex 1`, `Resolve-Selection -GroupsConfig $Configuration.BrowserGroups -AllowMultipleSelections`, `Resolve-Selection -ConfirmationMessage "Are you sure?"`
 
 Used by `Open-Browser`, `Open-Project`, `Set-Locale`, `Set-DisplayLanguage`, `Configure-NerdFont`, and others as the shared selection primitive. In flat mode it accepts a number (1-based) or the literal option text. In hierarchical mode (`-GroupsConfig`), parent groups expand to their direct children automatically, and `-AllowMultipleSelections` permits space/comma-separated picks. Pre-selected values can be passed via `-InputObject` (or the pipeline) to skip the interactive prompt entirely. An invalid hierarchical pre-selection reports the offending value(s) (naming the caller) and returns `$null` rather than executing a bare `break`, which would propagate out of the function into the nearest loop in the caller (e.g. `Open-Workspace`'s action loop) and silently abort every remaining action - callers already handle `$null`.
+
+`-ConfirmationMessage` turns the menu into a safeguard for destructive actions (used by [Docker-Cleanup](workflow.md#docker-cleanup)): the message is rendered as the prompt in red, and when the OptionList contains "No" - it does by default - pressing Enter selects it, so the destructive path always takes an explicit "Yes". An explicitly passed `-PromptMessage` or `-DefaultOptionIndex` still wins, and `-InputObject` bypasses the prompt entirely, so never pass it on a confirmation call.
 
 | Parameter                   | Type       | Description                                                                                            |
 | --------------------------- | ---------- | ------------------------------------------------------------------------------------------------------ |
@@ -1078,6 +1098,7 @@ Used by `Open-Browser`, `Open-Project`, `Set-Locale`, `Set-DisplayLanguage`, `Co
 | `-AllowEmptyPromptResponse` | `switch`   | Returns `$null` on empty input instead of re-prompting (when no default is set).                       |
 | `-AllowMultipleSelections`  | `switch`   | Accepts space/comma-separated numbers or names to select multiple items.                               |
 | `-DefaultOptionIndex`       | `int`      | 1-based index of the option returned when the user presses Enter (`0` = no default).                   |
+| `-ConfirmationMessage`      | `string`   | Destructive-action safeguard: shows the message as a red prompt and defaults Enter to "No".            |
 | `-GroupsConfig`             | `object`   | Hierarchical group definitions (hashtable). Enables nested menu navigation and expansion.              |
 
 ```powershell
@@ -1093,30 +1114,37 @@ Resolve-Selection -OptionList @("English", "Espanol", "Francais") -PromptMessage
 
 # Hierarchical browser-group menu with multi-select support
 Resolve-Selection -GroupsConfig $Configuration.BrowserGroups -AllowMultipleSelections
+
+# Destructive-action safeguard: red prompt, Enter defaults to "No"
+if ((Resolve-Selection -ConfirmationMessage "Are you sure you want to delete all volumes?") -eq "Yes") { ... }
 ```
 
 ## [Resolve-Steps](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Helper/Functions/Resolve-Steps.ps1)
 
-- **Description:** The generic step-map resolver shared by every configurable step set (`Resolve-KillAllSteps` and `Resolve-SystemThemeSteps` in the System module, `Resolve-BootstrapSteps` in the Bootstrap module are thin wrappers over it). Per step, single-pass tri-state resolution: `-Skip` beats `-Include` beats config (a plain boolean, or a per-machine-type hashtable with a `Default` fallback - the `BootstrapConfig.Steps.WSL` shape) beats the built-in `-Defaults`. `$false` is a real config value, so booleans resolve with explicit `$null` checks rather than truthiness. Returns an ordered hashtable of step name → boolean in the order `-Defaults` defines; the only side effect is a warning for each step that appears in both `-Skip` and `-Include` (the step is skipped).
+- **Description:** The generic step-map resolver shared by every configurable step set (`Resolve-KillAllSteps` and `Resolve-SystemThemeSteps` in the System module, `Resolve-BootstrapSteps` in the Bootstrap module, and `Resolve-RunProjectSteps` in this module are thin wrappers over it). Per step, single-pass tri-state resolution: `-Skip` beats `-Include` beats config (a plain boolean, or a per-machine-type hashtable with a `Default` fallback - the `BootstrapConfig.Steps.WSL` shape) beats the built-in `-Defaults`. `$false` is a real config value, so booleans resolve with explicit `$null` checks rather than truthiness. Returns an ordered hashtable of step name → boolean in the order `-Defaults` defines; the only side effect is a warning for each step that appears in both `-Skip` and `-Include` (the step is skipped).
 - **Parameters:** -Defaults (ordered step → default map, defines the step set and order), -ConfigSteps (the configuration `Steps` hashtable, or `$null`), -Skip, -Include
 - **Usage:** `Resolve-Steps -Defaults ([ordered]@{ Docker = $true }) -ConfigSteps $global:Configuration.KillAll.Steps`, `Resolve-Steps -Defaults $defaults -ConfigSteps $configSteps -Skip Docker, Browsers`
 
-**See also:** [Resolve-KillAllSteps](system.md#resolve-killallsteps), [Resolve-SystemThemeSteps](system.md#resolve-systemthemesteps), [Resolve-BootstrapSteps](bootstrap.md#resolve-bootstrapsteps)
+**See also:** [Resolve-KillAllSteps](system.md#resolve-killallsteps), [Resolve-SystemThemeSteps](system.md#resolve-systemthemesteps), [Resolve-BootstrapSteps](bootstrap.md#resolve-bootstrapsteps), [Resolve-RunProjectSteps](#resolve-runprojectsteps)
 
 ## [Run-Project](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Helper/Functions/Run-Project.ps1)
 
-- **Description:** Opens Windows Terminal tabs for one or more configured runnable projects. Selects from `Configuration.RunnableProjects` (with optional multi-select via `Resolve-Selection`) and runs each project's configured commands in its own tab. Existing terminal tabs for a project are detected and closed first to prevent duplicates, then fresh tabs are opened; a database provider is resolved (prompting when several are configured) and Docker is started when required. Both the project selection and database provider menus default to the first option when Enter is pressed.
+- **Description:** Opens Windows Terminal tabs for one or more configured runnable projects. Selects from `Configuration.RunnableProjects` (with optional multi-select via `Resolve-Selection`) and runs each project's configured commands in its own tab. Existing terminal tabs for a project are detected and closed first to prevent duplicates, then fresh tabs are opened; behind the optional Docker step, the project's Docker Compose source is resolved via `Resolve-ProjectDockerCompose` (prompting for the database provider when several are configured) and Docker is started when required. Both the project selection and database provider menus default to the first option when Enter is pressed.
 - **Implementation Note:** Passes the originating Windows Terminal handle/title into `Close-ProjectTerminals` so Docker cold-start focus changes do not cause duplicate tabs in a different terminal window.
-- **Parameters:** -Project, -InSameShell
-- **Usage:** `Run-Project`, `Run-Project -Project "MyProject", "OtherProject"`, `Run-Project -Project "MyProject" -InSameShell:$false`
+- **Parameters:** -Project, -InSameShell, -Skip, -Include
+- **Usage:** `Run-Project`, `Run-Project -Project "MyProject", "OtherProject"`, `Run-Project -Project "MyProject" -InSameShell:$false`, `Run-Project -Skip Docker`
 - **Alias:** rp
 
-Reads `Configuration.RunnableProjects` for the menu and `RunnableProjectMappings` for each project's run commands, pairing them against `ProjectTerminals` path keys (e.g. `Api`, `Ui`) so every path key gets a matching command and its own tab titled `<Project>.<PathKey>`. If a project has database providers configured, the matching Docker Compose file is started before the project runs; when the starting tab already matches a project tab it is reused instead of opening a duplicate, and focus is returned to the starting tab after all projects have been opened.
+Reads `Configuration.RunnableProjects` for the menu and `RunnableProjectMappings` for each project's run commands, pairing them against `ProjectTerminals` path keys (e.g. `Api`, `Ui`) so every path key gets a matching command and its own tab titled `<Project>.<PathKey>`. The Docker resolution lives in [Resolve-ProjectDockerCompose](workflow.md#resolve-projectdockercompose), and `DockerWizard` is called with `-PassThru`: when the daemon never becomes ready the project is skipped instead of opening tabs against a database that is not there. When the starting tab already matches a project tab it is reused instead of opening a duplicate, and focus is returned to the starting tab after all projects have been opened.
 
-| Parameter      | Description                                                                         |
-| -------------- | ----------------------------------------------------------------------------------- |
-| `-Project`     | One or more project name(s) to run. Omit to show the interactive multi-select menu. |
-| `-InSameShell` | When `$true` (default) reuse the current shell tab; when `$false` open new tabs.    |
+Docker is an optional step, resolved Kill-All-style through [Resolve-RunProjectSteps](#resolve-runprojectsteps): `RunProject.Steps.Docker` in configuration (plain boolean or per-machine-type hashtable with a `Default` fallback) decides persistently, and `-Skip Docker` / `-Include Docker` override per invocation. It defaults to on - inert unless a project mapping declares `DatabaseProviders` or `UsesDocker` - and a setup that runs its databases locally disables it once, after which `Run-Project` never touches Docker, not even the provider prompt.
+
+| Parameter      | Description                                                                            |
+| -------------- | ----------------------------------------------------------------------------------------- |
+| `-Project`     | One or more project name(s) to run. Omit to show the interactive multi-select menu.    |
+| `-InSameShell` | When `$true` (default) reuse the current shell tab; when `$false` open new tabs.       |
+| `-Skip`        | Step names to skip for this invocation, overriding config. Valid: `Docker`. Wins over `-Include`. |
+| `-Include`     | Step names to run even if config disables them. Valid: `Docker`.                       |
 
 ```powershell
 # Interactive menu (press Enter to accept the first project)
@@ -1127,9 +1155,12 @@ Run-Project -Project "MyProject", "OtherProject"
 
 # Open in fresh tabs instead of reusing the current shell
 Run-Project -Project "MyProject" -InSameShell:$false
+
+# One-off run without touching Docker (e.g. the database is already up)
+Run-Project -Project "MyProject" -Skip Docker
 ```
 
-**See also:** [Configuration Reference](../configuration/configuration-reference.md)
+**See also:** [Start-Containers](workflow.md#start-containers), [Resolve-ProjectDockerCompose](workflow.md#resolve-projectdockercompose), [Resolve-RunProjectSteps](#resolve-runprojectsteps), [Configuration Reference](../configuration/configuration-reference.md)
 
 ## [Show-FunctionDetails](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Helper/Functions/Show-FunctionDetails.ps1)
 

--- a/docs/modules/workflow.md
+++ b/docs/modules/workflow.md
@@ -176,19 +176,44 @@ Set-LogLevel Verbose { Close-Workspace Server }
 
 **See also:** [Open-Workspace](#open-workspace), [Close-Project](#close-project), [Get-WorkspaceState](#get-workspacestate), [Get-WorkspaceOpenDelta](#get-workspaceopendelta), [Wait-WindowsClosed](window.md#wait-windowsclosed), [Ensure-DesktopVisible](window.md#ensure-desktopvisible), [Get-WindowDesktopIndex](window.md#get-windowdesktopindex), [Remove-VirtualDesktops](system.md#remove-virtualdesktops)
 
+## [Docker-Cleanup](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Workflow/Functions/Docker-Cleanup.ps1)
+
+- **Description:** Menu-driven Docker maintenance with per-action confirmation safeguards. Presents the actions defined in `Configuration.DockerCleanupActions` (each entry: `Name`, `Command`, optional `ConfirmationMessage`) and runs the selected one. An action carrying a `ConfirmationMessage` only runs after an explicit "Yes" on a red confirmation prompt - pressing Enter defaults to "No" - so destructive operations can never fire on muscle memory.
+- **Parameters:** -Action
+- **Usage:** `Docker-Cleanup`, `Docker-Cleanup "Delete all volumes"`
+
+The shipped defaults cover the three classic teardown moves - stop all containers, `docker system prune -a --volumes -f`, and delete all volumes - and the list is plain configuration: forks replace it wholesale in `Configuration.local.psd1` to add or reword actions (the override replaces the array, so carry over any defaults you want to keep). The safeguard itself is [Resolve-Selection](helper.md#resolve-selection)'s `-ConfirmationMessage` parameter, so any other caller can reuse it.
+
+| Parameter | Description                                                                                          |
+| --------- | ----------------------------------------------------------------------------------------------------- |
+| `-Action` | Optional configured action name to run directly, skipping the menu. The confirmation still applies. |
+
+```powershell
+# Interactive menu of configured cleanup actions
+Docker-Cleanup
+
+# Run a specific action directly - the red confirmation prompt still gates it
+Docker-Cleanup "Delete all volumes"
+```
+
+**See also:** [DockerWizard](#dockerwizard), [Start-Containers](#start-containers), [Resolve-Selection](helper.md#resolve-selection)
+
 ## [DockerWizard](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Workflow/Functions/DockerWizard.ps1)
 
-- **Description:** Starts or stops Docker Desktop with loading-spinner feedback, daemon readiness detection, graceful Docker Desktop CLI integration, and Docker-owned WSL cleanup. When starting, it can clean up a partial Docker state, launch Docker Desktop in detached mode (falling back to `Open-Docker`), wait up to 180 seconds for `docker info` to succeed, and optionally start Docker Compose services from an explicit compose file path or a project directory. When stopping, it first requests a graceful shutdown and then force-cleans Docker-owned helper processes and `docker-desktop` WSL distros only if Docker gets stuck. Used by `Run-Project` to transparently spin up database containers before launching project servers.
-- **Parameters:** -Stop, -ComposeProjectPath, -ComposeFilePath
+- **Description:** Starts or stops Docker Desktop with loading-spinner feedback, daemon readiness detection, graceful Docker Desktop CLI integration, and Docker-owned WSL cleanup. When starting, it can clean up a partial Docker state, launch Docker Desktop in detached mode (falling back to `Open-Docker`), wait for `docker info` to succeed, and optionally start Docker Compose services from an explicit compose file path or a project directory. When stopping, it first requests a graceful shutdown and then force-cleans Docker-owned helper processes and `docker-desktop` WSL distros only if Docker gets stuck. Used by `Run-Project` and `Start-Containers` to transparently spin up database containers.
+- **Parameters:** -Stop, -ComposeProjectPath, -ComposeFilePath, -PassThru
 - **Usage:** `DockerWizard`, `DockerWizard -Stop`, `DockerWizard -ComposeProjectPath "<DevRoot>\MyProject"`, `DockerWizard -ComposeFilePath "C:\WinuX\Docker\docker-compose.postgresql.yml"`
 
-`DockerWizard` treats Docker Desktop as more than a single Windows process. It also checks for Docker-owned `wsl.exe` helper processes and terminates `docker-desktop` WSL distros when Docker is stuck in a partial `starting` state. On start it polls for daemon readiness (up to 180s); on stop it requests a graceful shutdown and only escalates to force-cleanup if the shutdown stalls (up to 60s).
+`DockerWizard` treats Docker Desktop as more than a single Windows process. It also checks for Docker-owned `wsl.exe` helper processes and terminates `docker-desktop` WSL distros when Docker is stuck in a partial `starting` state. On start it polls for daemon readiness; on stop it requests a graceful shutdown and only escalates to force-cleanup if the shutdown stalls. The polling budgets come from `Configuration.DockerTimeouts` (`StartSeconds`/`StopSeconds`/`CleanupSeconds`, defaulting to 180/60/30) so slower machines can raise them.
+
+Compose startup runs `docker compose up -d` unconditionally - `up -d` is idempotent, so a half-stopped stack is reconciled to the compose file instead of being skipped because one container still runs. A compose path that does not exist is reported with a warning instead of being silently ignored.
 
 | Parameter             | Description                                                                                                                                 |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-Stop`               | Stops Docker Desktop: requests a graceful shutdown, then force-cleans Docker-owned WSL distros and helper processes if the shutdown stalls. |
 | `-ComposeProjectPath` | Project directory to start Compose services from; looks for `docker-compose.yml` or `compose.yml` inside it.                                |
 | `-ComposeFilePath`    | Explicit Docker Compose file path; used directly, taking precedence over `-ComposeProjectPath`.                                             |
+| `-PassThru`           | Returns `[PSCustomObject]@{ Success; ComposeFilePath }` so callers can branch on the outcome instead of reading module-scoped state.        |
 
 ```powershell
 # Start Docker Desktop and wait for the daemon to become ready
@@ -202,9 +227,13 @@ DockerWizard -ComposeProjectPath "<DevRoot>\MyProject"
 
 # Start Docker and spin up Compose services from a specific compose file
 DockerWizard -ComposeFilePath "C:\WinuX\Docker\docker-compose.postgresql.yml"
+
+# Branch on the outcome (what Run-Project and Start-Containers do)
+$result = DockerWizard -ComposeFilePath "C:\WinuX\Docker\docker-compose.postgresql.yml" -PassThru
+if (-not $result.Success) { return }
 ```
 
-**See also:** [Kill-All](system.md#kill-all)
+**See also:** [Start-Containers](#start-containers), [Docker-Cleanup](#docker-cleanup), [Resolve-ProjectDockerCompose](#resolve-projectdockercompose), [Kill-All](system.md#kill-all)
 
 ## [EfCoreMigrationWizard](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Workflow/Functions/EfCoreMigrationWizard.ps1)
 
@@ -588,6 +617,39 @@ Set-LogLevel Verbose { w MyWorkspace }
 
 **See also:** [Open-Project](workflow.md#open-project), [Close-Project](workflow.md#close-project), [Close-Workspace](#close-workspace), [Open-Browser](../modules/application.md), [Open-ProjectSwagger](#open-projectswagger), [Save-WorkspaceState](#save-workspacestate)
 
+## [Resolve-ProjectDockerCompose](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Workflow/Functions/Resolve-ProjectDockerCompose.ps1)
+
+- **Description:** The single place that knows which Docker Compose source a runnable project's database containers come from. Looks up the project's `RunnableProjectMappings` entry, resolves the database provider (prompting via `Resolve-Selection` when several are configured), and decides whether Docker is required: the mapping sets `UsesDocker`, or the provider maps to a centralized compose file in `Configuration.DockerComposeFiles`, or the provider is Oracle (project-local compose file). Returns `$null` when the project needs no Docker.
+- **Parameters:** -ProjectName, -DatabaseProvider
+- **Usage:** `Resolve-ProjectDockerCompose -ProjectName "MyProject"`, `Resolve-ProjectDockerCompose -ProjectName "MyProject" -DatabaseProvider "PostgreSQL"`
+
+Extracted from `Run-Project`, which used to inline this resolution between its project menu and its terminal-tab logic. `Run-Project` calls it behind its optional Docker step (see [Resolve-RunProjectSteps](helper.md#resolve-runprojectsteps)); `Start-Containers` does not need it - it works directly on the `DockerComposeFiles` entries.
+
+The result carries the resolved provider and exactly one of the two compose shapes `DockerWizard` accepts:
+
+```powershell
+[PSCustomObject]@{
+    Provider           = "PostgreSQL"
+    ComposeFilePath    = "<RepoRoot>\Docker\docker-compose.postgresql.yml"  # centralized compose file
+    ComposeProjectPath = $null                                              # or the project root (project-local branch)
+}
+```
+
+| Parameter           | Description                                                                          |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| `-ProjectName`      | Name of the runnable project to resolve (a `RunnableProjectMappings` entry). Mandatory. |
+| `-DatabaseProvider` | Optional provider to use; skips the provider menu when given.                          |
+
+```powershell
+# Resolve a project's compose source (may prompt for the provider)
+Resolve-ProjectDockerCompose -ProjectName "MyProject"
+
+# Resolve non-interactively for a known provider
+Resolve-ProjectDockerCompose -ProjectName "MyProject" -DatabaseProvider "PostgreSQL"
+```
+
+**See also:** [Start-Containers](#start-containers), [DockerWizard](#dockerwizard), [Run-Project](helper.md#run-project)
+
 ## [Resolve-SwaggerBrowserGroup](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Workflow/Functions/Resolve-SwaggerBrowserGroup.ps1)
 
 - **Description:** Resolves the `Swagger` browser group for a project so it can be handed to `Open-Browser`. Maps a project name to its entry in the `BrowserGroups` `Swagger` group (case-insensitive match on the entry's `Name`) and returns that group name. By default it also checks whether the project's Swagger tab is already open and returns `$null` when it is, so callers never open a duplicate. That check is **probe-driven**: a short TCP connect to the Swagger URL's host and port ([Test-TcpPortReachable](helper.md#test-tcpportreachable)) decides its mode. Returns `$null` when the project has no `Swagger` entry, no project name is supplied, or the tab is already open. Called by [Open-ProjectSwagger](#open-projectswagger), the opt-in workspace action.
@@ -657,6 +719,38 @@ Save-WorkspaceState -Entry @()
 ```
 
 **See also:** [Get-WorkspaceOpenDelta](#get-workspaceopendelta), [Get-WorkspaceState](#get-workspacestate), [Format-WorkspaceStateContent](#format-workspacestatecontent), [Close-Workspace](#close-workspace), [Kill-All](system.md#kill-all)
+
+## [Start-Containers](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Workflow/Functions/Start-Containers.ps1)
+
+- **Description:** Starts (or stops) the Docker Compose stacks registered in `Configuration.DockerComposeFiles`, without running any project - so tools like DBeaver can connect while the project APIs/UIs stay closed. The stacks are shared by design (every PostgreSQL project talks to the same centralized containers), so the unit of control is the compose file itself, not a project: with a single configured stack the command is a pure on/off switch and asks nothing; with several, a multi-select menu is shown. After a successful start the compose file's published host ports are printed, so the connection target is obvious.
+- **Parameters:** -Name, -Stop, -Down
+- **Usage:** `Start-Containers`, `Start-Containers PostgreSQL`, `Start-Containers -Stop`, `Start-Containers -Stop -Down`
+
+Stack values resolve relative to `MachineSpecificPaths.DockerDirectory`; absolute paths are used as-is, so any compose file on disk can be registered (`Redis = "docker-compose.redis.yml"`, `MyStack = "D:\Stacks\compose.yml"`) - the mechanism is not database-specific. `-Stop` runs `docker compose stop` (containers kept, fast to resume); adding `-Down` runs `docker compose down` instead (containers and network removed, volumes kept). Docker Desktop itself stays running either way - that is [DockerWizard](#dockerwizard) `-Stop`'s job.
+
+It also works as a workspace/project action, e.g. `@{ Action = "Start-Containers" }`, for workspaces that want the database up without the servers.
+
+| Parameter | Description                                                                                              |
+| --------- | ---------------------------------------------------------------------------------------------------------- |
+| `-Name`   | Stack name(s) from `DockerComposeFiles`. Omit to start the single configured stack directly, or pick from the menu when several are configured. |
+| `-Stop`   | Stops the selected stacks' compose services (`docker compose stop`) instead of starting them.            |
+| `-Down`   | With `-Stop`, removes containers and network (`docker compose down`); volumes are kept. Implies `-Stop`. |
+
+```powershell
+# One configured stack: just starts it, no menu (menu appears only with several stacks)
+Start-Containers
+
+# Or by name
+Start-Containers PostgreSQL
+
+# Stop the containers, keep them for a fast resume
+Start-Containers -Stop
+
+# Remove the containers and network, keep the volumes (data survives)
+Start-Containers -Stop -Down
+```
+
+**See also:** [DockerWizard](#dockerwizard), [Docker-Cleanup](#docker-cleanup), [Resolve-ProjectDockerCompose](#resolve-projectdockercompose), [Run-Project](helper.md#run-project)
 
 ## [Test-TerminalTabsAlreadyOpen](https://github.com/IvanPavlak/WinuX/blob/master/Windows/PowerShell/Modules/Workflow/Functions/Test-TerminalTabsAlreadyOpen.ps1)
 
@@ -801,6 +895,7 @@ RunnableProjectMappings = @(
 | `Open-Outlook`                        | Opens Outlook                                                         |
 | `Open-Discord`                        | Opens Discord                                                         |
 | `Open-ProjectTerminals-Or-RunProject` | Opens terminals or runs servers                                       |
+| `Start-Containers`                    | Brings up the configured Docker Compose stack(s) (no API/UI)         |
 | `Set-WorkspaceWindowLayout`           | Applies window layout                                                 |
 | `Terminate-WindowsTerminalTabs`       | Closes terminal tabs (e.g., `-OnlyCurrent` to close calling tab)      |
 | `Return`                              | Stops action processing                                               |


### PR DESCRIPTION
## Description

`DockerWizard` with no arguments starts Docker Desktop and stops there; the knowledge of _which_
compose file the databases need lived only inside `Run-Project`, inlined between the project menu
and the terminal-tab logic. There was no way to bring up the database containers (e.g. for DBeaver)
without also opening tabs and starting servers - and conversely, `Run-Project` was welded to Docker
in a way that made no sense for setups running their databases locally.

- **`Start-Containers` (Workflow)** - starts/stops the compose stacks registered in
  `Configuration.DockerComposeFiles` (name => file, relative to `DockerDirectory` or absolute, so
  arbitrary stacks qualify). The stacks are shared by design - every PostgreSQL project talks to
  the same centralized containers - so the unit of control is the compose file, not a project: one
  configured entry is a pure on/off switch with no menu, several give a multi-select menu. Prints
  the published host ports after startup. `-Stop` = `docker compose stop`, `-Stop -Down` =
  `docker compose down` (volumes kept). Usable as a workspace action: `@{ Action = "Start-Containers" }`.
- **`Resolve-RunProjectSteps` (Helper) + `RunProject.Steps.Docker` + `Run-Project -Skip`/`-Include`** -
  the `KillAll.Steps` pattern applied to `Run-Project`, via a thin wrapper over the shared
  `Resolve-Steps` (plain boolean or per-machine-type hashtable with `Default`). Declaring
  `DatabaseProviders = @("PostgreSQL")` as project metadata no longer forces Docker onto a
  local-PostgreSQL setup: it sets `Docker = $false` once and `Run-Project` never touches Docker,
  not even the provider prompt. Default on, so existing behavior is unchanged.
- **`Resolve-ProjectDockerCompose` (Workflow)** - the resolver extracted from `Run-Project`,
  returning `$null` or `{ Provider; ComposeFilePath; ComposeProjectPath }`.
- **`Docker-Cleanup` (Workflow)** - menu driven by the new `DockerCleanupActions` configuration
  (`Name`/`Command`/optional `ConfirmationMessage`); defaults cover stop all containers,
  `docker system prune -a --volumes -f`, and delete all volumes. Destructive entries only run after
  an explicit "Yes" on a red prompt; Enter defaults to "No".
- **`Resolve-Selection -ConfirmationMessage` (Helper)** - the reusable safeguard behind it.
- **`DockerWizard -PassThru`** - returns `{ Success; ComposeFilePath }`, fixing a real bug: the
  module-scoped `$script:DockerStartFailed` was written in Workflow's scope and read in Helper's, so
  the guard never tripped and tabs opened against a daemon that never came up.
- **`DockerWizard` hardening** - `up -d` runs unconditionally (idempotent, so half-stopped stacks
  heal), a nonexistent compose path is reported and counts as a failure rather than a silent no-op,
  and the polling budgets come from the new `DockerTimeouts` configuration (180/60/30 defaults).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature / function (non-breaking change that adds functionality)
- [ ] Breaking change (existing behavior, parameters, or signature changes)
- [ ] Documentation only
- [ ] Tests only
- [ ] Refactor / chore (no behavior change)

## Quality bar

- [x] The change is **minimal and focused** (one logical change; reuses existing helpers, no duplication / DRY).
- [x] I **understand and have tested** this change myself (not unreviewed AI output).
- [x] No machine-specific values (paths, hostnames, usernames, emails) are hardcoded in functions.
- [x] Any new user-facing setting is driven by `Configuration.psd1` using placeholder paths (`{Dev}`, `{User}`, `{MachineType}`, `{RepoRoot}`, `{AppData}`).

## Tests

```powershell
Run-Tests
```

All tests pass!

- [x] I added/updated tests under `Windows/PowerShell/Modules/Tests/Modules/<Module>/`.
- [x] All relevant tests pass locally (`Run-Tests`) and the `Pester Tests` check is green.
- [x] Tests cover behavior/side effects/branching, not just output text.
- [ ] N/A - no testable behavior changed (docs/chore only).

New: `Start-Containers.Tests.ps1`, `Resolve-ProjectDockerCompose.Tests.ps1`,
`Docker-Cleanup.Tests.ps1`, `Resolve-RunProjectSteps.Tests.ps1`. Extended:
`DockerWizard.Tests.ps1` (PassThru success and every failure mode, missing-compose reporting,
`DockerTimeouts`, unconditional `up -d`), `Resolve-Selection.Tests.ps1` (red prompt,
Enter-defaults-to-No, explicit-default wins), `Run-Project.Tests.ps1` (compose file forwarded to
`DockerWizard -PassThru`, project skipped when the daemon never becomes ready, Docker step disabled
means the resolver and provider prompt are never reached).

## Documentation & manifests

- [x] I updated `docs/modules/<Module>.md` for any added/renamed/removed/changed function.
- [x] I updated the module `.psd1` `FunctionsToExport`.
- [ ] I updated `docs/docs_overview.md` (and `docs/_sidebar.md` if a page was added/removed).
- [x] `List-Functions -ListDiscrepancies` reports no discrepancies and manifest completeness holds.
- [ ] N/A - no exported function changed.

## Tested on

- Windows version: Windows 11 Pro 26200
- PowerShell version: 7.6.5
- Machine type(s): PC and Work via a private fork

## Checklist

- [x] My commit messages follow the project style (imperative, sentence case, no trailing period, no Conventional-Commits prefix).
- [x] My branch is up to date with `master`.
- [x] I read and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md).
- [x] This PR contains no secrets or personal data (tokens, real paths/hostnames/emails).
